### PR TITLE
Add missing quotes to token in config

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -1,6 +1,6 @@
 {
   "channel": "#sir-complains-a-lot",
-  "slack_token": {{ sir_complainsalot_slack_token }},
+  "slack_token": "{{ sir_complainsalot_slack_token }}",
   "sources": {
     "doctor-visits": {
       "max_age": 5,


### PR DESCRIPTION
### Description
Fix.

Adds missing quotes around token in params file.

### Changelog
### Fixes 

- Fixes #(issue)