### PR TITLE
Update hhs signal name in staging api

### DIFF
--- a/ansible/templates/staging-api-match-list.j2
+++ b/ansible/templates/staging-api-match-list.j2
@@ -2,4 +2,4 @@ data_source=quidel-staging&signal=covid_ag_
 data_source=chng
 data_source=safegraph
 data_source=google-symptoms
-data_source=hhs-hosp
+data_source=hhs


### PR DESCRIPTION
### Description
We want to be able to query for `hhs` in the staging api. Was `hhs_hosp`
previously.