### PR TITLE
Update smoother nan handling

### DIFF
--- a/_delphi_utils_python/delphi_utils/smooth.py
+++ b/_delphi_utils_python/delphi_utils/smooth.py
@@ -301,7 +301,6 @@ class Smoother:  # pylint: disable=too-many-instance-attributes
 
     def savgol_predict(self, signal, poly_fit_degree, nr):
         """Predict a single value using the savgol method.
-        
         Fits a polynomial through the values given by the signal and returns the value
         of the polynomial at the right-most signal-value. More precisely, for a signal of length
         n, fits a poly_fit_degree polynomial through the points signal[-n+1+nr], signal[-n+2+nr],


### PR DESCRIPTION
It seemed that there were many cases in JHU tests that required the smoother to be able to act on an array full of nans, so instead of throwing an error, I improved things to be more graceful.

Basically handles the following cases:
* the entire array is nans, in which case the array is returned
* the array begins left-padded with nans, in which case the nans are truncated, the remaining signal is smoothed, and the nans are appended back before being returned
* fixes a couple edge cases where the polynomial degree size or the window length is larger than the number of data points

Its base is #476, so should be merged after.