### PR TITLE
Fix CI to not run on drafts and trigger properly when non draft

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -7,13 +7,13 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    types: [ review_requested, ready_for_review ]
+    types: [ opened, synchronized, reopened, ready_for_review ]
     branches: [ main ]
 
 jobs:
   build:
-
     runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
     strategy:
       matrix:
         #packages: [_delphi_utils_python, cdc_covidnet, claims_hosp, combo_cases_and_deaths, google_symptoms, jhu, nchs_mortality, quidel, quidel_covidtest, safegraph, safegraph_patterns, usafacts]


### PR DESCRIPTION
Summary of Changes:
- Update CI workflow to skip on drafts (and trigger once the draft is ready for review), and also trigger on normal PRs even if there are no reviewers assigned