### PR TITLE
Correct date format on usafacts params file

### DIFF
--- a/ansible/templates/usafacts-params-prod.json.j2
+++ b/ansible/templates/usafacts-params-prod.json.j2
@@ -1,5 +1,5 @@
 {
-  "export_start_date": "20200201",
+  "export_start_date": "2020-02-01",
   "static_file_dir": "./static",
   "export_dir": "/common/covidcast/receiving/usa-facts",
   "cache_dir": "./cache",


### PR DESCRIPTION
Summary of changes:
- Change fro yyyymmdd to yyyy-mm-dd since the former was erroring