### PR TITLE
Get nchs to pass pydocstyle

### DIFF
--- a/nchs_mortality/Makefile
+++ b/nchs_mortality/Makefile
@@ -13,7 +13,8 @@ install: venv
 
 lint:
 	. env/bin/activate; \
-	pylint $(dir)
+	pylint $(dir); \
+	pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/nchs_mortality/delphi_nchs_mortality/archive_diffs.py
+++ b/nchs_mortality/delphi_nchs_mortality/archive_diffs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Function for diffing and archiving"""
+"""Function for diffing and archiving."""
 
 from os import remove, listdir
 from os.path import join
@@ -10,6 +10,8 @@ from delphi_utils import S3ArchiveDiffer
 
 def arch_diffs(params, daily_arch_diff):
     """
+    Archive differences between new updates and existing data.
+
     We check for updates for NCHS mortality data every weekday as how it is
     reported by NCHS and stash these daily updates on S3, but not our API.
     On a weekly level (on Mondays), we additionally upload the changes to the
@@ -22,7 +24,6 @@ def arch_diffs(params, daily_arch_diff):
     daily_arch_diff: S3ArchiveDiffer
         Used to store and update cache
     """
-
     export_dir = params["export_dir"]
     daily_export_dir = params["daily_export_dir"]
     cache_dir = params["cache_dir"]

--- a/nchs_mortality/delphi_nchs_mortality/constants.py
+++ b/nchs_mortality/delphi_nchs_mortality/constants.py
@@ -1,4 +1,4 @@
-"""Registry for constants"""
+"""Registry for constants."""
 # global constants
 METRICS = [
         "covid_deaths", "total_deaths", "percent_of_expected_deaths",


### PR DESCRIPTION
### Description
Fix linting on nchs indicator so pydocstyle passes.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Fix linting errors
- Enable pydocstyle to run in makefile so it gets run on CI

### Fixes 
- n/a
