### PR TITLE
Pin xlrd version for Quidel

### DIFF
--- a/quidel/setup.py
+++ b/quidel/setup.py
@@ -10,7 +10,7 @@ required = [
     "pylint",
     "delphi-utils",
     "imap-tools",
-    "xlrd",
+    "xlrd==1.2.0",
     "covidcast"
 ]
 

--- a/quidel_covidtest/setup.py
+++ b/quidel_covidtest/setup.py
@@ -10,7 +10,7 @@ required = [
     "pylint",
     "delphi-utils",
     "imap-tools",
-    "xlrd",
+    "xlrd==1.2.0",
     "covidcast"
 ]
 


### PR DESCRIPTION
### Description
Latest versions of [xlrd](https://pypi.org/project/xlrd/#history) (released this morning, and both 2.0.0. and 2.0.1)  breaks the tests, so pinning the version we were previously on.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Pin xlrd to 0.1.2

### Fixes 
- Fixes #(issue)
