### PR TITLE
SirCAL default config: Update signals list and max ages

### DIFF
--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -1,40 +1,53 @@
 {
-  "channel": "#covid-19-outages",
+  "channel": "#sir-complains-a-lot",
   "slack_token": "",
   "sources": {
     "doctor-visits": {
       "max_age": 5,
-      "maintainers": ["U010VE2T51N"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "hospital-admissions": {
       "max_age": 5,
-      "maintainers": ["U010VE2T51N"],
-      "retired-signals": ["smoothed_covid19", "smoothed_adj_covid19"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
+      "retired-signals": ["smoothed_covid19","smoothed_adj_covid19"]
+    },
+    "chng": {
+      "max_age": 6,
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
+    },
+    "google-symptoms": {
+      "max_age": 11,
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "ght": {
       "max_age": 5,
-      "maintainers": ["U010VE2T51N"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
+    },
+    "usa-facts": {
+      "max_age": 3,
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "jhu-csse": {
       "max_age": 2,
-      "maintainers": ["UUCGWMJ5P"]
-    },
-    "usa-facts": {
-      "max_age": 2,
-      "maintainers": ["UUCGWMJ5P"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "safegraph": {
-      "max_age": 4,
-      "maintainers": ["U010VE2T51N"]
+      "max_age": 11,
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "fb-survey": {
-      "max_age": 2,
+      "max_age": 3,
       "maintainers": ["U01069KCRS7"]
     },
     "indicator-combination": {
-      "max_age": 2,
-      "maintainers": ["U010VE2T51N"],
+      "max_age": 3,
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
       "retired-signals": ["nmf_day_doc_fbs_ght"]
+    },
+    "quidel": {
+      "max_age":6,
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
+      "retired-signals": ["raw_pct_negative","smoothed_pct_negative","raw_tests_per_device","smoothed_tests_per_device"]
     }
   }
 }


### PR DESCRIPTION
### Description
Configuration update for "Sir Complains-a-lot" fault detection tool to cover new signals (chng, google-symptoms, but also jhu-csse and quidel which were for some reason excluded before)

### Changelog
- SirCAL params file template