### PR TITLE
SirCAL: logger -> LOGGER

### DIFF
--- a/sir_complainsalot/delphi_sir_complainsalot/run.py
+++ b/sir_complainsalot/delphi_sir_complainsalot/run.py
@@ -65,7 +65,7 @@ def report_complaints(all_complaints, params):
 
     for complaints in split_complaints(all_complaints):
         blocks = format_complaints_aggregated_by_source(complaints)
-        logger.info(f"blocks: {len(blocks)}")
+        LOGGER.info(f"blocks: {len(blocks)}")
         try:
             client.chat_postMessage(
                 channel=params["channel"],


### PR DESCRIPTION
### Description
Bug fix: `logger` should be `LOGGER`

### Changelog
- run.py