### PR TITLE
Changehc: get region count from GeoMapper instead of config.Constants

### DIFF
--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -528,14 +528,14 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         data = data.reset_index().groupby([date_col, mega_col]).sum()
         return data.reset_index()
 
-    def as_mapper_name(self, geo_type):
+    def as_mapper_name(self, geo_type, state="state_id"):
         """
         Return the mapper equivalent of a region type.
 
         Human-readable names like 'county' will return their mapper equivalents ('fips').
         """
         if geo_type == "state":
-            return "state_code"
+            return state
         if geo_type == "county":
             return "fips"
         return geo_type

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -528,6 +528,17 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         data = data.reset_index().groupby([date_col, mega_col]).sum()
         return data.reset_index()
 
+    def as_mapper_name(self, geo_type):
+        """
+        Return the mapper equivalent of a region type.
+
+        Human-readable names like 'county' will return their mapper equivalents ('fips').
+        """
+        if geo_type == "state":
+            return "state_code"
+        if geo_type == "county":
+            return "fips"
+        return geo_type
     def get_geo_values(self, geo_type):
         """
         Return a set of all values for a given geography type.

--- a/changehc/delphi_changehc/config.py
+++ b/changehc/delphi_changehc/config.py
@@ -54,26 +54,3 @@ class Config:
         7  # maximum number of days used to average a backfill correction
     )
     MIN_CUM_VISITS = 500  # need to observe at least 500 counts before averaging
-
-
-class Constants:
-    """
-    Contains the maximum number of geo units for each geo type.
-
-    Used for sanity checks
-    """
-
-    # number of counties in usa, including megacounties
-    NUM_COUNTIES = 3141 + 52
-    NUM_HRRS = 308
-    NUM_MSAS = 392 + 52  # MSA + States
-    NUM_STATES = 52  # including DC and PR
-    NUM_NATIONS = 1
-    NUM_HHSS = 10
-
-    MAX_GEO = {"county": NUM_COUNTIES,
-               "hrr": NUM_HRRS,
-               "msa": NUM_MSAS,
-               "state": NUM_STATES,
-               "nation": NUM_NATIONS,
-               "hhs": NUM_HHSS}

--- a/changehc/delphi_changehc/update_sensor.py
+++ b/changehc/delphi_changehc/update_sensor.py
@@ -14,7 +14,7 @@ import pandas as pd
 from delphi_utils import GeoMapper, read_params, add_prefix
 
 # first party
-from .config import Config, Constants
+from .config import Config
 from .constants import SMOOTHED, SMOOTHED_ADJ, SMOOTHED_CLI, SMOOTHED_ADJ_CLI, NA
 from .sensor import CHCSensor
 from .weekday import Weekday
@@ -164,7 +164,7 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
         # for each location, fill in all missing dates with 0 values
         multiindex = pd.MultiIndex.from_product((unique_geo_ids, self.fit_dates),
                                                 names=[geo, Config.DATE_COL])
-        assert (len(multiindex) <= (Constants.MAX_GEO[geo] * len(self.fit_dates))
+        assert (len(multiindex) <= (len(gmpr.get_geo_values(gmpr.as_mapper_name(geo))) * len(self.fit_dates))
                 ), "more loc-date pairs than maximum number of geographies x number of dates"
         # fill dataframe with missing dates using 0
         data_frame = data_frame.reindex(multiindex, fill_value=0)

--- a/changehc/tests/test_load_data.py
+++ b/changehc/tests/test_load_data.py
@@ -2,15 +2,14 @@
 import pytest
 
 # third party
-from delphi_utils import read_params
+from delphi_utils import read_params, GeoMapper
 import pandas as pd
 
 # first party
-from delphi_changehc.config import Config, Constants
+from delphi_changehc.config import Config
 from delphi_changehc.load_data import *
 
 CONFIG = Config()
-CONSTANTS = Constants()
 PARAMS = read_params()
 COVID_FILEPATH = PARAMS["input_covid_file"]
 DENOM_FILEPATH = PARAMS["input_denom_file"]
@@ -24,6 +23,7 @@ class TestLoadData:
                     Config.COVID_COLS, Config.COVID_DTYPES, Config.COVID_COL)
     combined_data = load_combined_data(DENOM_FILEPATH, COVID_FILEPATH, DROP_DATE,
                                             "fips")
+    gmpr = GeoMapper()
 
     def test_base_unit(self):
         with pytest.raises(AssertionError):
@@ -78,7 +78,7 @@ class TestLoadData:
                      self.combined_data]:
             assert (
                     len(data.index.get_level_values(
-                        'fips').unique()) <= CONSTANTS.NUM_COUNTIES
+                        'fips').unique()) <= len(self.gmpr.get_geo_values("fips"))
             )
 
     def test_combined_fips_values(self):

--- a/changehc/tests/test_update_sensor.py
+++ b/changehc/tests/test_update_sensor.py
@@ -15,11 +15,10 @@ import pytest
 from delphi_utils import read_params
 
 # first party
-from delphi_changehc.config import Config, Constants
+from delphi_changehc.config import Config
 from delphi_changehc.update_sensor import write_to_csv, CHCSensorUpdator
 
 CONFIG = Config()
-CONSTANTS = Constants()
 PARAMS = read_params()
 COVID_FILEPATH = PARAMS["input_covid_file"]
 DENOM_FILEPATH = PARAMS["input_denom_file"]


### PR DESCRIPTION
### Description
Make changehc use GeoMapper to get the region count instead of using a hardcoded value.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Let GeoMapper help with converting "state" and "county" to mappable region types
- Use GeoMapper for region counts
- Fix tests

### Fixes 
- Fixes #721
