### PR TITLE
Fix smoother index drop

### DIFF
--- a/_delphi_utils_python/delphi_utils/smooth.py
+++ b/_delphi_utils_python/delphi_utils/smooth.py
@@ -172,6 +172,7 @@ class Smoother:  # pylint: disable=too-many-instance-attributes
             return signal
 
         is_pandas_series = isinstance(signal, pd.Series)
+        pandas_index = signal.index if is_pandas_series else None
         signal = signal.to_numpy() if is_pandas_series else signal
 
         # Find where the first non-nan value is located and truncate the initial nans
@@ -197,7 +198,10 @@ class Smoother:  # pylint: disable=too-many-instance-attributes
 
         # Append the nans back, since we want to preserve length
         signal_smoothed = np.hstack([np.nan*np.ones(ix), signal_smoothed])
-        signal_smoothed = signal_smoothed if not is_pandas_series else pd.Series(signal_smoothed)
+        # Convert back to pandas if necessary
+        if is_pandas_series:
+            signal_smoothed = pd.Series(signal_smoothed)
+            signal_smoothed.index = pandas_index
         return signal_smoothed
 
     def impute(self, signal):

--- a/_delphi_utils_python/tests/test_smooth.py
+++ b/_delphi_utils_python/tests/test_smooth.py
@@ -281,3 +281,11 @@ class TestSmoothers:
         assert np.allclose(
             signal[window_length - 1 :], smoothed_signal[window_length - 1 :]
         )
+
+        # Test that the index of the series gets preserved
+        signal = pd.Series(np.ones(30), index=np.arange(50, 80))
+        smoother = Smoother(smoother_name="moving_average", window_length=10)
+        smoothed_signal = signal.transform(smoother.smooth)
+        ix1 = signal.index
+        ix2 = smoothed_signal.index
+        assert ix1.equals(ix2)


### PR DESCRIPTION
Fixes a bug where the smoother would drop the index of the Pandas series given to it. The index is restored after smoothing. Base is #477 and contains #437, so should be merged after.