### PR TITLE
Update safegraph patterns docstrings to pass pydocstyle

### DIFF
--- a/safegraph_patterns/delphi_safegraph_patterns/process.py
+++ b/safegraph_patterns/delphi_safegraph_patterns/process.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Process and export Safegraph patterns signal."""
 import glob
 from itertools import product
 
@@ -122,8 +123,9 @@ def aggregate(df, metric, geo_res):
 def process(fname, sensors, metrics, geo_resolutions,
             export_dir, brand_df):
     """
-    Process an input census block group-level CSV and export it.  Assumes
-    that the input file has _only_ one date of data.
+    Process an input census block group-level CSV and export it.
+
+    Assumes that the input file has _only_ one date of data.
 
     Parameters
     ----------

--- a/safegraph_patterns/delphi_safegraph_patterns/run.py
+++ b/safegraph_patterns/delphi_safegraph_patterns/run.py
@@ -39,7 +39,7 @@ GEO_RESOLUTIONS = [
 
 
 def run_module():
-
+    """Run module for Safegraph patterns data."""
     params = read_params()
     export_dir = params["export_dir"]
     raw_data_dir = params["raw_data_dir"]


### PR DESCRIPTION
Summary of changes:
- Update docstrings so they pass the pydocstyle linter, which checks against most of PEP257