### PR TITLE
Retain gitkeep file for JHU

### DIFF
--- a/jhu/tests/conftest.py
+++ b/jhu/tests/conftest.py
@@ -16,7 +16,8 @@ from delphi_jhu.run import run_module
 def run_as_module():
     # Clean receiving directory
     for fname in listdir("receiving"):
-        remove(join("receiving", fname))
+        if fname != ".gitkeep":
+            remove(join("receiving", fname))
 
     with mock_s3():
         # Create the fake bucket we will be using


### PR DESCRIPTION
closes #403

Summary of changes:
- Add a statement to prevent the .gitkeep file from being removed when tests run.