### PR TITLE
Add licensing/DUA checks to signal release process

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_release.md
+++ b/.github/ISSUE_TEMPLATE/feature_release.md
@@ -22,6 +22,7 @@ assignees: 'benjaminysmith'
 
 - [ ] Statistical review (usually [correlations](https://github.com/cmu-delphi/covidcast/tree/main/docs/R-notebooks))
 - [ ] Signal / source name review (usually [Roni](https://docs.google.com/document/d/10hGd4Evce4lJ4VkWaQEKFQxvmw2P4xyYGtIAWF52Sf8/edit?usp=sharing))
+- [ ] Verify licensing terms and any applicable DUA restrictions
 
 <!-- relevant for new map signals -->
 


### PR DESCRIPTION
So we always check the DUA before releasing and apply any necessary restrictions. A process fix like this ensures we can't make this class of mistakes easily.

### Description
Update the issue template for new features.

