### PR TITLE
Add new Jenkins deployment workflow

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,90 +1,72 @@
 #!groovy
 
-// import shared library: https://github.com/cmu-delphi/jenkins-shared-library
+// Import shared lib.
 @Library('jenkins-shared-library') _
 
+/*
+   Declare variables.
+   - indicator_list should contain all the indicators to handle in the pipeline.
+   - Keep in sync with '.github/workflows/python-ci.yml'.
+   - TODO: Get this list automatically from python-ci.yml at runtime?
+ */
+def indicator_list = ["cdc_covidnet", "claims_hosp", "combo_cases_and_deaths", "google_symptoms", "jhu", "nchs_mortality", "quidel", "quidel_covidtest", "safegraph", "safegraph_patterns", "usafacts"]
+def build_package = [:]
+def deploy_staging = [:]
+def deploy_production = [:]
+
 pipeline {
-
     agent any
-
     stages {
-
-        stage ("Environment") {            
+        stage('Build and Package') {
             when {
-                anyOf {
-                    branch "deploy-*";
-                    changeRequest target: "deploy-*", comparator: "GLOB"
-                }
+                branch "main";
             }
             steps {
                 script {
-                    // Get the indicator name from the pipeline env.
-                    if ( env.CHANGE_TARGET ) {
-                        INDICATOR = env.CHANGE_TARGET.replaceAll("deploy-", "")
+                    indicator_list.each { indicator ->
+                        build_package[indicator] = {
+                            sh "jenkins/build-and-package.sh ${indicator}"
+                        }
                     }
-                    else if ( env.BRANCH_NAME ) {
-                        INDICATOR = env.BRANCH_NAME.replaceAll("deploy-", "")
+                    parallel build_package
+                }
+            }
+        }
+        stage('Deploy staging') {
+            when {
+                branch "main";
+            }
+            steps {
+                script {
+                    indicator_list.each { indicator ->
+                        deploy_staging[indicator] = {
+                            sh "jenkins/deploy-staging.sh ${indicator}"
+                        }
                     }
-                    else {
-                        INDICATOR = ""
+                    parallel deploy_staging
+                }
+            }
+        }
+        stage('Deploy production') {
+            when {
+                branch "prod";
+            }
+            steps {
+                script {
+                    indicator_list.each { indicator ->
+                        deploy_production[indicator] = {
+                            sh "jenkins/deploy-production.sh ${indicator}"
+                        }
                     }
-                } 
-            }
-        }
-
-        stage('Build') {
-            when {
-                changeRequest target: "deploy-*", comparator: "GLOB"
-            }
-            steps {
-                sh "jenkins/${INDICATOR}-jenkins-build.sh"
-            }
-        }
-
-        stage('Test') {
-            when {
-                changeRequest target: "deploy-*", comparator: "GLOB"
-            }
-            steps {
-                sh "jenkins/${INDICATOR}-jenkins-test.sh"
-            }
-        }
-        
-        stage('Package') {
-            when {
-                changeRequest target: "deploy-*", comparator: "GLOB"
-            }
-            steps {
-                sh "jenkins/${INDICATOR}-jenkins-package.sh"
-            }
-        }
-
-        stage('Deploy to staging env') {
-            when {
-                changeRequest target: "deploy-*", comparator: "GLOB"
-            }
-            steps {
-                sh "jenkins/jenkins-deploy-staging.sh ${INDICATOR}"
-            }
-        }
-
-        stage('Deploy') {
-            when {
-                branch "deploy-*"
-            }
-            steps {
-                sh "jenkins/${INDICATOR}-jenkins-deploy.sh"
+                    parallel deploy_production
+                }
             }
         }
     }
-
     post {
         always {
             script {
-                /*
-                Use slackNotifier.groovy from shared library and provide current
-                build result as parameter.
-                */   
+                // Use slackNotifier.groovy from shared lib.
                 slackNotifier(currentBuild.currentResult)
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
    Declare variables.
    - indicator_list should contain all the indicators to handle in the pipeline.
    - Keep in sync with '.github/workflows/python-ci.yml'.
-   - TODO: Get this list automatically from python-ci.yml at runtime?
+   - TODO: #527 Get this list automatically from python-ci.yml at runtime.
  */
 def indicator_list = ["cdc_covidnet", "claims_hosp", "combo_cases_and_deaths", "google_symptoms", "jhu", "nchs_mortality", "quidel", "quidel_covidtest", "safegraph", "safegraph_patterns", "usafacts"]
 def build_package = [:]

--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -1,7 +1,7 @@
 ---
 runtime_user: "indicators"
 jenkins_user: "jenkins"
-#jenkins_artifact_dir: "/var/lib/jenkins/artifacts"
+#jenkins_artifact_dir: "/var/lib/jenkins/artifacts" # TODO: Switcheroo to `artifacts` after this goes live! 
 jenkins_artifact_dir: "/var/lib/jenkins/test-artifacts"
 indicators_runtime_dir: "/home/{{ runtime_user }}/runtime"
 package: "{{ indicator }}.tar.gz" # {{ indicator }} is passed in from the Jenkins shell script wrapper.

--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -1,8 +1,7 @@
 ---
 runtime_user: "indicators"
 jenkins_user: "jenkins"
-#jenkins_artifact_dir: "/var/lib/jenkins/artifacts" # TODO: Switcheroo to `artifacts` after this goes live! 
-jenkins_artifact_dir: "/var/lib/jenkins/test-artifacts"
+jenkins_artifact_dir: "/var/lib/jenkins/artifacts"
 indicators_runtime_dir: "/home/{{ runtime_user }}/runtime"
 package: "{{ indicator }}.tar.gz" # {{ indicator }} is passed in from the Jenkins shell script wrapper.
 python_version: "3.8.2"

--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -1,7 +1,8 @@
 ---
 runtime_user: "indicators"
 jenkins_user: "jenkins"
-jenkins_artifact_dir: "/var/lib/jenkins/artifacts"
+#jenkins_artifact_dir: "/var/lib/jenkins/artifacts"
+jenkins_artifact_dir: "/var/lib/jenkins/test-artifacts"
 indicators_runtime_dir: "/home/{{ runtime_user }}/runtime"
 package: "{{ indicator }}.tar.gz" # {{ indicator }} is passed in from the Jenkins shell script wrapper.
 python_version: "3.8.2"

--- a/jenkins/build-and-package.sh
+++ b/jenkins/build-and-package.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Jenkins build-and-package
+#
+
+set -eo pipefail
+source ~/.bash_profile
+
+# Vars
+local_indicator=$1
+
+#
+# Build
+#
+
+cd "${WORKSPACE}/${local_indicator}" || exit
+
+# Set up venv
+python -m venv env
+source env/bin/activate
+pip install ../_delphi_utils_python/.
+pip install .
+
+#
+# Package
+#
+
+cd "${WORKSPACE}" || exit
+
+# Create .tar.gz for deployment
+# TODO: Switcheroo to `artifacts` after this goes live!
+tar -czvf "${JENKINS_HOME}/test-artifacts/${local_indicator}.tar.gz" "${local_indicator}"

--- a/jenkins/build-and-package.sh
+++ b/jenkins/build-and-package.sh
@@ -28,5 +28,4 @@ pip install .
 cd "${WORKSPACE}" || exit
 
 # Create .tar.gz for deployment
-# TODO: Switcheroo to `artifacts` after this goes live!
-tar -czvf "${JENKINS_HOME}/test-artifacts/${local_indicator}.tar.gz" "${local_indicator}"
+tar -czvf "${JENKINS_HOME}/artifacts/${local_indicator}.tar.gz" "${local_indicator}"

--- a/jenkins/deploy-production.sh
+++ b/jenkins/deploy-production.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Jenkins deploy
+#
+
+set -eo pipefail
+source ~/.bash_profile
+
+#
+# Deploy
+#
+
+local_indicator=$1
+
+cd "${WORKSPACE}/ansible" || exit
+
+# Ansible!
+ansible-playbook ansible-deploy.yaml --extra-vars "indicator=${local_indicator}" -i inventory

--- a/jenkins/deploy-staging.sh
+++ b/jenkins/deploy-staging.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Jenkins deploy
+#
+
+set -eo pipefail
+source ~/.bash_profile
+
+#
+# Deploy
+#
+
+local_indicator=$1
+
+cd "${WORKSPACE}/ansible" || exit
+
+# Ansible!
+ansible-playbook ansible-deploy-staging.yaml --extra-vars "indicator=${local_indicator}" -i inventory


### PR DESCRIPTION
### Description
This PR adds new Jenkins functionality to simplify indicator deploys for the new repo development workflow.

It will work like this:

- A merge to main:
  - Creates a venv for each indicator, handles package installation and setup,
    and then creates a package (at the moment a tar.gz).
  - Deploys each indicator to the staging environment.

- A merge to prod:

  - Deploys each indicator to the production environment.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add new Jenkinsfile
- Add new supporting shell scripts