### PR TITLE
Cut 7-day average signal name down to fit within the 32-character limit

### DIFF
--- a/jhu/delphi_jhu/run.py
+++ b/jhu/delphi_jhu/run.py
@@ -45,7 +45,7 @@ SENSOR_NAME_MAP = {
 }
 SMOOTHERS_MAP = {
     "unsmoothed":           (identity, ''),
-    "seven_day_average":    (seven_day_moving_average, '7day_avg_'),
+    "seven_day_average":    (seven_day_moving_average, '7dav_'),
 }
 GEO_RESOLUTIONS = [
     "county",

--- a/jhu/tests/test_smooth.py
+++ b/jhu/tests/test_smooth.py
@@ -14,7 +14,7 @@ class TestSmooth:
 
         smoothed = pd.read_csv(
             join("receiving",
-                f"{dates[-1]}_state_confirmed_7day_avg_cumulative_num.csv")
+                f"{dates[-1]}_state_confirmed_7dav_cumulative_num.csv")
         )
 
         raw = pd.concat([


### PR DESCRIPTION
Quick fix; shouldn't affect the other PR.