### PR TITLE
Add linting to CI for subset of indicators

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -35,8 +35,9 @@ jobs:
       run: |
         make install
     - name: Lint
+      if: ${{ matrix.packages }} == changehc || ${{ matrix.packages }} == claims_hosp || ${{ matrix.packages }} == quidel || ${{ matrix.packages }} == usafacts
       run: |
-        # make lint
+        make lint
     - name: Test
       run: |
         make test

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         make install
     - name: Lint
-      if: ${{ matrix.packages }} == changehc || ${{ matrix.packages }} == claims_hosp || ${{ matrix.packages }} == quidel || ${{ matrix.packages }} == usafacts
+      if: ${{ matrix.packages }} != changehc || ${{ matrix.packages }} != claims_hosp || ${{ matrix.packages }} != quidel || ${{ matrix.packages }} != usafacts
       run: |
         make lint
     - name: Test

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         make install
     - name: Lint
-      if: ${{ matrix.packages }} != changehc || ${{ matrix.packages }} != claims_hosp || ${{ matrix.packages }} != quidel || ${{ matrix.packages }} != usafacts
+      if: ${{ matrix.packages != 'changehc' && matrix.packages != 'claims_hosp' && matrix.packages != 'quidel' && matrix.packages != 'usafacts'}}
       run: |
         make lint
     - name: Test

--- a/google_symptoms/delphi_google_symptoms/geo.py
+++ b/google_symptoms/delphi_google_symptoms/geo.py
@@ -75,4 +75,3 @@ def geo_map(df, geo_res):
         newdf[mask] = np.nan
         converted_df = converted_df.append(newdf)
     return converted_df
-    


### PR DESCRIPTION
### Description
Add linting for tests which currently pass linting. Decided that waiting for get all of them fixed in #452 could take a few days and may lead to other lint breaking changes getting merged in the meantime, so might as well enable the ones that work.

### Changelog
- Enable linting with a conditional statement to only run on the indicators which currently pass.
- Fixed a whitespace on google symptoms to get it to pass

### Fixes 
- n/a
