### PR TITLE
Change source name of changehc to chng

### DIFF
--- a/ansible/templates/changehc-params-prod.json.j2
+++ b/ansible/templates/changehc-params-prod.json.j2
@@ -1,6 +1,6 @@
 {
   "static_file_dir": "./static",
-  "export_dir": "/common/covidcast/receiving/changehc",
+  "export_dir": "/common/covidcast/receiving/chng",
   "cache_dir": "./cache",
   "input_denom_file": null,
   "input_covid_file": null,


### PR DESCRIPTION
### Description
From Roni:
> Just today, they ask that we refer to them as "Change Healthcare" whenever possible, at least externally (which github is these days).  If we "have" to use a shorthand, they asked that we use CHNG.  @Katie I don't think this quite requires re-naming the API source, but if it's easy enough, we should consider doing so.

### Changelog
Set delivery location to `/common/covidcast/receiving/chng`

