### PR TITLE
Keep thresholded counties for future calculations

### DIFF
--- a/doctor_visits/delphi_doctor_visits/geo_maps.py
+++ b/doctor_visits/delphi_doctor_visits/geo_maps.py
@@ -101,11 +101,14 @@ class GeoMaps:
 
         Returns: tuple of dataframe at the daily-state resolution, and geo_id column name
         """
-        data = self.gmpr.fips_to_megacounty(data,
+        all_data = self.gmpr.fips_to_megacounty(data,
                                             threshold_visits,
                                             threshold_len,
                                             fips_col="PatCountyFIPS",
                                             thr_col="Denominator",
                                             date_col="ServiceDate")
-        data.rename({"megafips": "PatCountyFIPS"}, axis=1, inplace=True)
+        all_data.rename({"megafips": "PatCountyFIPS"}, axis=1, inplace=True)
+        megacounties = all_data[all_data.PatCountyFIPS.str.endswith("000")]
+        data = pd.concat([data, megacounties])
+
         return data.groupby("PatCountyFIPS"), "PatCountyFIPS"

--- a/doctor_visits/tests/test_geomap.py
+++ b/doctor_visits/tests/test_geomap.py
@@ -46,8 +46,13 @@ class TestGeoMap:
         assert name == "PatCountyFIPS"
         assert set(out.groups.keys()) == {
                 "01001",
+                "01003",
                 "01005",
+                "01007",
                 "01009",
+                "01011",
+                "01013",
                 "01015",
+                "01017",
                 "01000"
         }


### PR DESCRIPTION
### Description
Fix bug where rows in thresholded counties are dropped in megacounty creation. When dropped, the signal backfill is incorrectly computed on 0-padded dates. 

### Changelog
- extract megacounties and concatenate to original data in `geo_maps::county_to_megacounty`
- update unit test `test_geo_map::test_county_to_megacounty`


Unit tests pass. Checks on state/msa/hrr match exactly to current behavior. More counties are produced (due to increased denominator from backwards padding).

@krivard Do we need to regenerate past issues of DV, up till when we switched to the geomapper? The data isn't _wrong_, but it is _different_, since it would have been produced only on larger counties, without the correct dynamic backwards padding. 