### PR TITLE
Update claims hosp docstrings to pass pydocstyle

### DIFF
--- a/claims_hosp/delphi_claims_hosp/config.py
+++ b/claims_hosp/delphi_claims_hosp/config.py
@@ -11,9 +11,7 @@ from datetime import datetime, timedelta
 
 
 class Config:
-    """
-    Static configuration variables.
-    """
+    """Static configuration variables."""
 
     signal_name = "smoothed_covid19_from_claims"
     signal_weekday_name = "smoothed_adj_covid19_from_claims"
@@ -59,9 +57,7 @@ class Config:
 
 
 class GeoConstants:
-    """
-    Constant geographical variables.
-    """
+    """Constant geographical variables."""
 
     # number of counties in usa, including megacounties
     NUM_COUNTIES = 3141 + 52

--- a/claims_hosp/delphi_claims_hosp/indicator.py
+++ b/claims_hosp/delphi_claims_hosp/indicator.py
@@ -19,13 +19,11 @@ from .smooth import left_gauss_linear
 
 
 class ClaimsHospIndicator:
-    """
-    Class to fit a hospitalizations indicator using CLI counts from claims-based data.
-    """
+    """Class to fit a hospitalizations indicator using CLI counts from claims-based data."""
 
     @staticmethod
     def gauss_smooth(num, den):
-        """smooth using the left_gauss_linear
+        """Smooth using the left_gauss_linear.
 
         Args:
             num: array of numerator counts
@@ -48,8 +46,9 @@ class ClaimsHospIndicator:
             k=Config.MAX_BACKWARDS_PAD_LENGTH,
             min_visits_to_fill=Config.MIN_CUM_VISITS):
         """
-         Adjust for small denominators by using a
-         variable length smoother, which starts from the RHS and moves
+         Adjust for small denominators by using a variable length smoother.
+
+         This smoother starts from the RHS and moves
          leftwards (backwards through time). We cumulatively sum the total
          visits (denominator), until we have observed some minimum number of
          counts, then calculate the sum over that bin. We restrict the

--- a/claims_hosp/delphi_claims_hosp/run.py
+++ b/claims_hosp/delphi_claims_hosp/run.py
@@ -19,11 +19,7 @@ from .update_indicator import ClaimsHospIndicatorUpdater
 
 
 def run_module():
-    """
-    Read from params.json and generate the updated claims-based hospitalization
-    indicator values.
-    """
-
+    """Read from params.json and generate updated claims-based hospitalization indicator values."""
     params = read_params()
     logging.basicConfig(level=logging.DEBUG)
 

--- a/claims_hosp/delphi_claims_hosp/smooth.py
+++ b/claims_hosp/delphi_claims_hosp/smooth.py
@@ -1,5 +1,6 @@
 """
 This file contains a left gauss filter used to smooth a 1-d signal.
+
 Code is courtesy of Addison Hu (minor adjustments by Maria).
 
 Author: Maria Jahja
@@ -24,7 +25,6 @@ def left_gauss_linear(arr, bandwidth=Config.SMOOTHER_BANDWIDTH):
     Returns: a smoothed 1D signal.
 
     """
-
     n_rows = len(arr)
     out_arr = np.zeros_like(arr)
     X = np.vstack([np.ones(n_rows), np.arange(n_rows)]).T

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -31,7 +31,7 @@ class ClaimsHospIndicatorUpdater:
     def __init__(self, startdate, enddate, dropdate, geo, parallel, weekday,
                  write_se, signal_name):
         """
-        Updater for the claims-based hospitalization indicator.
+        Initialize updater for the claims-based hospitalization indicator.
 
         Args:
             startdate: first indicator date (YYYY-mm-dd)

--- a/claims_hosp/delphi_claims_hosp/weekday.py
+++ b/claims_hosp/delphi_claims_hosp/weekday.py
@@ -17,7 +17,7 @@ class Weekday:
 
     @staticmethod
     def get_params(data):
-        """Correct a signal estimated as numerator/denominator for weekday effects.
+        r"""Correct a signal estimated as numerator/denominator for weekday effects.
 
         The ordinary estimate would be numerator_t/denominator_t for each time point
         t. Instead, model
@@ -54,7 +54,6 @@ class Weekday:
         Return a matrix of parameters: the entire vector of betas, for each time
         series column in the data.
         """
-
         tmp = data.reset_index()
         denoms = tmp.groupby(Config.DATE_COL).sum()["den"]
         nums = tmp.groupby(Config.DATE_COL).sum()["num"]
@@ -112,7 +111,6 @@ class Weekday:
         -- this has the same effect.
 
         """
-
         tmp = sub_data.reset_index()
 
         wd_correction = np.zeros((len(tmp["num"])))


### PR DESCRIPTION
Summary of changes:
- Update docstrings so they pass the pydocstyle linter, which checks against most of PEP257