### PR TITLE
Update run script to copy a specific range of files to the receiving directory

### DIFF
--- a/safegraph_patterns/run-safegraph_patterns.sh
+++ b/safegraph_patterns/run-safegraph_patterns.sh
@@ -24,4 +24,5 @@ env/bin/python -m delphi_safegraph_patterns
 # - awk prints the files that are inclusive of ${start_day} to ${today}.
 # - Pipe that list into xargs and copy those files to the receiving dir.
 echo "Copying files to the ingestion directory..."
-ls -1 | awk '$0>=from && $0<=to' from="${start_day}" to="${today}" | xargs cp -t /common/covidcast/receiving/safegraph
+ls -1 | awk '$0>=from && $0<=to' from="${start_day}" to="${today}" \
+  | xargs cp -t /common/covidcast/receiving/safegraph

--- a/safegraph_patterns/run-safegraph_patterns.sh
+++ b/safegraph_patterns/run-safegraph_patterns.sh
@@ -24,5 +24,6 @@ env/bin/python -m delphi_safegraph_patterns
 # - awk prints the files that are inclusive of ${start_day} to ${today}.
 # - Pipe that list into xargs and copy those files to the receiving dir.
 echo "Copying files to the ingestion directory..."
-ls -1 ./receiving | awk '$0>=from && $0<=to' from="${start_day}" to="${today}" \
+cd ./receiving || exit
+ls -1 *.csv | awk '$0>=from && $0<=to' from="${start_day}" to="${today}" \
   | xargs cp -t /common/covidcast/receiving/safegraph

--- a/safegraph_patterns/run-safegraph_patterns.sh
+++ b/safegraph_patterns/run-safegraph_patterns.sh
@@ -5,6 +5,11 @@
 
 #set -eo pipefail
 
+# Vars.
+# Date of first monday 8 weeks in the past. Taste to suit!
+start_day=$(date --date 'monday-56 days' +"%Y%m%d")
+today=$(date +"%Y%m%d")
+
 # Purge the receiving directory.
 echo "Purging ./receiving..."
 rm -f ./receiving/*
@@ -14,7 +19,9 @@ echo "Running the indicator..."
 env/bin/python -m delphi_safegraph_patterns
 
 # Copy the files to the ingestion directory.
+# The unwieldy one-liner does the following:
+# - Pipe a list (ls -1) of files into awk.
+# - awk prints the files that are inclusive of ${start_day} to ${today}.
+# - Pipe that list into xargs and copy those files to the receiving dir.
 echo "Copying files to the ingestion directory..."
-# Hack to make cp care less about missing recent files since we don't always have them.
-cp $(date +"receiving/%Y%m*") /common/covidcast/receiving/safegraph 2>/dev/null
-cp $(date --date='-1 month' +"receiving/%Y%m*") /common/covidcast/receiving/safegraph
+ls -1 | awk '$0>=from && $0<=to' from="${start_day}" to="${today}" | xargs cp -t /common/covidcast/receiving/safegraph

--- a/safegraph_patterns/run-safegraph_patterns.sh
+++ b/safegraph_patterns/run-safegraph_patterns.sh
@@ -24,5 +24,5 @@ env/bin/python -m delphi_safegraph_patterns
 # - awk prints the files that are inclusive of ${start_day} to ${today}.
 # - Pipe that list into xargs and copy those files to the receiving dir.
 echo "Copying files to the ingestion directory..."
-ls -1 | awk '$0>=from && $0<=to' from="${start_day}" to="${today}" \
+ls -1 ./receiving | awk '$0>=from && $0<=to' from="${start_day}" to="${today}" \
   | xargs cp -t /common/covidcast/receiving/safegraph

--- a/safegraph_patterns/run-safegraph_patterns.sh
+++ b/safegraph_patterns/run-safegraph_patterns.sh
@@ -20,7 +20,7 @@ env/bin/python -m delphi_safegraph_patterns
 
 # Copy the files to the ingestion directory.
 # The unwieldy one-liner does the following:
-# - Pipe a list (ls -1) of files into awk.
+# - Pipe a list of files into awk.
 # - awk prints the files that are inclusive of ${start_day} to ${today}.
 # - Pipe that list into xargs and copy those files to the receiving dir.
 echo "Copying files to the ingestion directory..."


### PR DESCRIPTION
### Description
Adds shell script variables and one-liner to copy a specific range of generated
files to the receiving directory.

There is a current need to copy generated files that start on the Monday 8 weeks
in the past up until today (or the most recently generated). The run script has
been updated with a one-liner to handle this. It is not a beaut but seems to
work.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Update run-safegraph_patterns.sh