### PR TITLE
enable CHC linting onCI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         make install
     - name: Lint
-      if: ${{ matrix.packages != 'changehc' && matrix.packages != 'claims_hosp' && matrix.packages != 'quidel' && matrix.packages != 'usafacts'}}
+      if: ${{ matrix.packages != 'claims_hosp' && matrix.packages != 'quidel' && matrix.packages != 'usafacts'}}
       run: |
         make lint
     - name: Test


### PR DESCRIPTION
### Description
Enable linting CI step to occur for CHC now that it passes.

### Changelog
- remove CHC from the lint exclusion list

### Fixes 
- n/a
