### PR TITLE
Enable usafacts linting on CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         make install
     - name: Lint
-      if: ${{ matrix.packages != 'claims_hosp' && matrix.packages != 'quidel' && matrix.packages != 'usafacts'}}
+      if: ${{ matrix.packages != 'claims_hosp' && matrix.packages != 'quidel'}}
       run: |
         make lint
     - name: Test


### PR DESCRIPTION
### Description
Linting passes for USAFacts now that the smoothing refactor is merged, so enabling it to run on the CI.

### Changelog
- Remove usafacts from linting exclusion conditions

### Fixes 
- n/a