### PR TITLE
Attempting to fix the intermittent issues in Jenkins when building multiple venvs at once.

### DIFF
--- a/jenkins/build-and-package.sh
+++ b/jenkins/build-and-package.sh
@@ -18,8 +18,9 @@ cd "${WORKSPACE}/${local_indicator}" || exit
 # Set up venv
 python -m venv env
 source env/bin/activate
-pip install ../_delphi_utils_python/.
-pip install .
+pip install --upgrade pip --retries 10 --timeout 20
+pip install ../_delphi_utils_python/. --retries 10 --timeout 20
+pip install . --retries 10 --timeout 20
 
 #
 # Package


### PR DESCRIPTION
### Description
Fix:

The issue appears to be pip install failures, possibly due to timeout or 
throttling by the package repo. This is hard to reproduce, so I am hoping that
retries with a longer timeout will help here.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Adding pip retry and timeout flags when doing `pip install`.

### Fixes 
- Fixes #(issue)