### PR TITLE
Remove wildcard imports from test

### DIFF
--- a/cdc_covidnet/tests/test_handle_wip_signal.py
+++ b/cdc_covidnet/tests/test_handle_wip_signal.py
@@ -1,6 +1,6 @@
 import unittest
 from delphi_cdc_covidnet.update_sensor import add_prefix
-from delphi_cdc_covidnet.constants import *
+from delphi_cdc_covidnet.constants import SIGNALS
 
 def test_handle_wip_signal():
     # Test wip_signal = True, add prefix to all signals

--- a/claims_hosp/tests/test_load_data.py
+++ b/claims_hosp/tests/test_load_data.py
@@ -4,7 +4,7 @@ import pytest
 
 # first party
 from delphi_claims_hosp.config import Config, GeoConstants
-from delphi_claims_hosp.load_data import *
+from delphi_claims_hosp.load_data import load_data, load_claims_data
 from delphi_utils import read_params
 
 CONFIG = Config()

--- a/claims_hosp/tests/test_update_indicator.py
+++ b/claims_hosp/tests/test_update_indicator.py
@@ -12,7 +12,6 @@ import pytest
 
 # first party
 from delphi_claims_hosp.config import Config, GeoConstants
-from delphi_claims_hosp.load_data import *
 from delphi_claims_hosp.update_indicator import ClaimsHospIndicatorUpdater
 
 CONFIG = Config()


### PR DESCRIPTION
Closes #258 by removing remaining non emr_hosp (deactivated) wildcard imports. 

Summary of changes
- Remove wildcard imports
- Remove an unused import

