### PR TITLE
Remove redundant statements in CHC test

### DIFF
--- a/changehc/tests/test_sensor.py
+++ b/changehc/tests/test_sensor.py
@@ -1,16 +1,14 @@
 # standard
-import pytest
 
-# third party
-from delphi_utils import read_params, Smoother
 import numpy as np
 import numpy.random as nr
 import pandas as pd
-
 # first party
 from delphi_changehc.config import Config
 from delphi_changehc.load_data import load_combined_data
 from delphi_changehc.sensor import CHCSensor
+# third party
+from delphi_utils import read_params
 
 CONFIG = Config()
 PARAMS = read_params()
@@ -21,11 +19,6 @@ DROP_DATE = pd.to_datetime(PARAMS["drop_date"])
 class TestLoadData:
     combined_data = load_combined_data(DENOM_FILEPATH, COVID_FILEPATH, DROP_DATE,
                                        "fips")
-    # change smoother window length for test data
-    CHCSensor.smoother = Smoother("savgol",
-                                  poly_fit_degree=1,
-                                  gaussian_bandwidth=Config.SMOOTHER_BANDWIDTH,
-                                  window_length=20)
 
     def test_backfill(self):
         num0 = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=float).reshape(-1, 1)


### PR DESCRIPTION
### Description
Update the change tests to remove some unneeded statements

### Changelog
- Remove unused imports
- Remove a test-specific smoother change that is unnecessary due to #477 fixing the bug that required it

### Fixes 
- n/a
