### PR TITLE
Get quidel to pass pylint and enable CI

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         make install
     - name: Lint
-      if: ${{ matrix.packages != 'claims_hosp' && matrix.packages != 'quidel'}}
+      if: ${{ matrix.packages != 'claims_hosp' }}
       run: |
         make lint
     - name: Test

--- a/quidel/delphi_quidel/generate_sensor.py
+++ b/quidel/delphi_quidel/generate_sensor.py
@@ -93,7 +93,7 @@ def generate_sensor_for_other_geores(state_groups, data, res_key, smooth,
             res_group = res_group.merge(parent_group, how="left",
                                         on="timestamp", suffixes=('', '_parent'))
             res_group = res_group.drop(columns=[res_key, "state_id", "state_id" + '_parent'])
-        except:
+        except KeyError:
             has_parent = False
             res_group = res_group.drop(columns=[res_key, "state_id"])
         res_group.set_index("timestamp", inplace=True)

--- a/quidel/delphi_quidel/geo_maps.py
+++ b/quidel/delphi_quidel/geo_maps.py
@@ -1,5 +1,6 @@
 """Contains geographic mapping tools."""
 def geo_map(geo_res, data, map_df):
+    """Call appropriate mapping function based on desired geo resolution."""
     if geo_res == "county":
         return zip_to_county(data, map_df)
     if geo_res == "msa":

--- a/quidel/delphi_quidel/pull.py
+++ b/quidel/delphi_quidel/pull.py
@@ -33,10 +33,9 @@ def compare_dates(date1, date2, flag):
         if flag == "l":
             return date1
         return date2
-    else:
-        if flag == "l":
-            return date2
-        return date1
+    if flag == "l":
+        return date2
+    return date1
 
 def check_whether_date_in_range(search_date, start_date, end_date):
     """
@@ -130,9 +129,9 @@ def get_from_email(column_names, start_dates, end_dates, mail_server,
                         continue
 
                     # Check whether we pull the data from a valid time range
-                    WhetherInRange = check_whether_date_in_range(
+                    whether_in_range = check_whether_date_in_range(
                             search_date, start_dates[test], end_dates[test])
-                    if not WhetherInRange:
+                    if not whether_in_range:
                         continue
 
                     print(f"Pulling {test} data received on %s"%search_date.date())
@@ -370,7 +369,7 @@ def pull_quidel_data(params):
     return dfs, _end_date
 
 def check_export_end_date(input_export_end_dates, _end_date,
-                          END_FROM_TODAY_MINUS):
+                          end_from_today_minus):
     """
     Update the export_end_date according to the data received
     By default, set the export end date to be the last pulling date - 5 days
@@ -393,7 +392,7 @@ def check_export_end_date(input_export_end_dates, _end_date,
     export_end_dates = {}
     for test_type in TEST_TYPES:
         export_end_dates[test_type] = _end_date \
-                                      - timedelta(days=END_FROM_TODAY_MINUS)
+                                      - timedelta(days=end_from_today_minus)
         if input_export_end_dates[test_type] != "":
             input_export_end_dates[test_type] = datetime.strptime(
                     input_export_end_dates[test_type], '%Y-%m-%d')
@@ -403,7 +402,7 @@ def check_export_end_date(input_export_end_dates, _end_date,
     return export_end_dates
 
 def check_export_start_date(export_start_dates, export_end_dates,
-                            EXPORT_DAY_RANGE):
+                            export_day_range):
     """
     Update the export_start_date according to the export_end_date so that it
     could be export_end_date - EXPORT_DAY_RANGE
@@ -414,7 +413,7 @@ def check_export_start_date(export_start_dates, export_end_dates,
         export_end_date: dict
             Calculated according to the data received.
             The type of values are datetime.datetime
-        EXPORT_DAY_RANGE: int
+        export_day_range: int
             Number of days to report
 
     Returns:
@@ -430,7 +429,7 @@ def check_export_start_date(export_start_dates, export_end_dates,
                     export_start_dates[test_type], '%Y-%m-%d')
         # Only export data from -45 days to -5 days
         export_start_dates[test_type] = compare_dates(
-                export_end_dates[test_type] - timedelta(days=EXPORT_DAY_RANGE),
+                export_end_dates[test_type] - timedelta(days=export_day_range),
                 export_start_dates[test_type], "l")
         if test_type == "covid_ag":
             export_start_dates[test_type] = compare_dates(

--- a/quidel/delphi_quidel/run.py
+++ b/quidel/delphi_quidel/run.py
@@ -21,6 +21,7 @@ from .constants import (END_FROM_TODAY_MINUS, EXPORT_DAY_RANGE,
                         GEO_RESOLUTIONS, SENSORS)
 
 def run_module():
+    """Run Quidel flu test module."""
     params = read_params()
     cache_dir = params["cache_dir"]
     export_dir = params["export_dir"]


### PR DESCRIPTION
### Description
Fix outstanding pylint errors and enable the pylint check on CI. This does not make it pass pydocstyle yet.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Remove quidel from CI lint exclusion list
- Fix linting errors on quidel

### Fixes 
- Addresses part of #452 
