### PR TITLE
Impute FIPS if zip is present for HHS Faciliies

### DIFF
--- a/hhs_facilities/delphi_hhs_facilities/geo.py
+++ b/hhs_facilities/delphi_hhs_facilities/geo.py
@@ -69,8 +69,8 @@ def fill_missing_fips(df: pd.DataFrame, gmpr: GeoMapper) -> pd.DataFrame:
     # we keep unmapped zips because they may be used in HRR mapping so we don't want to drop them
     added_fips = gmpr.add_geocode(no_fips, "zip", "fips", dropna=False)
     added_fips["fips_code"] = added_fips["fips"]
-    # set weight of unmapped zips to 1 to they don"t zero out all the values when multiplied
-    added_fips.weight.fillna(1, inplace=True)  
+    # set weight of unmapped zips to 1 to they don't zero out all the values when multiplied
+    added_fips.weight.fillna(1, inplace=True)
     added_fips[data_cols] = added_fips[data_cols].multiply(added_fips["weight"], axis=0)
     fips_filled = added_fips.groupby(no_data_cols, dropna=False, as_index=False).sum(min_count=1)
     fips_filled.drop(columns="weight", inplace=True)

--- a/hhs_facilities/delphi_hhs_facilities/geo.py
+++ b/hhs_facilities/delphi_hhs_facilities/geo.py
@@ -1,6 +1,7 @@
 """Functions for mapping geographic regions."""
 
 import pandas as pd
+from numpy import dtype
 from delphi_utils.geomap import GeoMapper
 
 
@@ -38,3 +39,39 @@ def convert_geo(df: pd.DataFrame, geo: str, gmpr: GeoMapper) -> pd.DataFrame:
         output_df = gmpr.add_geocode(df, "fips", geo, from_col="fips_code")
         output_df["geo_id"] = output_df[geo]
     return output_df
+
+
+def fill_missing_fips(df: pd.DataFrame, gmpr: GeoMapper) -> pd.DataFrame:
+    """
+    Fill in missing FIPS code if zip is present.
+
+    Maps rows that have the FIPS missing but zip present. The rest of the rows,
+    including those where both FIPS and zip are nan, are kept as is and appended back at the end.
+
+    TODO #636 Generalize this function to geomapper.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        Input DataFrame containing zip and fips columns.
+    gmpr:
+        GeoMapper object.
+
+    Returns
+    -------
+    DataFrame with missing FIPS imputed with zip.
+    """
+    mask = pd.isna(df["fips_code"]) & ~pd.isna(df["zip"])
+    no_fips = df[mask]
+    fips_present = df[~mask]
+    no_data_cols = [c for c in df.columns if df[c].dtypes not in (dtype("int64"), dtype("float64"))]
+    data_cols = list(set(df.columns) - set(no_data_cols))
+    # we keep unmapped zips because they may be used in HRR mapping so we don't want to drop them
+    added_fips = gmpr.add_geocode(no_fips, "zip", "fips", dropna=False)
+    added_fips["fips_code"] = added_fips["fips"]
+    # set weight of unmapped zips to 1 to they don"t zero out all the values when multiplied
+    added_fips.weight.fillna(1, inplace=True)  
+    added_fips[data_cols] = added_fips[data_cols].multiply(added_fips["weight"], axis=0)
+    fips_filled = added_fips.groupby(no_data_cols, dropna=False, as_index=False).sum(min_count=1)
+    fips_filled.drop(columns="weight", inplace=True)
+    return pd.concat([fips_present, fips_filled]).reset_index(drop=True)

--- a/hhs_facilities/delphi_hhs_facilities/geo.py
+++ b/hhs_facilities/delphi_hhs_facilities/geo.py
@@ -47,6 +47,9 @@ def fill_missing_fips(df: pd.DataFrame, gmpr: GeoMapper) -> pd.DataFrame:
 
     Maps rows that have the FIPS missing but zip present. The rest of the rows,
     including those where both FIPS and zip are nan, are kept as is and appended back at the end.
+    Rows with a zip which fail to map to a FIPS are also kept so that column totals remain equal.
+    This means that column sums before and after imputation should be identical, and any dropping
+    of values is handled by downstream geomapping.
 
     TODO #636 Generalize this function to geomapper.
 
@@ -66,7 +69,6 @@ def fill_missing_fips(df: pd.DataFrame, gmpr: GeoMapper) -> pd.DataFrame:
     fips_present = df[~mask]
     no_data_cols = [c for c in df.columns if df[c].dtypes not in (dtype("int64"), dtype("float64"))]
     data_cols = list(set(df.columns) - set(no_data_cols))
-    # we keep unmapped zips because they may be used in HRR mapping so we don't want to drop them
     added_fips = gmpr.add_geocode(no_fips, "zip", "fips", dropna=False)
     added_fips["fips_code"] = added_fips["fips"]
     # set weight of unmapped zips to 1 to they don't zero out all the values when multiplied

--- a/hhs_facilities/tests/test_geo.py
+++ b/hhs_facilities/tests/test_geo.py
@@ -1,9 +1,10 @@
 """Tests for running the geo conversion functions."""
 
 import pandas as pd
+import numpy as np
 
 from delphi_utils.geomap import GeoMapper
-from delphi_hhs_facilities.geo import convert_geo
+from delphi_hhs_facilities.geo import convert_geo, fill_missing_fips
 
 
 class TestGeo:
@@ -32,3 +33,47 @@ class TestGeo:
             test_hrr_output.geo_id, pd.Series(["230"]), check_names=False
         )
 
+    def test_fill_missing_fips(self):
+        gmpr = GeoMapper()
+        test_input = pd.DataFrame(
+            {"hospital_pk": ["test", "test2", "test3"],
+             "fips_code": ["fakefips", np.nan, np.nan],
+             "zip": ["01001", "01001", "00601"],
+             "val1": [1.0, 5.0, 10.0],
+             "val2": [2.0, 25.0, 210.0]
+             })
+        expected = pd.DataFrame(
+            {"hospital_pk": ["test", "test2", "test3", "test3"],
+             "fips_code": ["fakefips", "25013", "72001", "72141"],
+             "zip": ["01001", "01001", "00601", "00601"],
+             "val1": [1.0, 5.0, 0.994345718901454*10, 0.005654281098546042*10],
+             "val2": [2.0, 25.0, 0.994345718901454*210.0, 0.005654281098546042*210.0]
+             })
+        pd.testing.assert_frame_equal(fill_missing_fips(test_input, gmpr), expected)
+
+        # test all nans stay as nan
+        test_input = pd.DataFrame(
+            {"hospital_pk": ["test", "test2", "test3"],
+             "fips_code": ["fakefips", np.nan, np.nan],
+             "zip": ["01001", "01001", "00601"],
+             "val1": [1.0, 5.0, np.nan],
+             "val2": [2.0, 25.0, 210.0]
+             })
+        expected = pd.DataFrame(
+            {"hospital_pk": ["test", "test2", "test3", "test3"],
+             "fips_code": ["fakefips", "25013", "72001", "72141"],
+             "zip": ["01001", "01001", "00601", "00601"],
+             "val1": [1.0, 5.0, np.nan, np.nan],
+             "val2": [2.0, 25.0, 0.994345718901454*210.0, 0.005654281098546042*210.0]
+             })
+        pd.testing.assert_frame_equal(fill_missing_fips(test_input, gmpr), expected)
+
+        # test that populated fips or both nan is no-op
+        test_input_no_missing = pd.DataFrame(
+            {"hospital_pk": ["test", "test2", "test3", "test4"],
+             "fips_code": ["fakefips", "testfips", "pseudofips", np.nan],
+             "zip": ["01001", "01001", "00601", np.nan],
+             "val": [1.0, 5.0, 10.0, 0.0]
+             })
+        pd.testing.assert_frame_equal(fill_missing_fips(test_input_no_missing, gmpr),
+                                      test_input_no_missing)


### PR DESCRIPTION
### Description
Merge after #632. 

Some rows in the HHS data have a zip but no fips, so this adds a function that imputes the missing fips from the zip. See [this thread](https://github.com/cmu-delphi/covidcast-indicators/pull/632#discussion_r541273291) for discussion. Ended up being a little messier than I thought.

### Changelog
Itemize code/test/documentation changes and files added/removed.
-  Add function and unit tests to impute fips

### Fixes 
- n/a
