### PR TITLE
Add CI for python

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,41 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        #packages: [_delphi_utils_python, cdc_covidnet, claims_hosp, combo_cases_and_deaths, google_symptoms, jhu, nchs_mortality, quidel, quidel_covidtest, safegraph, safegraph_patterns, usafacts]
+        packages: [cdc_covidnet, claims_hosp, combo_cases_and_deaths, google_symptoms, jhu, nchs_mortality, quidel, quidel_covidtest, safegraph, safegraph_patterns, usafacts]
+    defaults:
+      run:
+        working-directory: ${{ matrix.packages }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install testing dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint pytest pydocstyle wheel
+    - name: Install
+      run: |
+        make install
+    - name: Lint
+      run: |
+        # make lint
+    - name: Test
+      run: |
+        make test


### PR DESCRIPTION
Blocked by #443, which is currently merged into this branch since we use the make commands. The only actual change in this pr should be the workflow yaml

Summary of changes:
- Add workflows for all production indicators
- Google health is excluded since it is deprecated and also makes network calls in tests, though shouldn't be too much work if we want to spend the time to add it.
- Delphi utils is commented out until #448
- linting is commented out while I work on PR's to get them all to pass

There's a handful of small optimizations that could be made to the workflow, but I think things will slightly change anyway as we tune linting and see how various commands work.