### PR TITLE
Add basic functionality to process only the latest (ie yesterday's) updates

### DIFF
--- a/usafacts/delphi_usafacts/run.py
+++ b/usafacts/delphi_usafacts/run.py
@@ -4,7 +4,7 @@
 This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m MODULE_NAME`.
 """
-from datetime import datetime
+from datetime import datetime, date, timedelta
 from itertools import product
 from functools import partial
 from os.path import join
@@ -66,6 +66,9 @@ def run_module():
 
     params = read_params()
     export_start_date = params["export_start_date"]
+    if export_start_date == "latest":
+        export_start_date = date.today() - timedelta(days=1)
+        export_start_date = export_start_date.strftime('%Y-%m-%d')
     export_dir = params["export_dir"]
     base_url = params["base_url"]
     static_file_dir = params["static_file_dir"]


### PR DESCRIPTION
Allows specifying "latest" for the `export_start_date` in the `params.json`.
This causes the indicator to process only the data from yesterday, which is
effectively the latest.