### PR TITLE
Convert hhs_hosp to use geomapper geo values

### DIFF
--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -30,13 +30,7 @@ def run_module():
     """Generate ground truth HHS hospitalization data."""
     params = read_params()
     mapper = GeoMapper()
-
-    # get a list of state codes
-    all_states = pd.DataFrame(
-        { "state_code": ["{:02d}".format(x) for x in range(1, 72)] }
-    )
-    all_states =  mapper.add_geocode(all_states, "state_code", "state_id")
-    request_all_states = ",".join(all_states.state_id)
+    request_all_states = ",".join(mapper.get_geo_values("state_id"))
 
     today = date.today()
     past_reference_day = date(year=2020, month=1, day=1) # first available date in DB


### PR DESCRIPTION
### Description
Both fixes a bug where PR and other territories were excluded, and also converts to using the new geomapper method to return all the state id values.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Use geomapper.get_geo_values() function to get all the states

### Fixes 
- Fixes #(issue)
