### PR TITLE
Prepare hhs_hosp for staging release.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@
    - Keep in sync with '.github/workflows/python-ci.yml'.
    - TODO: #527 Get this list automatically from python-ci.yml at runtime.
  */
-def indicator_list = ["cdc_covidnet", "changehc", "claims_hosp", "combo_cases_and_deaths", "google_health", "google_symptoms", "jhu", "nchs_mortality", "quidel", "quidel_covidtest", "safegraph", "safegraph_patterns", "usafacts"]
+def indicator_list = ["cdc_covidnet", "changehc", "claims_hosp", "combo_cases_and_deaths", "google_health", "google_symptoms", "hhs_hosp", "jhu", "nchs_mortality", "quidel", "quidel_covidtest", "safegraph", "safegraph_patterns", "usafacts"]
 def build_package = [:]
 def deploy_staging = [:]
 def deploy_production = [:]

--- a/ansible/templates/hhs_hosp-params-prod.json.j2
+++ b/ansible/templates/hhs_hosp-params-prod.json.j2
@@ -1,0 +1,6 @@
+{
+  "static_file_dir": "./static",
+  "export_dir": "/common/covidcast/receiving/hhs-hosp",
+  "cache_dir": "./cache",
+  "wip_signal": ""
+}

--- a/ansible/templates/staging-api-match-list.j2
+++ b/ansible/templates/staging-api-match-list.j2
@@ -2,3 +2,4 @@ data_source=quidel-staging&signal=covid_ag_
 data_source=chng
 data_source=safegraph
 data_source=google-symptoms
+data_source=hhs-hosp


### PR DESCRIPTION
### Description
Release:

Adds basic necessities to get hhs_hosp to staging so we can validate for
eventual production release.

### Changelog
Adds:
- Production-ready params template.

Updates:
- Jenkinsfile to build/deploy hhs_hosp.
- Staging API proxy match list to surface `hhs-hosp` (assuming this for signal name in the API).