### PR TITLE
Use archive differ to construct USAFacts issues instead of 'latest'

### DIFF
--- a/ansible/templates/usafacts-params-prod.json.j2
+++ b/ansible/templates/usafacts-params-prod.json.j2
@@ -1,5 +1,5 @@
 {
-  "export_start_date": "latest",
+  "export_start_date": "20200201",
   "static_file_dir": "./static",
   "export_dir": "/common/covidcast/receiving/usa-facts",
   "cache_dir": "./cache",


### PR DESCRIPTION
This PR corrects the production USAFacts settings for use with the archive differ.

USAFacts production params were left as "latest" which only runs 1 day of 7dav signals and 7 days of raw signals. With the archive differ in place, the correct setting is "20200201". 