### PR TITLE
Fix nchs linting

### DIFF
--- a/nchs_mortality/delphi_nchs_mortality/__main__.py
+++ b/nchs_mortality/delphi_nchs_mortality/__main__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Call the function run_module when executed.
 
-This file indicates that calling the module (`python -m MODULE_NAME`) will
+This file indicates that calling the module (`python -m delphi_nchs_mortality`) will
 call the function `run_module` found within the run.py file. There should be
 no need to change this template.
 """

--- a/nchs_mortality/delphi_nchs_mortality/archive_diffs.py
+++ b/nchs_mortality/delphi_nchs_mortality/archive_diffs.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Function for diffing and archiving"""
+
+from os import remove, listdir
+from os.path import join
+from shutil import copy
+from datetime import datetime
+
+from delphi_utils import S3ArchiveDiffer
+
+def arch_diffs(params, daily_arch_diff):
+    """
+    We check for updates for NCHS mortality data every weekday as how it is
+    reported by NCHS and stash these daily updates on S3, but not our API.
+    On a weekly level (on Mondays), we additionally upload the changes to the
+    data made over the past week (due to backfill) to our API.
+
+    Parameters:
+    -----------
+    params: dict
+        Read from params.json
+    daily_arch_diff: S3ArchiveDiffer
+        Used to store and update cache
+    """
+
+    export_dir = params["export_dir"]
+    daily_export_dir = params["daily_export_dir"]
+    cache_dir = params["cache_dir"]
+
+    # Weekly run of archive utility on Monday
+    # - Does not upload to S3, that is handled by daily run of archive utility
+    # - Exports issues into receiving for the API
+    if datetime.today().weekday() == 0:
+        # Copy todays raw output to receiving
+        for output_file in listdir(daily_export_dir):
+            copy(
+                join(daily_export_dir, output_file),
+                join(export_dir, output_file))
+
+        weekly_arch_diff = S3ArchiveDiffer(
+            cache_dir, export_dir,
+            params["bucket_name"], "nchs_mortality",
+            params["aws_credentials"])
+
+        # Dont update cache from S3 (has daily files), only simulate a update_cache() call
+        weekly_arch_diff._cache_updated = True  # pylint: disable=protected-access
+
+        # Diff exports, and make incremental versions
+        _, common_diffs, new_files = weekly_arch_diff.diff_exports()
+
+        # Archive changed and new files only
+        to_archive = [f for f, diff in common_diffs.items() if diff is not None]
+        to_archive += new_files
+        _, fails = weekly_arch_diff.archive_exports(to_archive, update_s3=False)
+
+        # Filter existing exports to exclude those that failed to archive
+        succ_common_diffs = {f: diff for f, diff in common_diffs.items() if f not in fails}
+        weekly_arch_diff.filter_exports(succ_common_diffs)
+
+        # Report failures: someone should probably look at them
+        for exported_file in fails:
+            print(f"Failed to archive (weekly) '{exported_file}'")
+
+    # Daily run of archiving utility
+    # - Uploads changed files to S3
+    # - Does not export any issues into receiving
+
+    # Diff exports, and make incremental versions
+    _, common_diffs, new_files = daily_arch_diff.diff_exports()
+
+    # Archive changed and new files only
+    to_archive = [f for f, diff in common_diffs.items() if diff is not None]
+    to_archive += new_files
+    _, fails = daily_arch_diff.archive_exports(to_archive)
+
+    # Daily output not needed anymore, remove them
+    for exported_file in new_files:
+        remove(exported_file)
+    for exported_file, diff_file in common_diffs.items():
+        remove(exported_file)
+        remove(diff_file)
+
+    # Report failures: someone should probably look at them
+    for exported_file in fails:
+        print(f"Failed to archive (daily) '{exported_file}'")

--- a/nchs_mortality/delphi_nchs_mortality/constants.py
+++ b/nchs_mortality/delphi_nchs_mortality/constants.py
@@ -1,0 +1,22 @@
+"""Registry for constants"""
+# global constants
+METRICS = [
+        "covid_deaths", "total_deaths", "percent_of_expected_deaths",
+        "pneumonia_deaths", "pneumonia_and_covid_deaths", "influenza_deaths",
+        "pneumonia_influenza_or_covid_19_deaths"
+]
+SENSOR_NAME_MAP = {
+        "covid_deaths": "deaths_covid_incidence",
+        "total_deaths": "deaths_allcause_incidence",
+        "percent_of_expected_deaths": "deaths_percent_of_expected",
+        "pneumonia_deaths": "deaths_pneumonia_notflu_incidence",
+        "pneumonia_and_covid_deaths": "deaths_covid_and_pneumonia_notflu_incidence",
+        "influenza_deaths": "deaths_flu_incidence",
+        "pneumonia_influenza_or_covid_19_deaths": "deaths_pneumonia_or_flu_or_covid_incidence"
+}
+SENSORS = [
+        "num",
+        "prop"
+]
+INCIDENCE_BASE = 100000
+GEO_RES = "state"

--- a/nchs_mortality/delphi_nchs_mortality/run.py
+++ b/nchs_mortality/delphi_nchs_mortality/run.py
@@ -2,12 +2,10 @@
 """Functions to call when running the function.
 
 This module should contain a function called `run_module`, that is executed
-when the module is run with `python -m MODULE_NAME`.
+when the module is run with `python -m delphi_nchs_mortality`.
 """
 from datetime import datetime, date, timedelta
 from os.path import join
-from os import remove, listdir
-from shutil import copy
 
 import numpy as np
 import pandas as pd
@@ -15,28 +13,9 @@ from delphi_utils import read_params, S3ArchiveDiffer
 
 from .pull import pull_nchs_mortality_data
 from .export import export_csv
-
-# global constants
-METRICS = [
-        'covid_deaths', 'total_deaths', 'percent_of_expected_deaths',
-        'pneumonia_deaths', 'pneumonia_and_covid_deaths', 'influenza_deaths',
-        'pneumonia_influenza_or_covid_19_deaths'
-]
-SENSOR_NAME_MAP = {
-        "covid_deaths": "deaths_covid_incidence",
-        "total_deaths": "deaths_allcause_incidence",
-        "percent_of_expected_deaths": "deaths_percent_of_expected",
-        "pneumonia_deaths": "deaths_pneumonia_notflu_incidence",
-        "pneumonia_and_covid_deaths": "deaths_covid_and_pneumonia_notflu_incidence",
-        "influenza_deaths": "deaths_flu_incidence",
-        "pneumonia_influenza_or_covid_19_deaths": "deaths_pneumonia_or_flu_or_covid_incidence"
-}
-SENSORS = [
-        "num",
-        "prop"
-]
-INCIDENCE_BASE = 100000
-GEO_RES = "state"
+from .archive_diffs import arch_diffs
+from .constants import (METRICS, SENSOR_NAME_MAP,
+                        SENSORS, INCIDENCE_BASE, GEO_RES)
 
 def run_module():  # pylint: disable=too-many-branches,too-many-statements
     """Run module for processing NCHS mortality data."""
@@ -46,9 +25,7 @@ def run_module():  # pylint: disable=too-many-branches,too-many-statements
         export_start_date = date.today() - timedelta(
                 days=date.today().weekday() + 2)
         export_start_date = export_start_date.strftime('%Y-%m-%d')
-    export_dir = params["export_dir"]
     daily_export_dir = params["daily_export_dir"]
-    cache_dir = params["cache_dir"]
     daily_cache_dir = params["daily_cache_dir"]
     static_file_dir = params["static_file_dir"]
     token = params["token"]
@@ -100,56 +77,7 @@ def run_module():  # pylint: disable=too-many-branches,too-many-statements
     # Weekly run of archive utility on Monday
     # - Does not upload to S3, that is handled by daily run of archive utility
     # - Exports issues into receiving for the API
-    if datetime.today().weekday() == 0:
-        # Copy todays raw output to receiving
-        for output_file in listdir(daily_export_dir):
-            copy(
-                join(daily_export_dir, output_file),
-                join(export_dir, output_file))
-
-        weekly_arch_diff = S3ArchiveDiffer(
-            cache_dir, export_dir,
-            params["bucket_name"], "nchs_mortality",
-            params["aws_credentials"])
-
-        # Dont update cache from S3 (has daily files), only simulate a update_cache() call
-        weekly_arch_diff._cache_updated = True  # pylint: disable=protected-access
-
-        # Diff exports, and make incremental versions
-        _, common_diffs, new_files = weekly_arch_diff.diff_exports()
-
-        # Archive changed and new files only
-        to_archive = [f for f, diff in common_diffs.items() if diff is not None]
-        to_archive += new_files
-        _, fails = weekly_arch_diff.archive_exports(to_archive, update_s3=False)
-
-        # Filter existing exports to exclude those that failed to archive
-        succ_common_diffs = {f: diff for f, diff in common_diffs.items() if f not in fails}
-        weekly_arch_diff.filter_exports(succ_common_diffs)
-
-        # Report failures: someone should probably look at them
-        for exported_file in fails:
-            print(f"Failed to archive (weekly) '{exported_file}'")
-
     # Daily run of archiving utility
     # - Uploads changed files to S3
     # - Does not export any issues into receiving
-
-    # Diff exports, and make incremental versions
-    _, common_diffs, new_files = daily_arch_diff.diff_exports()
-
-    # Archive changed and new files only
-    to_archive = [f for f, diff in common_diffs.items() if diff is not None]
-    to_archive += new_files
-    _, fails = daily_arch_diff.archive_exports(to_archive)
-
-    # Daily output not needed anymore, remove them
-    for exported_file in new_files:
-        remove(exported_file)
-    for exported_file, diff_file in common_diffs.items():
-        remove(exported_file)
-        remove(diff_file)
-
-    # Report failures: someone should probably look at them
-    for exported_file in fails:
-        print(f"Failed to archive (daily) '{exported_file}'")
+    arch_diffs(params, daily_arch_diff)


### PR DESCRIPTION
Fix NCHS linter errors:
- too-many-branches
- too-many-statements
- trailing witespaces

[additional notes from @krivard:]
* Moved archive-diff procedures to their own file
* Moved constants to their own file