### PR TITLE
Link directly to the data source template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_release.md
+++ b/.github/ISSUE_TEMPLATE/feature_release.md
@@ -15,7 +15,7 @@ assignees: 'benjaminysmith'
 
 <!-- relevant for most work -->
 
-- [ ] API [documentation](https://github.com/cmu-delphi/delphi-epidata/tree/main/docs/api) and/or [changelog](https://github.com/cmu-delphi/delphi-epidata/blob/main/docs/api/covidcast_changelog.md)
+- [ ] API [documentation](https://github.com/cmu-delphi/delphi-epidata/blob/main/docs/api/covidcast-signals/_source-template.md) and/or [changelog](https://github.com/cmu-delphi/delphi-epidata/blob/main/docs/api/covidcast_changelog.md)
 - [ ] API mailing list notification
 
 <!-- relevant for new signals -->


### PR DESCRIPTION
To encourage its use by everyone adding a data source.

### Description

The template covers everything important (and I'll soon add licensing to it), so we should make sure people creating a new signal notice it and use it.
