### PR TITLE
Get FB package tests up to date

### DIFF
--- a/facebook/README.md
+++ b/facebook/README.md
@@ -23,7 +23,7 @@ Rscript run.R
 
 ## Building and testing the code
 
-The documentation for the package is written using the **roxygen2** packaage. To
+The documentation for the package is written using the **roxygen2** package. To
 (re)-create this documentation for the package, run the following from the package
 directory:
 
@@ -31,7 +31,7 @@ directory:
 make lib
 ```
 
-Testing the package is done with the build-in R package checks (which include both
+Testing the package is done with the built-in R package checks (which include both
 static and dynamic checks), as well as unit tests written with **testthat**. To run all
 of these, use the following from within this directory:
 

--- a/facebook/delphiFacebook/tests/testthat/test-geo.R
+++ b/facebook/delphiFacebook/tests/testthat/test-geo.R
@@ -60,7 +60,7 @@ test_that("testing MSA crosswalk function", {
 
 })
 
-test_that("testing creating all all crosswalk files", {
+test_that("testing creating all crosswalk files", {
 
   cw_list <- produce_crosswalk_list(static_dir)
 

--- a/facebook/delphiFacebook/tests/testthat/test-geo.R
+++ b/facebook/delphiFacebook/tests/testthat/test-geo.R
@@ -64,7 +64,7 @@ test_that("testing creating all all crosswalk files", {
 
   cw_list <- produce_crosswalk_list(static_dir)
 
-  expect_setequal(names(cw_list), c("county", "state", "msa", "hrr", "national"))
+  expect_setequal(names(cw_list), c("county", "state", "msa", "hrr", "nation"))
   expect_true(all(sapply(cw_list, function(v) inherits(v, "data.frame"))))
 
 })

--- a/facebook/delphiFacebook/tests/testthat/test-integration.R
+++ b/facebook/delphiFacebook/tests/testthat/test-integration.R
@@ -10,7 +10,7 @@ library(testthat)
 
 context("Testing the run_facebook function")
 
-geo_levels <- c("state", "county", "hrr", "msa", "national")
+geo_levels <- c("state", "county", "hrr", "msa", "nation")
 dates <- c("20200510", "20200511", "20200512", "20200513")
 metrics <- c("raw_cli", "raw_ili", "raw_hh_cmnty_cli", "raw_nohh_cmnty_cli",
              "raw_wcli", "raw_wili", "raw_whh_cmnty_cli", "raw_wnohh_cmnty_cli",
@@ -63,16 +63,16 @@ test_that("testing geo files contain correct number of lines", {
 
   expect_true(all(dt_nrow[grid$dates == "20200510"] == 1L))
   expect_true(all(dt_nrow[grid$dates == "20200511"] == 1L))
-  expect_true(all(dt_nrow[grid$dates == "20200512" & grid$geo_levels != "national"] == 2L))
+  expect_true(all(dt_nrow[grid$dates == "20200512" & grid$geo_levels != "nation"] == 2L))
   expect_true(all(
     dt_nrow[grid$dates == "20200513" & stri_detect(fnames, fixed = "raw")] == 1L
   ))
   expect_true(all(
     dt_nrow[grid$dates == "20200513" &
             stri_detect(fnames, fixed = "smoothed") &
-            grid$geo_levels != "national"] == 2L
+            grid$geo_levels != "nation"] == 2L
   ))
-  expect_true(all(dt_nrow[grid$geo_levels == "national"] == 1L))
+  expect_true(all(dt_nrow[grid$geo_levels == "nation"] == 1L))
 })
 
 test_that("testing raw community values files", {
@@ -363,7 +363,7 @@ test_that("testing national aggregation", {
     stringsAsFactors=FALSE
   )
   f_state <- sprintf("%s_%s_%s.csv", grid$dates, "state", grid$metrics)
-  f_national <- sprintf("%s_%s_%s.csv", grid$dates, "national", grid$metrics)
+  f_national <- sprintf("%s_%s_%s.csv", grid$dates, "nation", grid$metrics)
 
   for(i in seq_along(f_state))
   {

--- a/facebook/delphiFacebook/tests/testthat/test-integration.R
+++ b/facebook/delphiFacebook/tests/testthat/test-integration.R
@@ -16,7 +16,60 @@ metrics <- c("raw_cli", "raw_ili", "raw_hh_cmnty_cli", "raw_nohh_cmnty_cli",
              "raw_wcli", "raw_wili", "raw_whh_cmnty_cli", "raw_wnohh_cmnty_cli",
              "smoothed_cli", "smoothed_ili", "smoothed_hh_cmnty_cli",
              "smoothed_nohh_cmnty_cli", "smoothed_wcli", "smoothed_wili",
-             "smoothed_whh_cmnty_cli", "smoothed_wnohh_cmnty_cli")
+             "smoothed_whh_cmnty_cli", "smoothed_wnohh_cmnty_cli",
+
+             # # mask wearing, wave 4+
+             # "smoothed_wearing_mask",
+             # "smoothed_wwearing_mask",
+             # "smoothed_others_masked",
+             # "smoothed_wothers_masked",
+             #
+             # # mental health, wave 4+
+             # "smoothed_worried_become_ill",
+             # "smoothed_wworried_become_ill",
+             # "smoothed_worried_finances",
+             # "smoothed_wworried_finances",
+             #
+             # "smoothed_anxious_5d",
+             # "smoothed_wanxious_5d",
+             # "smoothed_depressed_5d",
+             # "smoothed_wdepressed_5d",
+             # "smoothed_felt_isolated_5d",
+             # "smoothed_wfelt_isolated_5d",
+
+             # travel
+             "smoothed_travel_outside_state_5d",
+             "smoothed_wtravel_outside_state_5d",
+
+             # work outside home
+             # pre-wave-4
+             "wip_smoothed_work_outside_home_5d",
+             "wip_smoothed_wwork_outside_home_5d"
+             # # wave 4+
+             # "smoothed_work_outside_home_1d",
+             # "smoothed_wwork_outside_home_1d",
+             # 
+             # # activities, wave 4+
+             # "smoothed_shop_1d",
+             # "smoothed_wshop_1d",
+             # "smoothed_restaurant_1d",
+             # "smoothed_wrestaurant_1d",
+             # "smoothed_spent_time_1d",
+             # "smoothed_wspent_time_1d",
+             # "smoothed_large_event_1d",
+             # "smoothed_wlarge_event_1d",
+             # "smoothed_public_transit_1d",
+             # "smoothed_wpublic_transit_1d",
+             # 
+             # # testing, wave 4+
+             # "smoothed_tested_14d",
+             # "smoothed_wtested_14d",
+             # "smoothed_tested_positive_14d",
+             # "smoothed_wtested_positive_14d",
+             # "smoothed_wanted_test_14d",
+             # "smoothed_wwanted_test_14d"
+             )
+
 
 test_that("testing existence of csv files", {
   grid <- expand.grid(

--- a/facebook/delphiFacebook/tests/testthat/test-integration.R
+++ b/facebook/delphiFacebook/tests/testthat/test-integration.R
@@ -18,7 +18,7 @@ metrics <- c("raw_cli", "raw_ili", "raw_hh_cmnty_cli", "raw_nohh_cmnty_cli",
              "smoothed_nohh_cmnty_cli", "smoothed_wcli", "smoothed_wili",
              "smoothed_whh_cmnty_cli", "smoothed_wnohh_cmnty_cli")
 
-test_that("testing existance of csv files", {
+test_that("testing existence of csv files", {
   grid <- expand.grid(
     geo_levels = geo_levels, dates = dates, metrics = metrics, stringsAsFactors=FALSE
   )

--- a/facebook/delphiFacebook/tests/testthat/test-integration.R
+++ b/facebook/delphiFacebook/tests/testthat/test-integration.R
@@ -18,25 +18,6 @@ metrics <- c("raw_cli", "raw_ili", "raw_hh_cmnty_cli", "raw_nohh_cmnty_cli",
              "smoothed_nohh_cmnty_cli", "smoothed_wcli", "smoothed_wili",
              "smoothed_whh_cmnty_cli", "smoothed_wnohh_cmnty_cli",
 
-             # # mask wearing, wave 4+
-             # "smoothed_wearing_mask",
-             # "smoothed_wwearing_mask",
-             # "smoothed_others_masked",
-             # "smoothed_wothers_masked",
-             #
-             # # mental health, wave 4+
-             # "smoothed_worried_become_ill",
-             # "smoothed_wworried_become_ill",
-             # "smoothed_worried_finances",
-             # "smoothed_wworried_finances",
-             #
-             # "smoothed_anxious_5d",
-             # "smoothed_wanxious_5d",
-             # "smoothed_depressed_5d",
-             # "smoothed_wdepressed_5d",
-             # "smoothed_felt_isolated_5d",
-             # "smoothed_wfelt_isolated_5d",
-
              # travel
              "smoothed_travel_outside_state_5d",
              "smoothed_wtravel_outside_state_5d",
@@ -45,29 +26,6 @@ metrics <- c("raw_cli", "raw_ili", "raw_hh_cmnty_cli", "raw_nohh_cmnty_cli",
              # pre-wave-4
              "wip_smoothed_work_outside_home_5d",
              "wip_smoothed_wwork_outside_home_5d"
-             # # wave 4+
-             # "smoothed_work_outside_home_1d",
-             # "smoothed_wwork_outside_home_1d",
-             # 
-             # # activities, wave 4+
-             # "smoothed_shop_1d",
-             # "smoothed_wshop_1d",
-             # "smoothed_restaurant_1d",
-             # "smoothed_wrestaurant_1d",
-             # "smoothed_spent_time_1d",
-             # "smoothed_wspent_time_1d",
-             # "smoothed_large_event_1d",
-             # "smoothed_wlarge_event_1d",
-             # "smoothed_public_transit_1d",
-             # "smoothed_wpublic_transit_1d",
-             # 
-             # # testing, wave 4+
-             # "smoothed_tested_14d",
-             # "smoothed_wtested_14d",
-             # "smoothed_tested_positive_14d",
-             # "smoothed_wtested_positive_14d",
-             # "smoothed_wanted_test_14d",
-             # "smoothed_wwanted_test_14d"
              )
 
 


### PR DESCRIPTION
### Description
Modify tests to reflect recent changes to code. Main source of failures was `national` -> `nation` update.

### Changelog
- Change `national` -> `nation` in `test-geos.R` and `test-integration.R`
- Add newly expected indicators to `test-integration.R`