### PR TITLE
add seven day smoothing

### DIFF
--- a/jhu/delphi_jhu/run.py
+++ b/jhu/delphi_jhu/run.py
@@ -6,6 +6,7 @@ when the module is run with `python -m MODULE_NAME`.
 """
 from datetime import datetime
 from itertools import product
+from functools import partial
 from os.path import join
 
 import numpy as np
@@ -14,9 +15,14 @@ from delphi_utils import read_params, create_export_csv
 
 from .geo import geo_map
 from .pull import pull_jhu_data
+from .smooth import (
+    identity,
+    kday_moving_average,
+)
 
 
 # global constants
+seven_day_moving_average = partial(kday_moving_average, k=7)
 METRICS = [
     "confirmed",
     "deaths",
@@ -27,11 +33,19 @@ SENSORS = [
     "incidence",  # new_counts per 100k people
     "cumulative_prop",
 ]
+SMOOTHERS = [
+    "unsmoothed",
+    "seven_day_average",
+]
 SENSOR_NAME_MAP = {
-    "new_counts": ("incidence_num", False),
-    "cumulative_counts": ("cumulative_num", False),
-    "incidence": ("incidence_prop", False),
-    "cumulative_prop": ("cumulative_prop", False),
+    "new_counts":           ("incidence_num", False),
+    "cumulative_counts":    ("cumulative_num", False),
+    "incidence":            ("incidence_prop", False),
+    "cumulative_prop":      ("cumulative_prop", False),
+}
+SMOOTHERS_MAP = {
+    "unsmoothed":           (identity, ''),
+    "seven_day_average":    (seven_day_moving_average, '7day_avg_'),
 }
 GEO_RESOLUTIONS = [
     "county",
@@ -58,17 +72,21 @@ def run_module():
     ).rename({"fips": "FIPS"}, axis=1)
 
     dfs = {metric: pull_jhu_data(base_url, metric, pop_df) for metric in METRICS}
-    for metric, geo_res, sensor in product(METRICS, GEO_RESOLUTIONS, SENSORS):
-        print(geo_res, metric, sensor)
+    for metric, geo_res, sensor, smoother in product(
+            METRICS, GEO_RESOLUTIONS, SENSORS, SMOOTHERS):
+        print(geo_res, metric, sensor, smoother)
         df = dfs[metric]
         # Aggregate to appropriate geographic resolution
         df = geo_map(df, geo_res, map_df)
-        df["val"] = df[sensor]
+        df["val"] = SMOOTHERS_MAP[smoother][0](df[sensor].values)
         df["se"] = np.nan
         df["sample_size"] = np.nan
+        # Drop early entries where data insufficient for smoothing
+        df = df.loc[~df["val"].isnull(), :]
         sensor_name = SENSOR_NAME_MAP[sensor][0]
         if SENSOR_NAME_MAP[sensor][1]:
             metric = f"wip_{metric}"
+        sensor_name = SMOOTHERS_MAP[smoother][1] + sensor_name
         create_export_csv(
             df,
             export_dir=export_dir,

--- a/jhu/delphi_jhu/smooth.py
+++ b/jhu/delphi_jhu/smooth.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+
+def identity(x):
+    '''Trivial "smoother" that does no smoothing.
+
+    Parameters
+    ----------
+    x: np.ndarray
+        Input array
+
+    Returns
+    -------
+    np.ndarray:
+        Same as x
+    '''
+    return x
+
+def kday_moving_average(x, k):
+    '''Compute k-day moving average on x.
+
+    Parameters
+    ----------
+    x: np.ndarray
+        Input array
+
+    Returns
+    -------
+    np.ndarray:
+        k-day moving average.  The first k-1 entries are np.nan.
+    '''
+    if not isinstance(k, int):
+        raise ValueError('k must be int.')
+    # temp = np.append(np.zeros(k - 1), x)
+    temp = np.append(np.nan*np.ones(k-1), x)
+    y = np.convolve(temp, np.ones(k, dtype=int), 'valid') / k
+    return y

--- a/jhu/tests/test_smooth.py
+++ b/jhu/tests/test_smooth.py
@@ -1,0 +1,30 @@
+import pytest
+
+from os import listdir
+from os.path import join
+
+import numpy as np
+import pandas as pd
+from delphi_jhu.run import run_module
+
+class TestSmooth:
+    def test_output_files_smoothed(self, run_as_module):
+
+        dates = [str(x) for x in range(20200304, 20200311)]
+
+        smoothed = pd.read_csv(
+            join("receiving",
+                f"{dates[-1]}_state_confirmed_7day_avg_cumulative_num.csv")
+        )
+
+        raw = pd.concat([
+            pd.read_csv(
+                join("receiving",
+                    f"{date}_state_confirmed_cumulative_num.csv")
+            ) for date in dates
+        ])
+
+        raw = raw.groupby('geo_id')['val'].mean()
+        df = pd.merge(smoothed, raw, on='geo_id', suffixes=('_smoothed', '_raw'))
+        
+        assert np.allclose(df['val_smoothed'].values, df['val_raw'].values)


### PR DESCRIPTION
Add seven day smoothing, with some flexibility to adjust the number of days or define new smoothers.

Note that the current implementation is mostly amenable to linear smoothers (geographical pooling is also linear, so order doesn't matter).

Linter is happy:

```
 addison  (e) env  …  covidcast  covidcast-indicators  jhu  env/bin/pylint delphi_jhu

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

No regressions on existing unit tests.  One new test is defined and passed.

```
 addison  (e) env  …  covidcast  covidcast-indicators  jhu  (cd tests && ../env/bin/pytest --cov=delphi_jhu --cov-report=term-missing)                                                  
==================================== test session starts =====================================                                                                                                
platform linux -- Python 3.8.2, pytest-5.4.2, py-1.8.1, pluggy-0.13.1                                                                                                                         
rootdir: /home/addison/repos/covidcast/covidcast-indicators/jhu                                                                                                                               
plugins: cov-2.9.0                                                                                                                                                                            
collected 15 items                                                                                                                                                                            
                                                                                                                                                                                              
test_geo.py ........                                                                   [ 53%]                                                                                                 
test_pull.py ....                                                                      [ 80%]                                                                                                 
test_run.py ..                                                                         [ 93%]                                                                                                 
test_smooth.py .                                                                       [100%]                                                                                                 
                                                                                                                                                                                              
----------- coverage: platform linux, python 3.8.2-final-0 -----------                                                                                                                        
Name                                                                                                            Stmts   Miss  Cover   Missing                                                 
---------------------------------------------------------------------------------------------------------------------------------------------                                                 
/home/addison/repos/covidcast/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/__init__.py       5      0   100%                                                           
/home/addison/repos/covidcast/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/__main__.py       1      1     0%   2                                                       
/home/addison/repos/covidcast/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/geo.py           56      0   100%
/home/addison/repos/covidcast/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/pull.py          49      1    98%   138
/home/addison/repos/covidcast/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/run.py           40      1    98%   88
/home/addison/repos/covidcast/covidcast-indicators/jhu/env/lib/python3.8/site-packages/delphi_jhu/smooth.py         9      1    89%   33
---------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                                             160      4    98%


==================================== 15 passed in 10.86s ===================================== 
```