### PR TITLE
Fix usafacts params

### DIFF
--- a/ansible/templates/usafacts-params-prod.json.j2
+++ b/ansible/templates/usafacts-params-prod.json.j2
@@ -8,6 +8,6 @@
     "aws_access_key_id": "{{ delphi_aws_access_key_id }}",
     "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"
   },
-  "bucket_name": "delphi-covidcast-indicator-output"
+  "bucket_name": "delphi-covidcast-indicator-output",
   "log_filename": "/var/log/indicators/usafacts.log"
 }


### PR DESCRIPTION
### Description
Fix:

Add a missing comma that was causing the indicator run to fail.

### Changelog
- Add comma to params file.