### PR TITLE
Add geoutil method to return all values for a given geo

### DIFF
--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -116,6 +116,11 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
             "state_code": {"hhs": None},
             "jhu_uid": {"fips": None},
         }
+        self.geo_lists = {
+            geo: None for geo in ["zip", "fips", "hrr", "state_id", "state_code",
+                                  "state_name", "hhs", "msa"]
+        }
+        self.geo_lists["nation"] = {"us"}
 
     # Utility functions
     def _load_crosswalk(self, from_code, to_code):
@@ -512,3 +517,45 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         data = data.join(mega_data)
         data = data.reset_index().groupby([date_col, mega_col]).sum()
         return data.reset_index()
+
+    def get_geo_values(self, geo_type):
+        """
+        Return a set of all values for a given geography type.
+
+        Uses the same caching paradigm as _load_crosswalks, storing the value from previous calls
+        and not re-reading the CSVs if the same geo type is requested multiple times. Does not
+        share the same crosswalk cache to keep complexity down.
+
+        Reads the FIPS crosswalk files by default for reference data since those have mappings to
+        all other geos. Exceptions are nation, which has no mapping file and is hard-coded as 'us',
+        and state, which uses the state codes table since the fips/state mapping doesn't include
+        all territories.
+
+        Note for state codes
+
+        Parameters
+        ----------
+        geo_type: str
+          One of "zip", "fips", "hrr", "state_id", "state_code", "state_name", "hhs", "msa",
+          and "nation"
+
+        Returns
+        -------
+        Set of geo values, all in string format.
+        """
+        if self.geo_lists[geo_type]:
+            return self.geo_lists[geo_type]
+        else:
+            from_code = "fips"
+            if geo_type.startswith("state"):
+                to_code = from_code = "state"
+            elif geo_type == "fips":
+                to_code = "pop"
+            else:
+                to_code = geo_type
+            stream = pkg_resources.resource_stream(
+                __name__, self.crosswalk_filepaths[from_code][to_code]
+            )
+            crosswalk = pd.read_csv(stream, dtype=str)
+            self.geo_lists[geo_type] = set(crosswalk[geo_type])
+            return self.geo_lists[geo_type]

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -531,8 +531,6 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         and state, which uses the state codes table since the fips/state mapping doesn't include
         all territories.
 
-        Note for state codes
-
         Parameters
         ----------
         geo_type: str

--- a/_delphi_utils_python/tests/test_geomap.py
+++ b/_delphi_utils_python/tests/test_geomap.py
@@ -292,3 +292,11 @@ class TestGeoMapper:
                 }
             )
         )
+
+    def test_get_geos(self):
+        gmpr = GeoMapper()
+        assert gmpr.get_geo_values("nation") == {"us"}
+        assert gmpr.get_geo_values("hhs") == set(str(i) for i in range(1, 11))
+        assert len(gmpr.get_geo_values("fips")) == 3274
+        assert len(gmpr.get_geo_values("state_id")) == 60
+        assert len(gmpr.get_geo_values("zip")) == 32976


### PR DESCRIPTION
### Description
Using the existing crosswalk files, this method will return all the values for a given geo type. It does not necessarily return all the geo values for the entire country only those present in the crosswalks, e.g. there are ~42k zip codes and we only map 32k, so this only returns 32k

Note that we use the greater zip number re: #648 

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add geo_geo_values() method to GeoMapper class and unit tests

### Fixes 
- Fixes #(issue)
