### PR TITLE
Move safegraph patterns results to correct directory

### DIFF
--- a/safegraph_patterns/delphi_safegraph_patterns/run.py
+++ b/safegraph_patterns/delphi_safegraph_patterns/run.py
@@ -18,8 +18,8 @@ from .process import process
 
 METRICS = [
         # signal_name, naics_code, wip
-        ('bars_visit', 722410, True),
-        ('restaurants_visit', 722511, True),
+        ('bars_visit', 722410, False),
+        ('restaurants_visit', 722511, False),
 ]
 VERSIONS = [
         # relaese version, access dir

--- a/safegraph_patterns/run-safegraph_patterns.sh
+++ b/safegraph_patterns/run-safegraph_patterns.sh
@@ -16,5 +16,5 @@ env/bin/python -m delphi_safegraph_patterns
 # Copy the files to the ingestion directory.
 echo "Copying files to the ingestion directory..."
 # Hack to make cp care less about missing recent files since we don't always have them.
-cp $(date +"receiving/%Y%m*") /common/covidcast/receiving/safegraph_patterns 2>/dev/null
-cp $(date --date='-1 month' +"receiving/%Y%m*") /common/covidcast/receiving/safegraph_patterns
+cp $(date +"receiving/%Y%m*") /common/covidcast/receiving/safegraph 2>/dev/null
+cp $(date --date='-1 month' +"receiving/%Y%m*") /common/covidcast/receiving/safegraph

--- a/safegraph_patterns/tests/test_run.py
+++ b/safegraph_patterns/tests/test_run.py
@@ -27,13 +27,13 @@ class TestRun:
             for geo in GEO_RESOLUTIONS:
                 for sensor in SENSORS:
                     for metric in METRICS:
-                        fn = "_".join([date, geo, "wip", metric[0], sensor]) + ".csv"
+                        fn = "_".join([date, geo, metric[0], sensor]) + ".csv"
                         expected_files.append(fn)
 
         assert set(expected_files).issubset(set(csv_files))
 
         # Test output format
         df = pd.read_csv(
-            join("./receiving", "20200729_state_wip_bars_visit_num.csv")
+            join("./receiving", "20200729_state_bars_visit_num.csv")
         )
         assert (df.columns.values == ["geo_id", "val", "se", "sample_size"]).all()


### PR DESCRIPTION
### Description
The signals generated by `delphi_safegraph_patterns` should go into the `safegraph` directory along with the safegraph mobility signals

### Changelog
Itemize code/test/documentation changes and files added/removed.
- `run_safegraph_patterns.sh`

