### PR TITLE
Add HHS and Nation to combo cases

### DIFF
--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/constants.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/constants.py
@@ -18,4 +18,6 @@ GEO_RESOLUTIONS = [
     "state",
     "msa",
     "hrr",
+    "hhs",
+    "nation"
 ]

--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -15,8 +15,11 @@ import covidcast
 import pandas as pd
 
 from delphi_utils import read_params, add_prefix
+from delphi_utils.geomap import GeoMapper
 from .constants import METRICS, SMOOTH_TYPES, SENSORS, GEO_RESOLUTIONS
 
+
+GMPR = GeoMapper()
 
 def check_none_data_frame(data_frame, label, date_range):
     """Log and return True when a data frame is None."""
@@ -46,31 +49,39 @@ COLUMN_MAPPING = {"time_value": "timestamp",
 def combine_usafacts_and_jhu(signal, geo, date_range, fetcher=covidcast.signal):
     """Add rows for PR from JHU signals to USA-FACTS signals."""
     print("Fetching usa-facts...")
-    usafacts_df = fetcher("usa-facts", signal, date_range[0], date_range[1], geo)
+    geo_to_fetch = "county" if geo in ["county", "hhs", "nation"] else geo
+    usafacts_df = fetcher("usa-facts", signal, date_range[0], date_range[1], geo_to_fetch)
     print("Fetching jhu-csse...")
-    jhu_df = fetcher("jhu-csse", signal, date_range[0], date_range[1], geo)
+    jhu_df = fetcher("jhu-csse", signal, date_range[0], date_range[1], geo_to_fetch)
 
     if check_none_data_frame(usafacts_df, "USA-FACTS", date_range) and \
-       (geo not in ('state', 'county') or \
+       (geo_to_fetch not in ('state', 'county') or \
         check_none_data_frame(jhu_df, "JHU", date_range)):
         return pd.DataFrame({}, columns=COLUMN_MAPPING.values())
 
     # State level
-    if geo == 'state':
+    if geo_to_fetch == 'state':
         combined_df = maybe_append(
             usafacts_df,
-            jhu_df if jhu_df is None else jhu_df[jhu_df["geo_value"] == 'pr'])
+            jhu_df if jhu_df is None else jhu_df[jhu_df["geo_value"] == 'pr']) # add territories
     # County level
-    elif geo == 'county':
+    elif geo_to_fetch == 'county':
         combined_df = maybe_append(
             usafacts_df,
             jhu_df if jhu_df is None else jhu_df[jhu_df["geo_value"] == '72000'])
     # For MSA and HRR level, they are the same
     else:
         combined_df = usafacts_df
+    combined_df.rename(COLUMN_MAPPING, axis=1, inplace=True)
 
-    combined_df = combined_df.rename(COLUMN_MAPPING,
-                                     axis=1)
+    if geo in ["hhs", "nation"]:
+        combined_df = GMPR.replace_geocode(combined_df,
+                                           from_col="geo_value",
+                                           from_code="fips",
+                                           new_code=geo,
+                                           date_col="timestamp")
+        combined_df.rename({geo: "geo_id"}, axis=1, inplace=True)
+
     return combined_df
 
 def extend_raw_date_range(params, sensor_name):
@@ -159,7 +170,9 @@ def run_module():
                 product(METRICS, GEO_RESOLUTIONS, SENSORS, SMOOTH_TYPES)]
     params = configure(variants)
     for metric, geo_res, sensor_name, signal in variants:
-        df = combine_usafacts_and_jhu(signal, geo_res, extend_raw_date_range(params, sensor_name)) # pylint: disable=invalid-name
+        df = combine_usafacts_and_jhu(signal,
+                                      geo_res,
+                                      extend_raw_date_range(params, sensor_name))
         df["timestamp"] = pd.to_datetime(df["timestamp"])
         start_date = pd.to_datetime(params['export_start_date'])
         export_dir = params["export_dir"]

--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -49,6 +49,8 @@ COLUMN_MAPPING = {"time_value": "timestamp",
 def combine_usafacts_and_jhu(signal, geo, date_range, fetcher=covidcast.signal):
     """Add rows for PR from JHU signals to USA-FACTS signals."""
     print("Fetching usa-facts...")
+    # for hhs and nation, fetch the county data so we can combined JHU and USAFacts before mapping
+    # to the desired geos.
     geo_to_fetch = "county" if geo in ["county", "hhs", "nation"] else geo
     usafacts_df = fetcher("usa-facts", signal, date_range[0], date_range[1], geo_to_fetch)
     print("Fetching jhu-csse...")

--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -51,7 +51,7 @@ def combine_usafacts_and_jhu(signal, geo, date_range, fetcher=covidcast.signal):
     print("Fetching usa-facts...")
     # for hhs and nation, fetch the county data so we can combined JHU and USAFacts before mapping
     # to the desired geos.
-    geo_to_fetch = "county" if geo in ["county", "hhs", "nation"] else geo
+    geo_to_fetch = "county" if geo in ["hhs", "nation"] else geo
     usafacts_df = fetcher("usa-facts", signal, date_range[0], date_range[1], geo_to_fetch)
     print("Fetching jhu-csse...")
     jhu_df = fetcher("jhu-csse", signal, date_range[0], date_range[1], geo_to_fetch)

--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -76,10 +76,14 @@ def combine_usafacts_and_jhu(signal, geo, date_range, fetcher=covidcast.signal):
 
     if geo in ["hhs", "nation"]:
         combined_df = GMPR.replace_geocode(combined_df,
-                                           from_col="geo_value",
+                                           from_col="geo_id",
                                            from_code="fips",
                                            new_code=geo,
                                            date_col="timestamp")
+        if "se" not in combined_df.columns and "sample_size" not in combined_df.columns:
+            # if a column has non numeric data including None, they'll be dropped.
+            # se and sample size are required later so we add them back.
+            combined_df["se"] = combined_df["sample_size"] = None
         combined_df.rename({geo: "geo_id"}, axis=1, inplace=True)
 
     return combined_df

--- a/combo_cases_and_deaths/tests/test_run.py
+++ b/combo_cases_and_deaths/tests/test_run.py
@@ -53,12 +53,12 @@ def test_unstable_sources():
 
     date_range = [date.today(), date.today()]
 
-    for geo in "state county msa".split():
+    for geo in ["state", "county", "msa", "nation", "hhs"]:
         for (fetcher, expected_size) in [
                 (fetcher00, 0),
                 (fetcher01, 0 if geo == "msa" else 1),
                 (fetcher10, 1),
-                (fetcher11, 1 if geo == "msa" else 2)
+                (fetcher11, 1 if geo in ["msa", "nation", "hhs"] else 2)
         ]:
             df = combine_usafacts_and_jhu("", geo, date_range, fetcher)
             assert df.size == expected_size * len(COLUMN_MAPPING), f"""


### PR DESCRIPTION
### Description
This ones a bit tricky since the signal combines usafacts and JHU. What I ended up doing was having hhs and nation process as if they were fips and then geomap them to the corresponding regions at the end. One thing to note was that the state and county values dont sum up to the same thing, not sure if thats expected due to JHU/USAFacts processing):

```
In [5]: df = pd.read_csv("receiving/20201218_county_confirmed_cumulative_num.csv")                                                                                   

In [6]: df.val.sum()                                                                                                                                                 
Out[6]: 17103973.0

In [7]: df = pd.read_csv("receiving/20201218_state_confirmed_cumulative_num.csv")                                                                                    

In [8]: df.val.sum()                                                                                                                                                 
Out[8]: 17167997
```

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add handling of hhs and nation conversion by adding having them retrieve the fips data and then geomap at the end. Update constants.

### Fixes 
- Fixes #(issue)
