### PR TITLE
Add attr-rgx to pylintrc files

### DIFF
--- a/_delphi_utils_python/.pylintrc
+++ b/_delphi_utils_python/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/_template_python/.pylintrc
+++ b/_template_python/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/cdc_covidnet/.pylintrc
+++ b/cdc_covidnet/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/changehc/.pylintrc
+++ b/changehc/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/claims_hosp/.pylintrc
+++ b/claims_hosp/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/combo_cases_and_deaths/.pylintrc
+++ b/combo_cases_and_deaths/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/emr_hosp/.pylintrc
+++ b/emr_hosp/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/google_health/.pylintrc
+++ b/google_health/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/jhu/.pylintrc
+++ b/jhu/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/nchs_mortality/.pylintrc
+++ b/nchs_mortality/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/quidel/.pylintrc
+++ b/quidel/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/quidel_covidtest/.pylintrc
+++ b/quidel_covidtest/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/safegraph/.pylintrc
+++ b/safegraph/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/safegraph_patterns/.pylintrc
+++ b/safegraph_patterns/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 

--- a/usafacts/.pylintrc
+++ b/usafacts/.pylintrc
@@ -14,6 +14,7 @@ disable=logging-format-interpolation,
 # Allow arbitrarily short-named variables.
 variable-rgx=[a-z_][a-z0-9_]*
 argument-rgx=[a-z_][a-z0-9_]*
+attr-rgx=[a-z_][a-z0-9_]*
 
 [DESIGN]
 


### PR DESCRIPTION
Summary of changes:
- Add line allowing attributes to have same naming conventions as variables and arguments