### PR TITLE
Fix ingestion directory path

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -1,7 +1,7 @@
 {
   "export_start_date": "2020-02-20",
   "static_file_dir": "./static",
-  "export_dir": "/common/covidcast/receiving/google_symptoms",
+  "export_dir": "/common/covidcast/receiving/google-symptoms",
   "cache_dir": "./cache",
   "base_url": "https://raw.githubusercontent.com/google-research/open-covid-19-data/master/data/exports/search_trends_symptoms_dataset/United%20States%20of%20America{sub_url}2020_US_{state}daily_symptoms_dataset.csv"
 }


### PR DESCRIPTION
### Description
Fix.

The ingestion directory should be `google-symptoms`.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Update google_symptoms-params-prod.json.j2