### PR TITLE
promote cumulative_prop from wip_ to official signal

### DIFF
--- a/jhu/delphi_jhu/run.py
+++ b/jhu/delphi_jhu/run.py
@@ -31,7 +31,7 @@ SENSOR_NAME_MAP = {
     "new_counts": ("incidence_num", False),
     "cumulative_counts": ("cumulative_num", False),
     "incidence": ("incidence_prop", False),
-    "cumulative_prop": ("cumulative_prop", True),
+    "cumulative_prop": ("cumulative_prop", False),
 }
 GEO_RESOLUTIONS = [
     "county",


### PR DESCRIPTION
Resolves #25

Trivial change, but I ran pylint and unittests as a matter of procedure:

```
 addison  (e) env  ~  repos  covidcast-indicators  jhu  env/bin/pylint delphi_jhu

------------------------------------
Your code has been rated at 10.00/10

 addison  (e) env  ~  repos  covidcast-indicators  jhu  (cd tests && ../env/bin/pytest --cov=delphi_jhu --cov-report=term-missing)
================================================ test session starts =================================================
platform linux -- Python 3.8.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/addison/repos/covidcast-indicators/jhu
plugins: cov-2.8.1
collected 14 items                                                                                                   

test_geo.py ........                                                                                           [ 57%]
test_pull.py ....                                                                                              [ 85%]
test_run.py ..                                                                                                 [100%]

----------- coverage: platform linux, python 3.8.2-final-0 -----------
Name                                                                                                  Stmts   Miss  Cover   Missing
-----------------------------------------------------------------------------------------------------------------------------------
/home/addison/repos/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/__init__.py       5      0   100%
/home/addison/repos/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/__main__.py       1      1     0%   2
/home/addison/repos/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/geo.py           56      0   100%
/home/addison/repos/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/pull.py          49      1    98%   138
/home/addison/repos/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/run.py           33      1    97%   71
-----------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                   144      3    98%


================================================= 14 passed in 4.15s =================================================
 addison  (e) env  ~  repos  covidcast-indicators  jhu  
```