### PR TITLE
Timezone issue described in #593

### DIFF
--- a/changehc/delphi_changehc/run.py
+++ b/changehc/delphi_changehc/run.py
@@ -85,8 +85,8 @@ def run_module():
     make_asserts(params)
 
     if params["drop_date"] is None:
-        # files are dropped about 8pm the day after the issue date
-        dropdate_dt = (datetime.now() - timedelta(days=1,hours=20))
+        # files are dropped about 4pm the day after the issue date
+        dropdate_dt = (datetime.now() - timedelta(days=1,hours=16))
         dropdate_dt = dropdate_dt.replace(hour=0,minute=0,second=0,microsecond=0)
     else:
         dropdate_dt = datetime.strptime(params["drop_date"], "%Y-%m-%d")


### PR DESCRIPTION
### Description
See #593. When we download the CHNG files, the timestamps are automatically converted into the code's timezone, in our case 4pm. We shouldn't run the indicator between 4-6pm Eastern just to be safe.

### Changelog
- run.py

### Fixes 
- Fixes #593 
