### PR TITLE
Add prod branch to CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,10 +5,10 @@ name: Python package
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, prod ]
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-    branches: [ main ]
+    branches: [ main, prod ]
 
 jobs:
   build:


### PR DESCRIPTION
### Description
Add CI checks so they run on prod branch. **This also needs to get merged into the prod branch unless we remake it once this is merged.**

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add `prod` as a branch for CI to run on.

### Fixes 
- n/a
