### PR TITLE
Fix covid_hosp date argument

### DIFF
--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -35,7 +35,7 @@ def run_module():
     today = date.today()
     past_reference_day = date(year=2020, month=1, day=1) # first available date in DB
     date_range = [ int(x.strftime("%Y%m%d")) for x in [past_reference_day, today] ]
-    response = Epidata.covid_hosp(request_all_states, date_range)
+    response = Epidata.covid_hosp(request_all_states, Epidata.range(*date_range))
     if response['result'] != 1:
         raise Exception(f"Bad result from Epidata: {response['message']}")
     all_columns = pd.DataFrame(response['epidata'])


### PR DESCRIPTION
### Description
Fix argument for the `covid_hosp` function in the `hhs_hosp` indicator

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Update argument from `[date1,date2]` -> `Epidata.range(date1, date2)` which is equiavelent to`{'from':date1, 'to':date2}`

### Fixes 
- Fixes #(issue)
