### PR TITLE
Add null removal feature to exporting

### DIFF
--- a/_delphi_utils_python/delphi_utils/export.py
+++ b/_delphi_utils_python/delphi_utils/export.py
@@ -14,7 +14,8 @@ def create_export_csv(
     sensor: str,
     metric: Optional[str] = None,
     start_date: Optional[datetime] = None,
-    end_date: Optional[datetime] = None
+    end_date: Optional[datetime] = None,
+    remove_null_samples: Optional[bool] = False
 ):
     """Export data in the format expected by the Delphi API.
 
@@ -34,6 +35,8 @@ def create_export_csv(
         Earliest date to export or None if no minimum date restrictions should be applied.
     end_date: Optional[datetime]
         Latest date to export or None if no maximum date restrictions should be applied.
+    remove_null_samples: Optional[bool]
+        Whether to remove entries whose sample sizes are null.
     """
     df = df.copy()
 
@@ -54,6 +57,7 @@ def create_export_csv(
         else:
             export_filename = f"{date.strftime('%Y%m%d')}_{geo_res}_{metric}_{sensor}.csv"
         export_file = join(export_dir, export_filename)
-        df[df["timestamp"] == date][["geo_id", "val", "se", "sample_size",]].to_csv(
-            export_file, index=False, na_rep="NA"
-        )
+        export_df = df[df["timestamp"] == date][["geo_id", "val", "se", "sample_size",]]
+        if remove_null_samples:
+            export_df = export_df[export_df["sample_size"].notnull()]
+        export_df.to_csv(export_file, index=False, na_rep="NA")

--- a/_delphi_utils_python/tests/test_export.py
+++ b/_delphi_utils_python/tests/test_export.py
@@ -153,3 +153,63 @@ class TestExport:
                 "20200315_state_test.csv",
             ]
         )
+
+    def test_export_with_null_removal(self):
+        """Test that `remove_null_samples = True` removes entries with null samples."""
+        _clean_directory(self.TEST_DIR)
+
+        df_with_nulls = self.DF.copy().append({
+                                "geo_id": "66666",
+                                "timestamp": datetime(2020, 6, 6),
+                                "val": 10,
+                                "se": 0.2,
+                                "sample_size": pd.NA},
+                            ignore_index=True)
+
+        create_export_csv(
+            df=df_with_nulls,
+            export_dir=self.TEST_DIR,
+            geo_res="state",
+            sensor="test",
+            remove_null_samples=True
+        )
+
+        assert _non_ignored_files_set(self.TEST_DIR) == set(
+            [
+                "20200215_state_test.csv",
+                "20200301_state_test.csv",
+                "20200315_state_test.csv",
+                "20200606_state_test.csv"
+            ]
+        )
+        assert pd.read_csv(join(self.TEST_DIR, "20200606_state_test.csv")).size == 0
+
+    def test_export_without_null_removal(self):
+        """Test that `remove_null_samples = False` does not remove entries with null samples."""
+        _clean_directory(self.TEST_DIR)
+
+        df_with_nulls = self.DF.copy().append({
+                                "geo_id": "66666",
+                                "timestamp": datetime(2020, 6, 6),
+                                "val": 10,
+                                "se": 0.2,
+                                "sample_size": pd.NA},
+                            ignore_index=True)
+
+        create_export_csv(
+            df=df_with_nulls,
+            export_dir=self.TEST_DIR,
+            geo_res="state",
+            sensor="test",
+            remove_null_samples=False
+        )
+
+        assert _non_ignored_files_set(self.TEST_DIR) == set(
+            [
+                "20200215_state_test.csv",
+                "20200301_state_test.csv",
+                "20200315_state_test.csv",
+                "20200606_state_test.csv"
+            ]
+        )
+        assert pd.read_csv(join(self.TEST_DIR, "20200606_state_test.csv")).size > 0


### PR DESCRIPTION
### Description
Add the ability to only export data points whose sample size is non-null.

As part of migrating indicators to a common export function in #497, I discovered some of the indicators remove entries whose sample sizes are null (see discussion on #516 and #517).  Rather than hack it in in the indicator code, I have made it a native option of `delphi_utils.create_export_csv()`

### Changelog
- `delphi_utils.create_export_csv()` takes a `remove_null_samples` option (default `False`) that, when `True`:
    - Does not write CSV rows for data points whose sample size is null
    - Does write a file for a date even if all data points on that day have null entries (i.e., the file will be empty)
