### PR TITLE
JHU: Appease the linter

### DIFF
--- a/jhu/delphi_jhu/pull.py
+++ b/jhu/delphi_jhu/pull.py
@@ -14,7 +14,7 @@ def download_data(base_url: str, metric: str) -> pd.DataFrame:
     df = pd.read_csv(base_url.format(metric=metric))
     # Keep the UID and the time series columns only
     # The regex filters for columns with the date format MM-DD-YY or M-D-YY
-    df = df.filter(regex="\d{1,2}\/\d{1,2}\/\d{2}|UID").melt(
+    df = df.filter(regex=r"\d{1,2}\/\d{1,2}\/\d{2}|UID").melt(
         id_vars=["UID"], var_name="timestamp", value_name="cumulative_counts"
     )
     df["timestamp"] = pd.to_datetime(df["timestamp"])

--- a/jhu/delphi_jhu/run.py
+++ b/jhu/delphi_jhu/run.py
@@ -7,10 +7,8 @@ when the module is run with `python -m MODULE_NAME`.
 from datetime import datetime
 from itertools import product
 from functools import partial
-from os.path import join
 
 import numpy as np
-import pandas as pd
 from delphi_utils import (
     read_params,
     create_export_csv,


### PR DESCRIPTION
Fix some linting errors that were introduced in #397 & #398 during the conflict resolution process (bad github; no biscuit)

@dshemetov I'm pretty sure the `r` prefix in that regex in `pull.py` is good but wanted to get your eyes on it. Because it's a network call, we don't have unit tests for it. I ran it by hand and it seemed to generate sensible output in the `timestamp` column.