### PR TITLE
Fix errors in Sir-Complains-a-lot

### DIFF
--- a/sir_complainsalot/delphi_sir_complainsalot/run.py
+++ b/sir_complainsalot/delphi_sir_complainsalot/run.py
@@ -33,7 +33,7 @@ def run_module():
         sys.exit(1)
 
 def split_complaints(complaints, n=49):
-    """Yield successive n-sized chunks from lst."""
+    """Yield successive n-sized chunks from complaints list."""
     for i in range(0, len(complaints), n):
         yield complaints[i:i + n]
 

--- a/sir_complainsalot/delphi_sir_complainsalot/run.py
+++ b/sir_complainsalot/delphi_sir_complainsalot/run.py
@@ -32,24 +32,30 @@ def run_module():
 
         sys.exit(1)
 
-def report_complaints(complaints, params):
+def split_complaints(complaints, n=49):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(complaints), n):
+        yield complaints[i:i + n]
+
+def report_complaints(all_complaints, params):
     """Post complaints to Slack."""
     if not params["slack_token"]:
         print("\b (dry-run)")
         return
 
-    blocks = format_complaints(complaints)
-
     client = WebClient(token=params["slack_token"])
 
-    try:
-        client.chat_postMessage(
-            channel=params["channel"],
-            blocks=blocks
-        )
-    except SlackApiError as e:
-        # You will get a SlackApiError if "ok" is False
-        assert e.response["error"]
+    for complaints in split_complaints(all_complaints):
+        blocks = format_complaints(complaints)
+        print(f"blocks: {len(blocks)}")
+        try:
+            client.chat_postMessage(
+                channel=params["channel"],
+                blocks=blocks
+            )
+        except SlackApiError as e:
+            # You will get a SlackApiError if "ok" is False
+            assert False, e.response["error"]
 
 def format_complaints(complaints):
     """Build a formatted Slack message for posting to the API.


### PR DESCRIPTION
This PR includes two fixes that were necessary to make Sir-CAL transmit to Slack successfully:

* Actually fail when Slack exceptions are raised
* Break up complaints stream into 50-block sections