### PR TITLE
Only run CI on non draft prs

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
+    types: [ review_requested, ready_for_review ]
     branches: [ main ]
 
 jobs:


### PR DESCRIPTION
Summary of changes:
- only run python CI on PRs that are ready for review or have a reviewer requested. figure this will help keep compute time down

Forgot to add this to my previous PR. 

