### PR TITLE
Refactor claims_hosp to use new geomapper functions

### DIFF
--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -127,7 +127,6 @@ class ClaimsHospIndicatorUpdater:
         assert (
                 len(multiindex) <= (GeoConstants.MAX_GEO[self.geo] * len(self.fit_dates))
         ), "more loc-date pairs than maximum number of geographies x number of dates"
-        print(data_frame)
         # fill dataframe with missing dates using 0
         data_frame = data_frame.reindex(multiindex, fill_value=0)
         data_frame.fillna(0, inplace=True)

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -96,13 +96,21 @@ class ClaimsHospIndicatorUpdater:
         """
         geo_map = GeoMapper()
         if self.geo == "county":
-            data_frame = geo_map.county_to_megacounty(
-                data, Config.MIN_DEN, Config.MAX_BACKWARDS_PAD_LENGTH,
-                thr_col="den", mega_col=self.geo)
+            data_frame = geo_map.fips_to_megacounty(data,
+                                                    Config.MIN_DEN,
+                                                    Config.MAX_BACKWARDS_PAD_LENGTH,
+                                                    thr_col="den",
+                                                    mega_col=self.geo)
         elif self.geo == "state":
-            data_frame = geo_map.county_to_state(data, state_id_col=self.geo)
+            data_frame = geo_map.replace_geocode(data,
+                                                 from_code="fips",
+                                                 new_col=self.geo,
+                                                 new_code="state_id")
+            data_frame[self.geo] = data_frame[self.geo].str.upper()
         elif self.geo == "msa":
-            data_frame = geo_map.county_to_msa(data, msa_col=self.geo)
+            data_frame = geo_map.replace_geocode(data,
+                                                 from_code="fips",
+                                                 new_col=self.geo)
         elif self.geo == "hrr":
             data_frame = data  # data is already adjusted in aggregation step above
         else:
@@ -119,7 +127,7 @@ class ClaimsHospIndicatorUpdater:
         assert (
                 len(multiindex) <= (GeoConstants.MAX_GEO[self.geo] * len(self.fit_dates))
         ), "more loc-date pairs than maximum number of geographies x number of dates"
-
+        print(data_frame)
         # fill dataframe with missing dates using 0
         data_frame = data_frame.reindex(multiindex, fill_value=0)
         data_frame.fillna(0, inplace=True)

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -106,7 +106,7 @@ class ClaimsHospIndicatorUpdater:
                                                  from_code="fips",
                                                  new_col=self.geo,
                                                  new_code="state_id")
-            data_frame[self.geo] = data_frame[self.geo].str.upper()
+            data_frame[self.geo] = data_frame[self.geo]
         elif self.geo == "msa":
             data_frame = geo_map.replace_geocode(data,
                                                  from_code="fips",

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -110,7 +110,7 @@ class ClaimsHospIndicatorUpdater:
         elif self.geo == "msa":
             data_frame = geo_map.replace_geocode(data,
                                                  from_code="fips",
-                                                 new_col=self.geo)
+                                                 new_code=self.geo)
         elif self.geo == "hrr":
             data_frame = data  # data is already adjusted in aggregation step above
         else:


### PR DESCRIPTION
Part of #306 

Summary of changes:
- Use the latest geomapper functions
- remove unused zips static file

Couple things to note here:

The previous functions, e.g. `county_to_state()`, don't exist in the GeoMapper package. 
- They do exist in [emr_hosp](https://github.com/cmu-delphi/covidcast-indicators/blob/9f0c22865441da2d12e5a8357918de7569074c63/emr_hosp/delphi_emr_hosp/geo_maps.py), but with different arguments.
- There are deprecated functions like `convert_fips_to_state_id()` in the GeoMapper package which contain the arguments called by this code, so maybe they used to be named `county_to_state()` but were renamed later. _However_, if you use these functions, the code doesn't work due to a non-unique multi-index.

After switching to the new functions all tests pass, but I can't verify against previous behaviour since the original code didn't run.
