### PR TITLE
Add pylint to utils

### DIFF
--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -8,6 +8,7 @@ required = [
     "moto",
     "numpy",
     "pandas>=1.1.0",
+    "pylint",
     "pytest",
     "pytest-cov",
     "xlrd"


### PR DESCRIPTION
Summary of changes:
- Add pylint package to setup.py for utils. Unlike the other indicators it wasn't present.