### PR TITLE
Refactor safegraph to use export util

### DIFF
--- a/safegraph/delphi_safegraph/process.py
+++ b/safegraph/delphi_safegraph/process.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 from delphi_utils.signal import add_prefix
 from delphi_utils.export import create_export_csv
-from delphi_utils import GeoMapper
+from delphi_utils.geomap import GeoMapper
 
 from .constants import HOME_DWELL, COMPLETELY_HOME, FULL_TIME_WORK, PART_TIME_WORK, GEO_RESOLUTIONS
 

--- a/safegraph/delphi_safegraph/process.py
+++ b/safegraph/delphi_safegraph/process.py
@@ -5,7 +5,7 @@ from typing import List
 import numpy as np
 import pandas as pd
 from delphi_utils.signal import add_prefix
-
+from delphi_utils.export import create_export_csv
 from delphi_utils import GeoMapper
 
 from .constants import HOME_DWELL, COMPLETELY_HOME, FULL_TIME_WORK, PART_TIME_WORK, GEO_RESOLUTIONS
@@ -192,10 +192,12 @@ def process_window(df_list: List[pd.DataFrame],
                 f'{signal}_se': 'se',
                 f'{signal}_n': 'sample_size',
             }, axis=1)
-            date_str = date.strftime('%Y%m%d')
-            df_export.to_csv(f'{export_dir}/{date_str}_{geo_res}_{signal}.csv',
-                             na_rep='NA',
-                             index=False, )
+            df_export["timestamp"] = date.strftime('%Y%m%d')
+            create_export_csv(df_export,
+                              export_dir,
+                              geo_res,
+                              signal,
+                              )
 
 
 def process(filenames: List[str],


### PR DESCRIPTION
### Description
Migrate safegraph to use the common export function rather than an indicator-specific one. Tested by storing the test output from original code and diff'ing against the new code to make sure nothing changed.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- `process_window()` now calls `delphi_utils.export.create_export_csv()` instead of `to_csv()`
- intermediate `timestamp` column is added so the util function can be used.

### Fixes 
- Partially addresses #497