### PR TITLE
Add groupby to USAFacts smoothing

### DIFF
--- a/usafacts/delphi_usafacts/run.py
+++ b/usafacts/delphi_usafacts/run.py
@@ -98,7 +98,9 @@ def run_module():
         df = dfs[metric]
         # Aggregate to appropriate geographic resolution
         df = geo_map(df, geo_res, sensor)
-        df["val"] = SMOOTHERS_MAP[smoother][0].smooth(df[sensor].values)
+        df["val"] = df[["geo_id", sensor]].groupby("geo_id")[sensor].transform(
+            SMOOTHERS_MAP[smoother][0].smooth
+        )
         df["se"] = np.nan
         df["sample_size"] = np.nan
         # Drop early entries where data insufficient for smoothing

--- a/usafacts/tests/test_run.py
+++ b/usafacts/tests/test_run.py
@@ -39,6 +39,8 @@ class TestRun:
         for date in dates:
             for geo in geos:
                 for metric in metrics:
+                    if "7dav" in metric and date in dates[:6]:
+                        continue  # there are no 7dav signals for first 6 days
                     expected_files += [date + "_" + geo + "_" + metric + ".csv"]
 
         assert set(csv_files) == set(expected_files)


### PR DESCRIPTION
### Description

Within each group, the smoothing should be correct since the [values are ordered by timestamp](https://github.com/cmu-delphi/covidcast-indicators/blob/2c8f5cb0da9a7b02ed498e5475e9c26e016f766c/usafacts/delphi_usafacts/pull.py#L135), and "[Groupby preserves the order of rows within each group.](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.groupby.html)"

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add groupby statement before smoothing so the smoothing is done on a per-geography basis
- Update tests to reflect the correct files that will be generated

### Fixes 
- Fixes #707 
