### PR TITLE
Check for duplicate rows

### DIFF
--- a/validator/PLANS.md
+++ b/validator/PLANS.md
@@ -38,7 +38,6 @@
 
 ### Starter/small issues
 
-* Check for duplicate rows
 * Backfill problems, especially with JHU and USA Facts, where a change to old data results in a datapoint that doesn’t agree with surrounding data ([JHU examples](https://delphi-org.slack.com/archives/CF9G83ZJ9/p1600729151013900)) or is very different from the value it replaced. If date is already in the API, have any values changed significantly within the "backfill" window (use span_length setting). See [this](https://github.com/cmu-delphi/covidcast-indicators/pull/155#discussion_r504195207) for context.
 * Run check_missing_date_files (or similar) on every geo type-signal type separately in comparative checks loop.
 

--- a/validator/PLANS.md
+++ b/validator/PLANS.md
@@ -24,6 +24,7 @@
 * Similar average value as API data (static threshold)
 * Source data for specified date range is empty
 * API data for specified date range is empty
+* Duplicate rows
 
 
 ## Current features

--- a/validator/delphi_validator/validate.py
+++ b/validator/delphi_validator/validate.py
@@ -721,6 +721,16 @@ class Validator():
 
         self.increment_total_checks()
 
+    def check_duplicate_rows(self, data_df, filename):
+        is_duplicate = data_df.duplicated()
+        if (any(is_duplicate)):
+            duplicate_row_idxs = list(data_df[is_duplicate].index)
+            self.raised_warnings.append(ValidationError(
+                ("check_duplicate_rows", filename),
+                duplicate_row_idxs, 
+                "Some rows are duplicated, which may indicate data integrity issues"))
+        self.increment_total_checks()
+
     def validate(self, export_dir):
         """
         Runs all data checks.
@@ -747,8 +757,8 @@ class Validator():
         # For every daily file, read in and do some basic format and value checks.
         for filename, match in validate_files:
             data_df = load_csv(join(export_dir, filename))
-
             self.check_df_format(data_df, filename)
+            self.check_duplicate_rows(data_df, filename)
             self.check_bad_geo_id_format(
                 data_df, filename, match.groupdict()['geo_type'])
             self.check_bad_geo_id_value(

--- a/validator/tests/test_checks.py
+++ b/validator/tests/test_checks.py
@@ -229,7 +229,8 @@ class TestCheckBadGeoIdFormat:
         assert "SP" not in validator.raised_errors[0].expression
 
 class TestDuplicatedRows:
-    params = {}
+    params = {"data_source": "", "span_length": 1,
+              "end_date": "2020-09-02", "expected_lag": {}}
     def test_no_duplicates(self):
         validator = Validator(self.params)
         df = pd.DataFrame([["a", "1"], ["b", "2"], ["c", "3"]])


### PR DESCRIPTION
### Description
New validation check raises warning if files contain multiple copies of an identical row (which indicates possible data integrity issues)

### Changelog
- validate.py - Added `check_duplicate_rows` and related calls
- test_checks.py - Added tests for `check_duplicate_rows` in validate.py
- PLANS.md - Remove duplicate rows task from list

### Fixes 
- Fixes "check for duplicate rows" task in PLANS.md (no associated Github issue)
