### PR TITLE
Patch smoothing utility to handle short signals (for backfill)

### DIFF
--- a/_delphi_utils_python/tests/test_smooth.py
+++ b/_delphi_utils_python/tests/test_smooth.py
@@ -167,11 +167,10 @@ class TestSmoothers:
         with pytest.raises(ValueError):
             imputed_signal = smoother.savgol_impute(signal)
 
-        # test window_length > len(signal)
+        # test window_length > len(signal) and boundary_method="identity"
         signal = np.arange(20)
         smoother = Smoother(smoother_name="savgol", boundary_method="identity", window_length=30)
-        with pytest.raises(ValueError):
-            smoothed_signal = smoother.smooth(signal)
+        smoothed_signal = smoother.smooth(signal)
 
         # test the boundary methods
         signal = np.arange(20)

--- a/_delphi_utils_python/tests/test_smooth.py
+++ b/_delphi_utils_python/tests/test_smooth.py
@@ -171,6 +171,7 @@ class TestSmoothers:
         signal = np.arange(20)
         smoother = Smoother(smoother_name="savgol", boundary_method="identity", window_length=30)
         smoothed_signal = smoother.smooth(signal)
+        assert np.allclose(signal, smoothed_signal)
 
         # test the boundary methods
         signal = np.arange(20)


### PR DESCRIPTION
Mostly documentation fixes, confrm to pydocstyle, add missing documentation for the argument boundary_method.

But also I removed the len(signal) < window_length constraint I added at the last minute; I forgot I wrote boundary methods to handle that case a few months ago.