### PR TITLE
Remove 'direction' statement from combo cases

### DIFF
--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -69,7 +69,6 @@ def combine_usafacts_and_jhu(signal, geo, date_range, fetcher=covidcast.signal):
     else:
         combined_df = usafacts_df
 
-    combined_df = combined_df.drop(["direction"], axis=1)
     combined_df = combined_df.rename(COLUMN_MAPPING,
                                      axis=1)
     return combined_df

--- a/combo_cases_and_deaths/tests/test_run.py
+++ b/combo_cases_and_deaths/tests/test_run.py
@@ -44,8 +44,8 @@ def test_unstable_sources():
     available.
     """
     placeholder = lambda geo: pd.DataFrame(
-        [(date.today(),"pr" if geo == "state" else "72000",1,1,1,0)],
-        columns="time_value geo_value value stderr sample_size direction".split())
+        [(date.today(),"pr" if geo == "state" else "72000",1,1,1)],
+        columns="time_value geo_value value stderr sample_size".split())
     fetcher10 = lambda *x: placeholder(x[-1]) if x[0] == "usa-facts" else None
     fetcher01 = lambda *x: placeholder(x[-1]) if x[0] == "jhu-csse" else None
     fetcher11 = lambda *x: placeholder(x[-1])


### PR DESCRIPTION
### Description
Direction was removed from the covidcast client, so now combo cases is erroring because it was trying to drop it.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Remove statement which expects the `direction` column

### Fixes 
- Fixes #633 
