### PR TITLE
Update CHNG production params to include CLI inputs

### DIFF
--- a/ansible/templates/changehc-params-prod.json.j2
+++ b/ansible/templates/changehc-params-prod.json.j2
@@ -2,8 +2,14 @@
   "static_file_dir": "./static",
   "export_dir": "/common/covidcast/receiving/chng",
   "cache_dir": "./cache",
-  "input_denom_file": null,
-  "input_covid_file": null,
+  "input_files": {
+    "denom": null,
+    "covid": null,
+    "flu": null,
+    "mixed": null,
+    "flu_like": null,
+    "covid_like": null
+  },
   "start_date": "2020-02-01",
   "end_date": null,
   "drop_date": null,


### PR DESCRIPTION
### Description
Updated production CHNG params file missing from https://github.com/cmu-delphi/covidcast-indicators/pull/587

### Changelog
- ansible template params file for CHNG

