### PR TITLE
Fix production params file as identified in #392

### DIFF
--- a/ansible/templates/safegraph-params-prod.json.j2
+++ b/ansible/templates/safegraph-params-prod.json.j2
@@ -8,5 +8,9 @@
   "aws_secret_access_key": "{{ safegraph_aws_secret_access_key }}",
   "aws_default_region": "us-east-1",
   "aws_endpoint": "https://s3.wasabisys.com",
-  "wip_signal": ""
+  "sync": true,
+  "wip_signal" : ["median_home_dwell_time_7d_avg",
+                  "completely_home_prop_7d_avg",
+                  "part_time_work_prop_7d_avg",
+                  "full_time_work_prop_7d_avg"]
 }


### PR DESCRIPTION
#392 identified a change to the params file that I didn't realize needed to be committed to the ansible tree. This PR adds that change, as well as updating the `wip` signals so that we don't accidentally end up with the prototype 7dav signals in production.