### PR TITLE
Stop lint recursion errors

### DIFF
--- a/jhu/delphi_jhu/pull.py
+++ b/jhu/delphi_jhu/pull.py
@@ -75,7 +75,7 @@ def pull_jhu_data(base_url: str, metric: str, pop_df: pd.DataFrame) -> pd.DataFr
     pop_df.rename(columns={'FIPS':'fips'}, inplace=True)
     pop_df['fips'] = pop_df['fips'].astype(int).\
         astype(str).str.zfill(5)
-    df = pd.merge(df, pop_df, on="fips", how='left')
+    df = df.merge(pop_df, on="fips", how='left')
 
     # Add a dummy first row here on day before first day
     # code below could be cleaned with groupby.diff

--- a/usafacts/delphi_usafacts/geo.py
+++ b/usafacts/delphi_usafacts/geo.py
@@ -188,7 +188,7 @@ def geo_map(df: pd.DataFrame, geo_res: str, map_df: pd.DataFrame, sensor: str):
         map_df = map_df.loc[~pd.isnull(map_df[colname])].copy()
         map_df["geo_id"] = map_df[colname].astype(int)
         df["fips"] = df["fips"].astype(int)
-        merged = pd.merge(df, map_df, on="fips")
+        merged = df.merge(map_df, on="fips")
         merged["cumulative_counts"] = merged["cumulative_counts"] * merged["pop_prop"]
         merged["new_counts"] = merged["new_counts"] * merged["pop_prop"]
         merged["population"] = merged["population"] * merged["pop_prop"]

--- a/usafacts/delphi_usafacts/pull.py
+++ b/usafacts/delphi_usafacts/pull.py
@@ -74,7 +74,7 @@ def pull_usafacts_data(base_url: str, metric: str, pop_df: pd.DataFrame) -> pd.D
 
     # Merge in population LOWERCASE, consistent across confirmed and deaths
     # Population for unassigned cases/deaths is NAN
-    df = pd.merge(df, pop_df, on="FIPS", how="left")
+    df = df.merge(pop_df, on="FIPS", how="left")
 
     # Change FIPS from 0 to XX000 for statewise unallocated cases/deaths
     unassigned_index = (df['FIPS'] == 0)


### PR DESCRIPTION
Fixes #333 (for now, at least).  Changes instances of `X = pd.merge(X, Y)` to `X = X.merge(Y)`, which for whatever reason removes the recursion limit exceed error.