### PR TITLE
Allow finer-grained validation suppression

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -55,7 +55,7 @@ Please update the follow settings:
    * `data_source`: should match the [formatting](https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html) as used in COVIDcast API calls
    * `end_date`: specifies the last date to be checked; if set to "latest", `end_date` will always be the current date
    * `span_length`: specifies the number of days before the `end_date` to check. `span_length` should be long enough to contain all recent source data that is still in the process of being updated (i.e. in the backfill period), for example, if the data source of interest has a 2-week lag before all reports are in for a given date, `scan_length` should be 14 days
-   * `suppressed_errors`: list of objects specifying errors that have been manually verified as false positives or acceptable deviations from expected.  These errors can be specified with the following variables, where omitted values are interpretted as a wildcard, i.e., not specifying a date applies to all dates:
+   * `suppressed_errors`: list of objects specifying errors that have been manually verified as false positives or acceptable deviations from expected.  These errors can be specified with the following variables, where omitted values are interpreted as a wildcard, i.e., not specifying a date applies to all dates:
        * `check_name` (required):  name of the check, as specified in the validation output
        * `date`:  date in `YYYY-MM-DD` format
        * `geo_type`:  geo resolution of the data

--- a/validator/README.md
+++ b/validator/README.md
@@ -55,7 +55,11 @@ Please update the follow settings:
    * `data_source`: should match the [formatting](https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html) as used in COVIDcast API calls
    * `end_date`: specifies the last date to be checked; if set to "latest", `end_date` will always be the current date
    * `span_length`: specifies the number of days before the `end_date` to check. `span_length` should be long enough to contain all recent source data that is still in the process of being updated (i.e. in the backfill period), for example, if the data source of interest has a 2-week lag before all reports are in for a given date, `scan_length` should be 14 days
-   * `suppressed_errors`: list of pairs of (`check_name`, `file_name`) uniquely specifying errors that have been manually verified as false positives or acceptable deviations from expected.  Either value can also take on the value `*` to apply to all check or file names.
+   * `suppressed_errors`: list of objects specifying errors that have been manually verified as false positives or acceptable deviations from expected.  These errors can be specified with the following variables, where omitted values are interpretted as a wildcard, i.e., not specifying a date applies to all dates:
+       * `check_name` (required):  name of the check, as specified in the validation output
+       * `date`:  date in `YYYY-MM-DD` format
+       * `geo_type`:  geo resolution of the data
+       * `signal`:  name of COVIDcast API signal
    * `test_mode`: boolean; `true` checks only a small number of data files
 * `static`: settings for validations that don't require comparison with external COVIDcast API data
    * `minimum_sample_size` (default: 100): threshold for flagging small sample sizes as invalid

--- a/validator/delphi_validator/datafetcher.py
+++ b/validator/delphi_validator/datafetcher.py
@@ -173,8 +173,9 @@ def get_one_api_df(data_source, min_date, max_date,
 
     except APIDataFetchError as e:
         geo_sig_api_df_or_error = ValidationFailure("api_data_fetch_error",
-                                                    f"{geo_type} {signal_type}",
-                                                    e.custom_msg)
+                                                    geo_type=geo_type,
+                                                    signal=signal_type,
+                                                    message=e.custom_msg)
 
     api_semaphore.release()
 

--- a/validator/delphi_validator/dynamic.py
+++ b/validator/delphi_validator/dynamic.py
@@ -102,7 +102,7 @@ class DynamicValidator:
                                                           geo_type=geo_type,
                                                           signal=signal_type,
                                                           message="file with geo_type-signal combo "
-                                                            "does not exist"))
+                                                                  "does not exist"))
                 continue
 
             max_date = geo_sig_df["time_value"].max()

--- a/validator/delphi_validator/dynamic.py
+++ b/validator/delphi_validator/dynamic.py
@@ -98,10 +98,11 @@ class DynamicValidator:
             report.increment_total_checks()
 
             if geo_sig_df.empty:
-                report.add_raised_error(ValidationFailure("check_missing_geo_sig_combo",
-                                                          f"{geo_type} {signal_type}",
-                                                          "file with geo_type-signal combo does "
-                                                          "not exist"))
+                report.add_raised_error(ValidationFailure(check_name="check_missing_geo_sig_combo",
+                                                          geo_type=geo_type,
+                                                          signal=signal_type,
+                                                          message="file with geo_type-signal combo "
+                                                            "does not exist"))
                 continue
 
             max_date = geo_sig_df["time_value"].max()
@@ -152,7 +153,9 @@ class DynamicValidator:
                 if recent_df.empty:
                     report.add_raised_error(
                         ValidationFailure("check_missing_geo_sig_date_combo",
-                                          f"{checking_date} {geo_type} {signal_type}",
+                                          checking_date,
+                                          geo_type,
+                                          signal_type,
                                           "test data for a given checking date-geo type-signal type"
                                           " combination is missing. Source data may be missing"
                                           " for one or more dates"))
@@ -178,7 +181,9 @@ class DynamicValidator:
                 if reference_api_df.empty:
                     report.add_raised_error(
                         ValidationFailure("empty_reference_data",
-                                          f"{checking_date} {geo_type} {signal_type}",
+                                          checking_date,
+                                          geo_type,
+                                          signal_type,
                                           "reference data is empty; comparative checks could not "
                                           "be performed"))
                     continue
@@ -217,8 +222,9 @@ class DynamicValidator:
         if max_date < self.params.generation_date - thres:
             report.add_raised_error(
                 ValidationFailure("check_min_max_date",
-                                  f"{geo_type} {signal_type}",
-                                  "date of most recent generated file seems too long ago"))
+                                  geo_type=geo_type,
+                                  signal=signal_type,
+                                  message="date of most recent generated file seems too long ago"))
 
         report.increment_total_checks()
 
@@ -238,8 +244,9 @@ class DynamicValidator:
         if max_date > self.params.generation_date:
             report.add_raised_error(
                 ValidationFailure("check_max_max_date",
-                                  f"{geo_type} {signal_type}",
-                                  "date of most recent generated file seems too recent"))
+                                  geo_type=geo_type,
+                                  signal=signal_type,
+                                  message="date of most recent generated file seems too recent"))
 
         report.increment_total_checks()
 
@@ -263,7 +270,9 @@ class DynamicValidator:
         if df_to_test["time_value"].max() < df_to_reference["time_value"].max():
             report.add_raised_error(
                 ValidationFailure("check_max_date_vs_reference",
-                                  f"{checking_date.date()} {geo_type} {signal_type}",
+                                  checking_date,
+                                  geo_type,
+                                  signal_type,
                                   "reference df has days beyond the max date in the =df_to_test="))
 
         report.increment_total_checks()
@@ -301,7 +310,9 @@ class DynamicValidator:
         if abs(compare_rows) > 0.35:
             report.add_raised_error(
                 ValidationFailure("check_rapid_change_num_rows",
-                                  f"{checking_date} {geo_type} {signal_type}",
+                                  checking_date,
+                                  geo_type,
+                                  signal_type,
                                   "Number of rows per day seems to have changed rapidly (reference "
                                   "vs test data)"))
 
@@ -431,7 +442,9 @@ class DynamicValidator:
             report.raised_errors.append(
                 ValidationFailure(
                     "check_positive_negative_spikes",
-                    f"{source_frame_start} {source_frame_end} {geo} {sig}",
+                    source_frame_end,
+                    geo,
+                    sig,
                     "Source dates with flagged ouliers based on the previous 14 days of data "
                     "available"))
 
@@ -535,7 +548,9 @@ class DynamicValidator:
             report.add_raised_error(
                 ValidationFailure(
                     "check_test_vs_reference_avg_changed",
-                    f"{checking_date} {geo_type} {signal_type}",
+                    checking_date,
+                    geo_type,
+                    signal_type,
                     'Average differences in variables by geo_id between recent & reference data '
                     + 'seem large --- either large increase '
                     + 'tending toward one direction or large mean absolute difference, relative '

--- a/validator/delphi_validator/errors.py
+++ b/validator/delphi_validator/errors.py
@@ -2,7 +2,9 @@
 """
 Custom validator exceptions.
 """
-from dataclasses import dataclass
+# from dataclasses import dataclass
+import datetime as dt
+from typing import Optional
 
 class APIDataFetchError(Exception):
     """Exception raised when reading API data goes wrong.
@@ -18,31 +20,60 @@ class APIDataFetchError(Exception):
     def __str__(self):
         return '{}'.format(self.custom_msg)
 
-@dataclass
 class ValidationFailure:
     """Structured report of single validation failure."""
-    # Which check the failure came from
+    def __init__(self,
+                 check_name: str,
+                 date: Optional[dt.date]=None,
+                 geo_type: Optional[str]=None,
+                 signal: Optional[str]=None,
+                 message: str="",
+                 filename: Optional[str]=None):
+        """
+            # Which check the failure came from
     check_name: str
-    # Data source of the failure
-    data_name: str
+    # Date of the failure
+    date: Optional[dt.date]
+    # Geo resolution of the failure
+    geo_type: Optional[str]
+    # Signal name of the failure
+    signal: Optional[str]
     # Additional context about the failure
-    message: str
+    message: str."""
+        self.check_name = check_name
+        self.message = message
+        if filename:
+            pieces = filename.split(".")[0].split("_", maxsplit=2)
+            assert len(pieces) == 3
+            date = dt.datetime.strptime(pieces[0], "%Y%m%d").date()
+            geo_type = pieces[1]
+            signal = pieces[2]
+        if isinstance(date, str):
+            date = dt.date.fromisoformat(date)
+        self.date = date
+        self.geo_type = geo_type
+        self.signal = signal
+
+    def __eq__(self, other):
+        def match_with_wildcard(x, y):
+            """Determine if x and y are equal or None."""
+            return x is None or y is None or x == y
+        return match_with_wildcard(self.check_name, other.check_name) and\
+            match_with_wildcard(self.date, other.date) and\
+            match_with_wildcard(self.geo_type, other.geo_type) and\
+            match_with_wildcard(self.signal, other.signal)
 
     def is_suppressed(self, suppressed_errors):
         """Determine whether the failure should be suppressed.
 
         Parameters
         ----------
-        errors_to_suppress: Set[Tuple[str]]
-            set of (check_name, data_name) tuples to ignore.
+        errors_to_suppress: List[ValidationFailure]
+            set of data sources to ignore.
         """
-        if (self.check_name, self.data_name) in suppressed_errors:
-            return True
-        if (self.check_name, "*") in suppressed_errors:
-            return True
-        if ("*", self.data_name) in suppressed_errors:
-            return True
-        return False
+        return self in suppressed_errors
 
     def __str__(self):
-        return f"{self.check_name} failed for {self.data_name}: {self.message}"
+        date_str = "*" if self.date is None else self.date.isoformat()
+        return f"{self.check_name} failed for {self.signal} at resolution {self.geo_type} on "\
+               f"{date_str}: {self.message}"

--- a/validator/delphi_validator/errors.py
+++ b/validator/delphi_validator/errors.py
@@ -82,7 +82,7 @@ class ValidationFailure:
 
     def __eq__(self, other):
         """Compare this object with ValidationFailure `other` for equality.
-        
+
         Two ValidationFailures are considered equal if their `check_name`, `date`, `geo_type`, and
         `signal` attributes correspondingly match.  A value of `None` in any of these attributes is
         considered to match any corresponding value on the other ValidationFailure.

--- a/validator/delphi_validator/errors.py
+++ b/validator/delphi_validator/errors.py
@@ -4,7 +4,7 @@ Custom validator exceptions.
 """
 # from dataclasses import dataclass
 import datetime as dt
-from typing import Optional
+from typing import Union, Optional
 
 class APIDataFetchError(Exception):
     """Exception raised when reading API data goes wrong.
@@ -24,22 +24,48 @@ class ValidationFailure:
     """Structured report of single validation failure."""
     def __init__(self,
                  check_name: str,
-                 date: Optional[dt.date]=None,
+                 date: Optional[Union[str, dt.date]]=None,
                  geo_type: Optional[str]=None,
                  signal: Optional[str]=None,
                  message: str="",
                  filename: Optional[str]=None):
+        """Initialize a ValidationFailure.
+        Parameters
+        ----------
+        check_name: str
+            Name of check at which the failure happened.
+        date: Optional[Union[str, dt.date]]
+            Date corresponding to the data over which the failure happened.
+            Strings are interpretted in ISO format ("YYYY-MM-DD").
+            When `None`, the failure is not tied to any date.
+        geo_type: Optional[str]
+            Geo resolution of the data at which the failure occurred.
+            When `None`, the failure is not tied to any geo resolution.
+        signal: Optional[str]
+            COVIDcast signal for which the failure occurred.
+            When `None`, the failure is not tied to any signal.
+        message: str
+            Additional context about the failure
+        filename: Optional[str]
+            Filename from which the failing data came.
+            When provided, any values passed to the `date`, `geo_type`, and `signal` parameters are
+            ignored and instead derived from this parameter, under the assumption that the filename
+            is formatted as "{date}_{geo_type}_{signal}.{extension}", where `date` is in the format
+            "YYYYMMDD".
+
+        Attributes
+        ----------
+        check_name: str
+            See above.
+        date: Optional[dt.date]
+            See above.
+        geo_type: Optional[str]
+            See above.
+        signal: Optional[str]
+            See above.
+        message: str
+            See above.
         """
-            # Which check the failure came from
-    check_name: str
-    # Date of the failure
-    date: Optional[dt.date]
-    # Geo resolution of the failure
-    geo_type: Optional[str]
-    # Signal name of the failure
-    signal: Optional[str]
-    # Additional context about the failure
-    message: str."""
         self.check_name = check_name
         self.message = message
         if filename:
@@ -55,6 +81,12 @@ class ValidationFailure:
         self.signal = signal
 
     def __eq__(self, other):
+        """Compare this object with ValidationFailure `other` for equality.
+        
+        Two ValidationFailures are considered equal if their `check_name`, `date`, `geo_type`, and
+        `signal` attributes correspondingly match.  A value of `None` in any of these attributes is
+        considered to match any corresponding value on the other ValidationFailure.
+        """
         def match_with_wildcard(x, y):
             """Determine if x and y are equal or None."""
             return x is None or y is None or x == y

--- a/validator/delphi_validator/errors.py
+++ b/validator/delphi_validator/errors.py
@@ -2,7 +2,6 @@
 """
 Custom validator exceptions.
 """
-# from dataclasses import dataclass
 import datetime as dt
 from typing import Union, Optional
 

--- a/validator/delphi_validator/errors.py
+++ b/validator/delphi_validator/errors.py
@@ -70,8 +70,12 @@ class ValidationFailure:
         self.message = message
         if filename:
             pieces = filename.split(".")[0].split("_", maxsplit=2)
-            assert len(pieces) == 3
-            date = dt.datetime.strptime(pieces[0], "%Y%m%d").date()
+            assert len(pieces) == 3, '`filename` argument expected to be in "{date}_{geo_type}_'\
+                                     '{signal}.{extension}" format'
+            try:
+                date = dt.datetime.strptime(pieces[0], "%Y%m%d").date()
+            except ValueError as e:
+                raise ValueError('date in `filename` must be in "YYYYMMDD" format') from e
             geo_type = pieces[1]
             signal = pieces[2]
         if isinstance(date, str):
@@ -102,6 +106,8 @@ class ValidationFailure:
         ----------
         errors_to_suppress: List[ValidationFailure]
             set of data sources to ignore.
+            Because we allow `None` values as wildcards, we cannot assume errors that are equal 
+            will hash to the same values.  Thus, we need to use a list rather than a set here.
         """
         return self in suppressed_errors
 

--- a/validator/delphi_validator/report.py
+++ b/validator/delphi_validator/report.py
@@ -1,22 +1,23 @@
 """Validation output reports."""
 import sys
-from typing import Set, Tuple
+from typing import List
 from delphi_utils.logger import get_structured_logger
+from delphi_validator.errors import ValidationFailure
 
 logger = get_structured_logger(__name__)
 
 class ValidationReport:
     """Class for reporting the results of validation."""
-    def __init__(self, errors_to_suppress: Set[Tuple[str]]):
+    def __init__(self, errors_to_suppress: List[ValidationFailure]):
         """Initialize a ValidationReport.
         Parameters
         ----------
-        errors_to_suppress: Set[Tuple[str]]
-            set of (check_name, data_name) tuples to ignore.
+        errors_to_suppress: List[ValidationFailure]
+            List of ValidationFailures to ignore.
 
         Attributes
         ----------
-        errors_to_suppress: Set[Tuple[str]]
+        errors_to_suppress: List[ValidationFailure]
             See above
         num_suppressed: int
             Number of errors suppressed
@@ -29,7 +30,7 @@ class ValidationReport:
         unsuppressed_errors: List[Exception]
             Errors raised from validation failures not found in `self.errors_to_suppress`
         """
-        self.errors_to_suppress = errors_to_suppress.copy()
+        self.errors_to_suppress = errors_to_suppress
         self.num_suppressed = 0
         self.total_checks = 0
         self.raised_errors = []

--- a/validator/delphi_validator/static.py
+++ b/validator/delphi_validator/static.py
@@ -164,7 +164,7 @@ class StaticValidator:
                     "check_geo_id_lowercase",
                     filename=filename,
                     message=f"geo_ids {upper_case_geos} contains uppercase characters. Lowercase "
-                    "is preferred."))
+                            "is preferred."))
         report.increment_total_checks()
 
     def check_bad_geo_id_format(self, df_to_test, nameformat, geo_type, report):
@@ -315,7 +315,7 @@ class StaticValidator:
                 report.add_raised_error(
                     ValidationFailure("check_se_missing_or_in_range",
                                       filename=nameformat,
-                                     message="se must be NA or in (0, min(50,val*(1+eps))]"))
+                                      message="se must be NA or in (0, min(50,val*(1+eps))]"))
 
             report.increment_total_checks()
         else:
@@ -336,7 +336,7 @@ class StaticValidator:
                 report.add_raised_error(
                     ValidationFailure("check_se_many_missing",
                                       filename=nameformat,
-                                     message='Recent se values are >50% NA'))
+                                      message='Recent se values are >50% NA'))
 
             report.increment_total_checks()
 
@@ -384,7 +384,7 @@ class StaticValidator:
                     ValidationFailure("check_n_missing_or_gt_min",
                                       filename=nameformat,
                                       message="sample size must be NA or >= "
-                                      f"{self.params.minimum_sample_size}"))
+                                              f"{self.params.minimum_sample_size}"))
 
             report.increment_total_checks()
 

--- a/validator/delphi_validator/static.py
+++ b/validator/delphi_validator/static.py
@@ -96,11 +96,10 @@ class StaticValidator:
         check_dateholes.sort()
 
         if check_dateholes:
-            report.add_raised_error(ValidationFailure("check_missing_date_files",
-                                                      str(check_dateholes),
-                                                      "Missing dates are observed; if these dates "
-                                                      "are already in the API they would not be "
-                                                      "updated"))
+            report.add_raised_error(
+                ValidationFailure("check_missing_date_files",
+                                  message="Missing dates are observed; if these dates are already "
+                                          "in the API they would not be updated"))
 
         report.increment_total_checks()
 
@@ -119,17 +118,19 @@ class StaticValidator:
         """
         pattern_found = FILENAME_REGEX.match(nameformat)
         if not nameformat or not pattern_found:
-            report.add_raised_error(ValidationFailure("check_filename_format",
-                                                      nameformat,
-                                                      "nameformat not recognized"))
+            report.add_raised_error(
+                ValidationFailure("check_filename_format",
+                                  filename=nameformat,
+                                  message="nameformat not recognized"))
 
         report.increment_total_checks()
 
         if not isinstance(df_to_test, pd.DataFrame):
             report.add_raised_error(
-                ValidationFailure("check_file_data_format",
-                                  nameformat,
-                                  f"expected pd.DataFrame but got {type(df_to_test)}."))
+                ValidationFailure(
+                    "check_file_data_format",
+                    filename=nameformat,
+                    message=f"expected pd.DataFrame but got {type(df_to_test)}."))
 
         report.increment_total_checks()
 
@@ -149,19 +150,21 @@ class StaticValidator:
         unexpected_geos = [geo for geo in df_to_test['geo_id']
                            if geo.lower() not in valid_geos]
         if len(unexpected_geos) > 0:
-            report.add_raised_error(ValidationFailure("check_bad_geo_id_value",
-                                                      filename,
-                                                      "Unrecognized geo_ids (not in historical "
-                                                      f"data) {unexpected_geos}"))
+            report.add_raised_error(
+                ValidationFailure(
+                    "check_bad_geo_id_value",
+                    filename=filename,
+                    message=f"Unrecognized geo_ids (not in historical data) {unexpected_geos}"))
         report.increment_total_checks()
         upper_case_geos = [
             geo for geo in df_to_test['geo_id'] if geo.lower() != geo]
         if len(upper_case_geos) > 0:
-            report.add_raised_warning(ValidationFailure("check_geo_id_lowercase",
-                                                        filename,
-                                                        f"geo_ids {upper_case_geos} contains "
-                                                        "uppercase characters. Lowercase is "
-                                                        "preferred."))
+            report.add_raised_warning(
+                ValidationFailure(
+                    "check_geo_id_lowercase",
+                    filename=filename,
+                    message=f"geo_ids {upper_case_geos} contains uppercase characters. Lowercase "
+                    "is preferred."))
         report.increment_total_checks()
 
     def check_bad_geo_id_format(self, df_to_test, nameformat, geo_type, report):
@@ -196,9 +199,10 @@ class StaticValidator:
                                             for geo in df_to_test["geo_id"].str.split(".")]
 
                     report.add_raised_warning(
-                        ValidationFailure("check_geo_id_type",
-                                          nameformat,
-                                          "geo_ids saved as floats; strings preferred"))
+                        ValidationFailure(
+                            "check_geo_id_type",
+                            filename=nameformat,
+                            message="geo_ids saved as floats; strings preferred"))
 
             if geo_type in fill_len.keys():
                 # Left-pad with zeroes up to expected length. Fixes missing leading zeroes
@@ -214,18 +218,20 @@ class StaticValidator:
 
             if len(unexpected_geos) > 0:
                 report.add_raised_error(
-                    ValidationFailure("check_geo_id_format",
-                                      nameformat,
-                                      f"Non-conforming geo_ids {unexpected_geos} found"))
+                    ValidationFailure(
+                        "check_geo_id_format",
+                        filename=nameformat,
+                        message=f"Non-conforming geo_ids {unexpected_geos} found"))
 
         if geo_type in GEO_REGEX_DICT:
             find_all_unexpected_geo_ids(
                 df_to_test, GEO_REGEX_DICT[geo_type], geo_type)
         else:
             report.add_raised_error(
-                ValidationFailure("check_geo_type",
-                                  nameformat,
-                                  f"Unrecognized geo type {geo_type}"))
+                ValidationFailure(
+                    "check_geo_type",
+                    filename=nameformat,
+                    message=f"Unrecognized geo type {geo_type}"))
 
         report.increment_total_checks()
 
@@ -248,10 +254,10 @@ class StaticValidator:
         if percent_option:
             if not df_to_test[(df_to_test['val'] > 100)].empty:
                 report.add_raised_error(
-                    ValidationFailure("check_val_pct_gt_100",
-                                      nameformat,
-                                      "val column can't have any cell greater than 100 for "
-                                      "percents"))
+                    ValidationFailure(
+                        "check_val_pct_gt_100",
+                        filename=nameformat,
+                        message="val column can't have any cell greater than 100 for percents"))
 
             report.increment_total_checks()
 
@@ -259,25 +265,25 @@ class StaticValidator:
             if not df_to_test[(df_to_test['val'] > 100000)].empty:
                 report.add_raised_error(
                     ValidationFailure("check_val_prop_gt_100k",
-                                      nameformat,
-                                      "val column can't have any cell greater than 100000 for "
-                                      "proportions"))
+                                      filename=nameformat,
+                                      message="val column can't have any cell greater than 100000 "
+                                              "for proportions"))
 
             report.increment_total_checks()
 
         if df_to_test['val'].isnull().values.any():
             report.add_raised_error(
                 ValidationFailure("check_val_missing",
-                                  nameformat,
-                                  "val column can't have any cell that is NA"))
+                                  filename=nameformat,
+                                  message="val column can't have any cell that is NA"))
 
         report.increment_total_checks()
 
         if not df_to_test[(df_to_test['val'] < 0)].empty:
             report.add_raised_error(
                 ValidationFailure("check_val_lt_0",
-                                  nameformat,
-                                  "val column can't have any cell smaller than 0"))
+                                  filename=nameformat,
+                                  message="val column can't have any cell smaller than 0"))
 
         report.increment_total_checks()
 
@@ -308,8 +314,8 @@ class StaticValidator:
             if not result.empty:
                 report.add_raised_error(
                     ValidationFailure("check_se_missing_or_in_range",
-                                      nameformat,
-                                     "se must be NA or in (0, min(50,val*(1+eps))]"))
+                                      filename=nameformat,
+                                     message="se must be NA or in (0, min(50,val*(1+eps))]"))
 
             report.increment_total_checks()
         else:
@@ -320,16 +326,17 @@ class StaticValidator:
             if not result.empty:
                 report.add_raised_error(
                     ValidationFailure("check_se_not_missing_and_in_range",
-                                      nameformat,
-                                      "se must be in (0, min(50,val*(1+eps))] and not missing"))
+                                      filename=nameformat,
+                                      message="se must be in (0, min(50,val*(1+eps))] and not "
+                                              "missing"))
 
             report.increment_total_checks()
 
             if df_to_test["se"].isnull().mean() > 0.5:
                 report.add_raised_error(
                     ValidationFailure("check_se_many_missing",
-                                      nameformat,
-                                     'Recent se values are >50% NA'))
+                                      filename=nameformat,
+                                     message='Recent se values are >50% NA'))
 
             report.increment_total_checks()
 
@@ -339,14 +346,16 @@ class StaticValidator:
         if not result_jeffreys.empty:
             report.add_raised_error(
                 ValidationFailure("check_se_0_when_val_0",
-                                  nameformat,
-                                  "when signal value is 0, se must be non-zero. please "
+                                  filename=nameformat,
+                                  message="when signal value is 0, se must be non-zero. please "
                                   + "use Jeffreys correction to generate an appropriate se"
                                   + " (see wikipedia.org/wiki/Binomial_proportion_confidence"
                                   + "_interval#Jeffreys_interval for details)"))
         elif not result_alt.empty:
             report.add_raised_error(
-                ValidationFailure("check_se_0", nameformat, "se must be non-zero"))
+                ValidationFailure("check_se_0",
+                                  filename=nameformat,
+                                  message="se must be non-zero"))
 
         report.increment_total_checks()
 
@@ -373,8 +382,8 @@ class StaticValidator:
             if not result.empty:
                 report.add_raised_error(
                     ValidationFailure("check_n_missing_or_gt_min",
-                                      nameformat,
-                                      "sample size must be NA or >= "
+                                      filename=nameformat,
+                                      message="sample size must be NA or >= "
                                       f"{self.params.minimum_sample_size}"))
 
             report.increment_total_checks()
@@ -383,8 +392,8 @@ class StaticValidator:
             if df_to_test['sample_size'].isnull().values.any():
                 report.add_raised_error(
                     ValidationFailure("check_n_missing",
-                                      nameformat,
-                                      "sample_size must not be NA"))
+                                      filename=nameformat,
+                                      message="sample_size must not be NA"))
 
             report.increment_total_checks()
 
@@ -395,8 +404,9 @@ class StaticValidator:
             if not result.empty:
                 report.add_raised_error(
                     ValidationFailure("check_n_gt_min",
-                                      nameformat,
-                                      f"sample size must be >= {self.params.minimum_sample_size}"))
+                                      filename=nameformat,
+                                      message="sample size must be >= "
+                                              f"{self.params.minimum_sample_size}"))
 
             report.increment_total_checks()
 
@@ -417,7 +427,7 @@ class StaticValidator:
         if any(is_duplicate):
             report.add_raised_warning(
                 ValidationFailure("check_duplicate_rows",
-                                  filename,
-                                  "Some rows are duplicated, which may indicate data integrity "
-                                  "issues"))
+                                  filename=filename,
+                                  message="Some rows are duplicated, which may indicate data "
+                                          "integrity issues"))
         report.increment_total_checks()

--- a/validator/delphi_validator/validate.py
+++ b/validator/delphi_validator/validate.py
@@ -4,11 +4,12 @@ Tools to validate CSV source data, including various check methods.
 """
 from .datafetcher import load_all_files
 from .dynamic import DynamicValidator
+from .errors import ValidationFailure
 from .report import ValidationReport
 from .static import StaticValidator
 from .utils import aggregate_frames, TimeWindow
 
-class Validator():
+class Validator:
     """ Class containing validation() function and supporting functions. Stores a list
     of all raised errors, and user settings. """
 
@@ -22,9 +23,12 @@ class Validator():
         suppressed_errors =  params["global"].get('suppressed_errors', [])
         for entry in suppressed_errors:
             assert isinstance(entry, list)
-            assert len(entry) == 2
+            assert len(entry) == 4
 
-        self.suppressed_errors = {tuple(item) for item in suppressed_errors}
+        self.suppressed_errors = [ValidationFailure(check_name=item[0],
+                                                    date=item[1],
+                                                    geo_type=item[2],
+                                                    signal=item[3]) for item in suppressed_errors]
 
         # Date/time settings
         self.time_window = TimeWindow.from_params(params["global"]["end_date"],

--- a/validator/delphi_validator/validate.py
+++ b/validator/delphi_validator/validate.py
@@ -22,13 +22,10 @@ class Validator:
         """
         suppressed_errors =  params["global"].get('suppressed_errors', [])
         for entry in suppressed_errors:
-            assert isinstance(entry, list)
-            assert len(entry) == 4
+            assert isinstance(entry, dict)
+            assert set(entry.keys()).issubset(["check_name", "date", "geo_type", "signal"])
 
-        self.suppressed_errors = [ValidationFailure(check_name=item[0],
-                                                    date=item[1],
-                                                    geo_type=item[2],
-                                                    signal=item[3]) for item in suppressed_errors]
+        self.suppressed_errors = [ValidationFailure(**entry) for entry in suppressed_errors]
 
         # Date/time settings
         self.time_window = TimeWindow.from_params(params["global"]["end_date"],

--- a/validator/delphi_validator/validate.py
+++ b/validator/delphi_validator/validate.py
@@ -22,8 +22,9 @@ class Validator:
         """
         suppressed_errors =  params["global"].get('suppressed_errors', [])
         for entry in suppressed_errors:
-            assert isinstance(entry, dict)
-            assert set(entry.keys()).issubset(["check_name", "date", "geo_type", "signal"])
+            assert isinstance(entry, dict), "suppressed_errors must be a list of objects"
+            assert set(entry.keys()).issubset(["check_name", "date", "geo_type", "signal"]),\
+                'suppressed_errors may only have fields "check_name", "date", "geo_type", "signal"'
 
         self.suppressed_errors = [ValidationFailure(**entry) for entry in suppressed_errors]
 

--- a/validator/params.json.template
+++ b/validator/params.json.template
@@ -5,8 +5,13 @@
       "end_date": "2020-09-08",
       "span_length": 3,
       "suppressed_errors": [
-        ["check_min_max_date", "county", "confirmed_7dav_cumulative_prop"],
-        ["check_val_lt_0", "20200906_county_deaths_7dav_incidence_num.csv"]],
+        {"check_name": "check_min_max_date",
+         "geo_type": "county",
+         "signal": "confirmed_7dav_cumulative_prop"},
+        {"check_name": "check_val_lt_0",
+         "date": "2020-09-06",
+         "geo_type": "county",
+         "signal": "deaths_7dav_incidence_num.csv"}],
       "test_mode": true
     },
     "static": {

--- a/validator/params.json.template
+++ b/validator/params.json.template
@@ -11,7 +11,7 @@
         {"check_name": "check_val_lt_0",
          "date": "2020-09-06",
          "geo_type": "county",
-         "signal": "deaths_7dav_incidence_num.csv"}],
+         "signal": "deaths_7dav_incidence_num"}],
       "test_mode": true
     },
     "static": {

--- a/validator/tests/test_datafetcher.py
+++ b/validator/tests/test_datafetcher.py
@@ -87,8 +87,10 @@ class TestDataFetcher:
             ("county", "a"): processed_signal_data_1,
             ("county", "b"): processed_signal_data_2,
             ("state", "a"): processed_signal_data_1,
-            ("state", "b"): ValidationFailure("api_data_fetch_error", "state b",
-                                             "Error fetching data from 2020-03-10 "
+            ("state", "b"): ValidationFailure("api_data_fetch_error",
+                                              geo_type="state",
+                                              signal="b",
+                                             message="Error fetching data from 2020-03-10 "
                                              "to 2020-06-10 for data source: "
                                              "source, signal type: b, geo type: state")
         }

--- a/validator/tests/test_dynamic.py
+++ b/validator/tests/test_dynamic.py
@@ -17,7 +17,7 @@ class TestCheckRapidChange:
 
     def test_same_df(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         test_df = pd.DataFrame([date.today()] * 5, columns=["time_value"])
         ref_df = pd.DataFrame([date.today()] * 5, columns=["time_value"])
         validator.check_rapid_change_num_rows(
@@ -27,7 +27,7 @@ class TestCheckRapidChange:
 
     def test_0_vs_many(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         time_value = datetime.combine(date.today(), datetime.min.time())
 
@@ -51,7 +51,7 @@ class TestCheckAvgValDiffs:
 
     def test_same_val(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         data = {"val": [1, 1, 1, 2, 0, 1], "se": [np.nan] * 6,
                 "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
@@ -66,7 +66,7 @@ class TestCheckAvgValDiffs:
 
     def test_same_se(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         data = {"val": [np.nan] * 6, "se": [1, 1, 1, 2, 0, 1],
                 "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
@@ -81,7 +81,7 @@ class TestCheckAvgValDiffs:
 
     def test_same_n(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         data = {"val": [np.nan] * 6, "se": [np.nan] * 6,
                 "sample_size": [1, 1, 1, 2, 0, 1], "geo_id": ["1"] * 6}
@@ -96,7 +96,7 @@ class TestCheckAvgValDiffs:
 
     def test_same_val_se_n(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         data = {"val": [1, 1, 1, 2, 0, 1], "se": [1, 1, 1, 2, 0, 1],
                 "sample_size": [1, 1, 1, 2, 0, 1], "geo_id": ["1"] * 6}
@@ -111,7 +111,7 @@ class TestCheckAvgValDiffs:
 
     def test_10x_val(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         test_data = {"val": [1, 1, 1, 20, 0, 1], "se": [np.nan] * 6,
                      "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
         ref_data = {"val": [1, 1, 1, 2, 0, 1], "se": [np.nan] * 6,
@@ -127,7 +127,7 @@ class TestCheckAvgValDiffs:
 
     def test_100x_val(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         test_data = {"val": [1, 1, 1, 200, 0, 1], "se": [np.nan] * 6,
                      "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
         ref_data = {"val": [1, 1, 1, 2, 0, 1], "se": [np.nan] * 6,
@@ -144,7 +144,7 @@ class TestCheckAvgValDiffs:
 
     def test_1000x_val(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         test_data = {"val": [1, 1, 1, 2000, 0, 1], "se": [np.nan] * 6,
                      "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
         ref_data = {"val": [1, 1, 1, 2, 0, 1], "se": [np.nan] * 6,
@@ -171,7 +171,7 @@ class TestDataOutlier:
     # Test to determine outliers based on the row data, has lead and lag outlier
     def test_pos_outlier(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,
                 31.42857143, 31.71428571, 32, 32, 32.14285714,
@@ -208,7 +208,7 @@ class TestDataOutlier:
 
     def test_neg_outlier(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         ref_val = [100, 101, 100, 101, 100,
                    100, 100, 100, 100, 100,
@@ -248,7 +248,7 @@ class TestDataOutlier:
 
     def test_zero_outlier(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,
                 31.42857143, 31.71428571, 32, 32, 32.14285714,
@@ -288,7 +288,7 @@ class TestDataOutlier:
 
     def test_no_outlier(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         #Data from 51580 between 9/24 and 10/26 (10/25 query date)
         ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,
@@ -327,7 +327,7 @@ class TestDataOutlier:
 
     def test_source_api_overlap(self):
         validator = DynamicValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         #Data from 51580 between 9/24 and 10/26 (10/25 query date)
         ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,

--- a/validator/tests/test_errors.py
+++ b/validator/tests/test_errors.py
@@ -33,11 +33,13 @@ class TestValidationFailure:
         assert vf3.signal == "cases_7dav"
         assert vf3.message == ""
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError,
+                           match='`filename` argument expected to be in "{date}_{geo_type}_'\
+                                 '{signal}.{extension}" format'):
             # file name not formatted correctly
             ValidationFailure("chk", filename="20200311_county.csv")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match='date in `filename` must be in "YYYYMMDD" format'):
             # date in file name not formatted correctly
             ValidationFailure("chk", filename="2020-03-11_county_cases_7dav.csv")
 

--- a/validator/tests/test_errors.py
+++ b/validator/tests/test_errors.py
@@ -1,4 +1,5 @@
 """Tests for errors.py."""
+import datetime as dt
 from delphi_validator.errors import ValidationFailure
 
 class TestValidationFailure:
@@ -6,10 +7,23 @@ class TestValidationFailure:
 
     def test_is_suppressed(self):
         """Tests the suppression of failures."""
-        vf = ValidationFailure("a", "b", "c")
-        assert vf.is_suppressed(set([("a", "b")]))
-        assert vf.is_suppressed(set([("*", "b")]))
-        assert vf.is_suppressed(set([("a", "*")]))
-        assert not vf.is_suppressed(set([("c", "*")]))
-        assert not vf.is_suppressed(set([("*", "*")]))
-        assert not vf.is_suppressed(set([("c", "d")]))
+        vf = ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "d")
+        assert vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "")])
+        assert vf.is_suppressed([ValidationFailure(None, dt.date(2021, 1, 20), "b", "c", "")])
+        assert vf.is_suppressed([ValidationFailure("a", None, "b", "c", "")])
+        assert vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), None, "c", "")])
+        assert vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), "b", None, "")])
+        assert vf.is_suppressed([ValidationFailure(None, None, "b", "c", "")])
+        assert vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), None, None, "")])
+        assert vf.is_suppressed([ValidationFailure(None, None, None, None, "")])
+
+    def test_not_is_suppressed(self):
+        """Tests the non-suppression of failures."""
+        vf = ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "d")
+        assert not vf.is_suppressed([ValidationFailure("x", dt.date(2021, 1, 20), "b", "c", "")])
+        assert not vf.is_suppressed([ValidationFailure(None, dt.date(2021, 1, 21), "b", "c", "")])
+        assert not vf.is_suppressed([ValidationFailure("a", None, "x", "c", "")])
+        assert not vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), None, "x", "")])
+        assert not vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), "x", None, "")])
+        assert not vf.is_suppressed([ValidationFailure(None, None, "x", "c", "")])
+        assert not vf.is_suppressed([ValidationFailure("x", dt.date(2021, 1, 20), None, None, "")])

--- a/validator/tests/test_errors.py
+++ b/validator/tests/test_errors.py
@@ -7,6 +7,8 @@ class TestValidationFailure:
     """Tests for ValidationFailure class."""
 
     def test_init(self):
+        """Test initialization of ValidationFailures."""
+        # Normal positional arguments.
         vf1 = ValidationFailure("chk", "1990-10-03", "state", "deaths", "msg")
         assert vf1.check_name == "chk"
         assert vf1.date == dt.date(1990, 10, 3)
@@ -14,13 +16,22 @@ class TestValidationFailure:
         assert vf1.signal == "deaths"
         assert vf1.message == "msg"
 
-        vf2 = ValidationFailure("chk", filename="20200311_county_cases_7dav.csv",
-                                date=dt.date(400, 4, 4), geo_type="ignored", signal="also_ignored")
+        # Missing arguments filled in.
+        vf2 = ValidationFailure("chk", dt.date(1990, 10, 3))
         assert vf2.check_name == "chk"
-        assert vf2.date == dt.date(2020, 3, 11)
-        assert vf2.geo_type == "county"
-        assert vf2.signal == "cases_7dav"
+        assert vf2.date == dt.date(1990, 10, 3)
+        assert vf2.geo_type == None
+        assert vf2.signal == None
         assert vf2.message == ""
+
+        # Values extracted from a filename.
+        vf3 = ValidationFailure("chk", filename="20200311_county_cases_7dav.csv",
+                                date=dt.date(400, 4, 4), geo_type="ignored", signal="also_ignored")
+        assert vf3.check_name == "chk"
+        assert vf3.date == dt.date(2020, 3, 11)
+        assert vf3.geo_type == "county"
+        assert vf3.signal == "cases_7dav"
+        assert vf3.message == ""
 
         with pytest.raises(AssertionError):
             # file name not formatted correctly
@@ -31,6 +42,7 @@ class TestValidationFailure:
             ValidationFailure("chk", filename="2020-03-11_county_cases_7dav.csv")
 
     def test_eq(self):
+        """Test equality checking of ValidationFailures."""
         vf = ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "d")
         assert vf == ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "")
         assert vf == ValidationFailure(None, dt.date(2021, 1, 20), "b", "c", "")
@@ -41,8 +53,6 @@ class TestValidationFailure:
         assert vf == ValidationFailure("a", dt.date(2021, 1, 20), None, None, "")
         assert vf == ValidationFailure(None, None, None, None, "")
 
-    def test_not_eq(self):
-        vf = ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "d")
         assert vf != ValidationFailure("x", dt.date(2021, 1, 20), "b", "c", "")
         assert vf != ValidationFailure(None, dt.date(2021, 1, 21), "b", "c", "")
         assert vf != ValidationFailure("a", None, "x", "c", "")
@@ -58,9 +68,6 @@ class TestValidationFailure:
                                  ValidationFailure(None, dt.date(2021, 1, 20), "b", "c", ""),
                                  ValidationFailure("a", None, "b", "c", "")])
 
-    def test_not_is_suppressed(self):
-        """Tests the non-suppression of failures."""
-        vf = ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "d")
         assert not vf.is_suppressed([ValidationFailure("x", dt.date(2021, 1, 20), "b", "c", ""),
                                      ValidationFailure(None, dt.date(2021, 1, 21), "b", "c", ""),
                                      ValidationFailure("a", None, "x", "c", ""),

--- a/validator/tests/test_errors.py
+++ b/validator/tests/test_errors.py
@@ -1,29 +1,67 @@
 """Tests for errors.py."""
 import datetime as dt
+import pytest
 from delphi_validator.errors import ValidationFailure
 
 class TestValidationFailure:
     """Tests for ValidationFailure class."""
 
+    def test_init(self):
+        vf1 = ValidationFailure("chk", "1990-10-03", "state", "deaths", "msg")
+        assert vf1.check_name == "chk"
+        assert vf1.date == dt.date(1990, 10, 3)
+        assert vf1.geo_type == "state"
+        assert vf1.signal == "deaths"
+        assert vf1.message == "msg"
+
+        vf2 = ValidationFailure("chk", filename="20200311_county_cases_7dav.csv",
+                                date=dt.date(400, 4, 4), geo_type="ignored", signal="also_ignored")
+        assert vf2.check_name == "chk"
+        assert vf2.date == dt.date(2020, 3, 11)
+        assert vf2.geo_type == "county"
+        assert vf2.signal == "cases_7dav"
+        assert vf2.message == ""
+
+        with pytest.raises(AssertionError):
+            # file name not formatted correctly
+            ValidationFailure("chk", filename="20200311_county.csv")
+
+        with pytest.raises(ValueError):
+            # date in file name not formatted correctly
+            ValidationFailure("chk", filename="2020-03-11_county_cases_7dav.csv")
+
+    def test_eq(self):
+        vf = ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "d")
+        assert vf == ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "")
+        assert vf == ValidationFailure(None, dt.date(2021, 1, 20), "b", "c", "")
+        assert vf == ValidationFailure("a", None, "b", "c", "")
+        assert vf == ValidationFailure("a", dt.date(2021, 1, 20), None, "c", "")
+        assert vf == ValidationFailure("a", dt.date(2021, 1, 20), "b", None, "")
+        assert vf == ValidationFailure(None, None, "b", "c", "")
+        assert vf == ValidationFailure("a", dt.date(2021, 1, 20), None, None, "")
+        assert vf == ValidationFailure(None, None, None, None, "")
+
+    def test_not_eq(self):
+        vf = ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "d")
+        assert vf != ValidationFailure("x", dt.date(2021, 1, 20), "b", "c", "")
+        assert vf != ValidationFailure(None, dt.date(2021, 1, 21), "b", "c", "")
+        assert vf != ValidationFailure("a", None, "x", "c", "")
+        assert vf != ValidationFailure("a", dt.date(2021, 1, 20), None, "x", "")
+        assert vf != ValidationFailure("a", dt.date(2021, 1, 20), "x", None, "")
+        assert vf != ValidationFailure(None, None, "x", "c", "")
+        assert vf != ValidationFailure("x", dt.date(2021, 1, 20), None, None, "")
+
     def test_is_suppressed(self):
         """Tests the suppression of failures."""
         vf = ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "d")
-        assert vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "")])
-        assert vf.is_suppressed([ValidationFailure(None, dt.date(2021, 1, 20), "b", "c", "")])
-        assert vf.is_suppressed([ValidationFailure("a", None, "b", "c", "")])
-        assert vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), None, "c", "")])
-        assert vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), "b", None, "")])
-        assert vf.is_suppressed([ValidationFailure(None, None, "b", "c", "")])
-        assert vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), None, None, "")])
-        assert vf.is_suppressed([ValidationFailure(None, None, None, None, "")])
+        assert vf.is_suppressed([ValidationFailure("a", dt.date(2020, 1, 20), "b", "c", ""),
+                                 ValidationFailure(None, dt.date(2021, 1, 20), "b", "c", ""),
+                                 ValidationFailure("a", None, "b", "c", "")])
 
     def test_not_is_suppressed(self):
         """Tests the non-suppression of failures."""
         vf = ValidationFailure("a", dt.date(2021, 1, 20), "b", "c", "d")
-        assert not vf.is_suppressed([ValidationFailure("x", dt.date(2021, 1, 20), "b", "c", "")])
-        assert not vf.is_suppressed([ValidationFailure(None, dt.date(2021, 1, 21), "b", "c", "")])
-        assert not vf.is_suppressed([ValidationFailure("a", None, "x", "c", "")])
-        assert not vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), None, "x", "")])
-        assert not vf.is_suppressed([ValidationFailure("a", dt.date(2021, 1, 20), "x", None, "")])
-        assert not vf.is_suppressed([ValidationFailure(None, None, "x", "c", "")])
-        assert not vf.is_suppressed([ValidationFailure("x", dt.date(2021, 1, 20), None, None, "")])
+        assert not vf.is_suppressed([ValidationFailure("x", dt.date(2021, 1, 20), "b", "c", ""),
+                                     ValidationFailure(None, dt.date(2021, 1, 21), "b", "c", ""),
+                                     ValidationFailure("a", None, "x", "c", ""),
+                                     ValidationFailure("a", dt.date(2021, 1, 20), None, "x", "")])

--- a/validator/tests/test_report.py
+++ b/validator/tests/test_report.py
@@ -6,19 +6,25 @@ from delphi_validator.report import ValidationReport
 class TestValidationReport:
     """Tests for ValidationReport class."""
 
-    ERROR_1 = ValidationFailure("good", "data 1", "msg 1")
-    ERROR_2 = ValidationFailure("bad", "data 2", "msg 2")
+    ERROR_1 = ValidationFailure("good",
+                                filename="20201107_county_sig1.csv",
+                                message="msg 1")
+    ERROR_2 = ValidationFailure("bad",
+                                filename="20201107_county_sig2.csv",
+                                message="msg 2")
 
     def test_add_raised_unsuppressed_error(self):
         """Test that an unsupressed error shows up in the unsuppressed error list."""
-        report = ValidationReport(set([("bad", "data 1")]))
+        report = ValidationReport([ValidationFailure("good",
+                                   filename="20201107_county_sig2.csv",
+                                   message="msg 2")])
         report.add_raised_error(self.ERROR_1)
         report.add_raised_error(self.ERROR_2)
         assert report.unsuppressed_errors == [self.ERROR_1, self.ERROR_2]
 
     def test_add_raised_suppressed_error(self):
         """Test that an supressed error does not show up in the unsuppressed error list."""
-        report = ValidationReport(set([("good", "data 1")]))
+        report = ValidationReport([self.ERROR_1])
         report.add_raised_error(self.ERROR_1)
 
         assert len(report.unsuppressed_errors) == 0
@@ -26,7 +32,7 @@ class TestValidationReport:
 
     def test_str(self):
         """Test that the string representation contains all information."""
-        report = ValidationReport(set([("good", "data 1")]))
+        report = ValidationReport([self.ERROR_1])
         report.increment_total_checks()
         report.increment_total_checks()
         report.increment_total_checks()
@@ -41,7 +47,7 @@ class TestValidationReport:
     @mock.patch("delphi_validator.report.logger")
     def test_log(self, mock_logger):
         """Test that the logs contain all failures and warnings."""
-        report = ValidationReport(set([("good", "data 1")]))
+        report = ValidationReport([self.ERROR_1])
         report.increment_total_checks()
         report.increment_total_checks()
         report.increment_total_checks()
@@ -52,5 +58,5 @@ class TestValidationReport:
 
         report.log()
         mock_logger.critical.assert_called_once_with(
-            "bad failed for data 2: msg 2")
+            "bad failed for sig2 at resolution county on 2020-11-07: msg 2")
         mock_logger.warning.assert_has_calls([mock.call("wrong import"), mock.call("right import")])

--- a/validator/tests/test_static.py
+++ b/validator/tests/test_static.py
@@ -6,6 +6,9 @@ from delphi_validator.datafetcher import FILENAME_REGEX
 from delphi_validator.report import ValidationReport
 from delphi_validator.static import StaticValidator
 
+# Properly formatted file name to use in tests where the actual value doesn't matter.
+FILENAME = "17760704_nation_num_declarations.csv"
+
 class TestCheckMissingDates:
 
     def test_empty_filelist(self):
@@ -17,8 +20,8 @@ class TestCheckMissingDates:
             }
         }
         validator = StaticValidator(params)
-        report = ValidationReport(set())
-        report = ValidationReport(set())
+        report = ValidationReport([])
+        report = ValidationReport([])
 
         filenames = list()
         validator.check_missing_date_files(filenames, report)
@@ -35,7 +38,7 @@ class TestCheckMissingDates:
             }
         }
         validator = StaticValidator(params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         filenames = [("20200901_county_signal_signal.csv", "match_obj")]
         validator.check_missing_date_files(filenames, report)
@@ -51,7 +54,7 @@ class TestCheckMissingDates:
             }
         }
         validator = StaticValidator(params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
 
         filenames = [("20200901_county_signal_signal.csv", "match_obj"),
                      ("20200903_county_signal_signal.csv", "match_obj"),
@@ -97,76 +100,76 @@ class TestCheckBadGeoIdFormat:
 
     def test_empty_df(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         empty_df = pd.DataFrame(columns=["geo_id"], dtype=str)
-        validator.check_bad_geo_id_format(empty_df, "name", "county", report)
+        validator.check_bad_geo_id_format(empty_df, FILENAME, "county", report)
 
         assert len(report.raised_errors) == 0
 
     def test_invalid_geo_type(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         empty_df = pd.DataFrame(columns=["geo_id"], dtype=str)
-        validator.check_bad_geo_id_format(empty_df, "name", "hello", report)
+        validator.check_bad_geo_id_format(empty_df, FILENAME, "hello", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_geo_type"
 
     def test_invalid_geo_id_format_county(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["0", "54321", "123", ".0000",
                            "abc12"], columns=["geo_id"])
-        validator.check_bad_geo_id_format(df, "name", "county", report)
+        validator.check_bad_geo_id_format(df, FILENAME, "county", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_geo_id_format"
 
     def test_invalid_geo_id_format_msa(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["0", "54321", "123", ".0000",
                            "abc12"], columns=["geo_id"])
-        validator.check_bad_geo_id_format(df, "name", "msa", report)
+        validator.check_bad_geo_id_format(df, FILENAME, "msa", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_geo_id_format"
 
     def test_invalid_geo_id_format_hrr(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["1", "12", "123", "1234", "12345",
                            "a", ".", "ab1"], columns=["geo_id"])
-        validator.check_bad_geo_id_format(df, "name", "hrr", report)
+        validator.check_bad_geo_id_format(df, FILENAME, "hrr", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_geo_id_format"
 
     def test_invalid_geo_id_format_state(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["aa", "hi", "HI", "hawaii",
                            "Hawaii", "a", "H.I."], columns=["geo_id"])
-        validator.check_bad_geo_id_format(df, "name", "state", report)
+        validator.check_bad_geo_id_format(df, FILENAME, "state", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_geo_id_format"
 
     def test_invalid_geo_id_format_hhs(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["1", "112"], columns=["geo_id"])
-        validator.check_bad_geo_id_format(df, "name", "hhs", report)
+        validator.check_bad_geo_id_format(df, FILENAME, "hhs", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_geo_id_format"
 
     def test_invalid_geo_id_format_nation(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["usa", "SP", " us", "us",
                            "usausa", "US"], columns=["geo_id"])
-        validator.check_bad_geo_id_format(df, "name", "nation", report)
+        validator.check_bad_geo_id_format(df, FILENAME, "nation", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_geo_id_format"
@@ -182,39 +185,39 @@ class TestDuplicatedRows:
 
     def test_no_duplicates(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame([["a", "1"], ["b", "2"], ["c", "3"]])
-        validator.check_duplicate_rows(df, "file", report)
+        validator.check_duplicate_rows(df, FILENAME, report)
         assert len(report.raised_warnings) == 0
 
     def test_single_column_duplicates_but_not_row(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame([["a", "1"], ["a", "2"], ["b", "2"]])
-        validator.check_duplicate_rows(df, "file", report)
+        validator.check_duplicate_rows(df, FILENAME, report)
         assert len(report.raised_warnings) == 0
 
     def test_non_consecutive_duplicates(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame([["a", "1"], ["b", "2"], ["a", "1"]])
-        validator.check_duplicate_rows(df, "file", report)
+        validator.check_duplicate_rows(df, FILENAME, report)
         assert len(report.raised_warnings) == 1
         assert report.raised_warnings[0].check_name == "check_duplicate_rows"
 
     def test_multiple_distinct_duplicates(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame([["a", "1"], ["b", "2"], ["a", "1"], ["b", "2"]])
-        validator.check_duplicate_rows(df, "file", report)
+        validator.check_duplicate_rows(df, FILENAME, report)
         assert len(report.raised_warnings) == 1
         assert report.raised_warnings[0].check_name == "check_duplicate_rows"
 
     def test_more_than_two_copies(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame([["a", "1"], ["b", "2"], ["b", "2"], ["b", "2"]])
-        validator.check_duplicate_rows(df, "file", report)
+        validator.check_duplicate_rows(df, FILENAME, report)
         assert len(report.raised_warnings) == 1
         assert report.raised_warnings[0].check_name == "check_duplicate_rows"
 
@@ -232,62 +235,62 @@ class TestCheckBadGeoIdValue:
 
     def test_empty_df(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         empty_df = pd.DataFrame(columns=["geo_id"], dtype=str)
-        validator.check_bad_geo_id_value(empty_df, "name", "county", report)
+        validator.check_bad_geo_id_value(empty_df, FILENAME, "county", report)
         assert len(report.raised_errors) == 0
 
     def test_invalid_geo_id_value_county(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["01001", "88888", "99999"], columns=["geo_id"])
-        validator.check_bad_geo_id_value(df, "name", "county", report)
+        validator.check_bad_geo_id_value(df, FILENAME, "county", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_bad_geo_id_value"
 
     def test_invalid_geo_id_value_msa(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["10180", "88888", "99999"], columns=["geo_id"])
-        validator.check_bad_geo_id_value(df, "name", "msa", report)
+        validator.check_bad_geo_id_value(df, FILENAME, "msa", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_bad_geo_id_value"
 
     def test_invalid_geo_id_value_hrr(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["1", "11", "111", "8", "88",
                            "888"], columns=["geo_id"])
-        validator.check_bad_geo_id_value(df, "name", "hrr", report)
+        validator.check_bad_geo_id_value(df, FILENAME, "hrr", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_bad_geo_id_value"
 
     def test_invalid_geo_id_value_hhs(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["1", "11"], columns=["geo_id"])
-        validator.check_bad_geo_id_value(df, "name", "hhs", report)
+        validator.check_bad_geo_id_value(df, FILENAME, "hhs", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_bad_geo_id_value"
 
     def test_invalid_geo_id_value_state(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["aa", "ak"], columns=["geo_id"])
-        validator.check_bad_geo_id_value(df, "name", "state", report)
+        validator.check_bad_geo_id_value(df, FILENAME, "state", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_bad_geo_id_value"
 
     def test_uppercase_geo_id(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["ak", "AK"], columns=["geo_id"])
-        validator.check_bad_geo_id_value(df, "name", "state", report)
+        validator.check_bad_geo_id_value(df, FILENAME, "state", report)
 
         assert len(report.raised_errors) == 0
         assert len(report.raised_warnings) == 1
@@ -295,9 +298,9 @@ class TestCheckBadGeoIdValue:
 
     def test_invalid_geo_id_value_nation(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame(["us", "zz"], columns=["geo_id"])
-        validator.check_bad_geo_id_value(df, "name", "nation", report)
+        validator.check_bad_geo_id_value(df, FILENAME, "nation", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_bad_geo_id_value"
@@ -313,7 +316,7 @@ class TestCheckBadVal:
 
     def test_empty_df(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         empty_df = pd.DataFrame(columns=["val"])
         validator.check_bad_val(empty_df, "", "", report)
         validator.check_bad_val(empty_df, "", "prop", report)
@@ -323,36 +326,36 @@ class TestCheckBadVal:
 
     def test_missing(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame([np.nan], columns=["val"])
-        validator.check_bad_val(df, "name", "signal", report)
+        validator.check_bad_val(df, FILENAME, "signal", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_val_missing"
 
     def test_lt_0(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame([-5], columns=["val"])
-        validator.check_bad_val(df, "name", "signal", report)
+        validator.check_bad_val(df, FILENAME, "signal", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_val_lt_0"
 
     def test_gt_max_pct(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame([1e7], columns=["val"])
-        validator.check_bad_val(df, "name", "pct", report)
+        validator.check_bad_val(df, FILENAME, "pct", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_val_pct_gt_100"
 
     def test_gt_max_prop(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         df = pd.DataFrame([1e7], columns=["val"])
-        validator.check_bad_val(df, "name", "prop", report)
+        validator.check_bad_val(df, FILENAME, "prop", report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_val_prop_gt_100k"
@@ -369,7 +372,7 @@ class TestCheckBadSe:
 
     def test_empty_df(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         empty_df = pd.DataFrame(
             columns=["val", "se", "sample_size"], dtype=float)
         validator.check_bad_se(empty_df, "", report)
@@ -383,16 +386,16 @@ class TestCheckBadSe:
 
     def test_missing(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         validator.params.missing_se_allowed = True
         df = pd.DataFrame([[np.nan, np.nan, np.nan]], columns=[
                           "val", "se", "sample_size"])
-        validator.check_bad_se(df, "name", report)
+        validator.check_bad_se(df, FILENAME, report)
 
         assert len(report.raised_errors) == 0
 
         validator.params.missing_se_allowed = False
-        validator.check_bad_se(df, "name", report)
+        validator.check_bad_se(df, FILENAME, report)
 
         assert len(report.raised_errors) == 2
         assert "check_se_not_missing_and_in_range" in [
@@ -402,11 +405,11 @@ class TestCheckBadSe:
 
     def test_e_0_missing_allowed(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         validator.params.missing_se_allowed = True
         df = pd.DataFrame([[1, 0, 200], [1, np.nan, np.nan], [
                           1, np.nan, np.nan]], columns=["val", "se", "sample_size"])
-        validator.check_bad_se(df, "name", report)
+        validator.check_bad_se(df, FILENAME, report)
 
         assert len(report.raised_errors) == 2
         assert "check_se_missing_or_in_range" in [
@@ -416,11 +419,11 @@ class TestCheckBadSe:
 
     def test_e_0_missing_not_allowed(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         validator.params.missing_se_allowed = False
         df = pd.DataFrame([[1, 0, 200], [1, 0, np.nan], [
                           1, np.nan, np.nan]], columns=["val", "se", "sample_size"])
-        validator.check_bad_se(df, "name", report)
+        validator.check_bad_se(df, FILENAME, report)
 
         assert len(report.raised_errors) == 2
         assert "check_se_not_missing_and_in_range" in [
@@ -430,11 +433,11 @@ class TestCheckBadSe:
 
     def test_jeffreys(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         validator.params.missing_se_allowed = False
         df = pd.DataFrame([[0, 0, 200], [1, 0, np.nan], [
                           1, np.nan, np.nan]], columns=["val", "se", "sample_size"])
-        validator.check_bad_se(df, "name", report)
+        validator.check_bad_se(df, FILENAME, report)
 
         assert len(report.raised_errors) == 2
         assert "check_se_not_missing_and_in_range" in [
@@ -454,7 +457,7 @@ class TestCheckBadN:
 
     def test_empty_df(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         empty_df = pd.DataFrame(
             columns=["val", "se", "sample_size"], dtype=float)
         validator.check_bad_sample_size(empty_df, "", report)
@@ -468,38 +471,38 @@ class TestCheckBadN:
 
     def test_missing(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         validator.params.missing_sample_size_allowed = True
         df = pd.DataFrame([[np.nan, np.nan, np.nan]], columns=[
                           "val", "se", "sample_size"])
-        validator.check_bad_sample_size(df, "name", report)
+        validator.check_bad_sample_size(df, FILENAME, report)
 
         assert len(report.raised_errors) == 0
 
         validator.params.missing_sample_size_allowed = False
-        validator.check_bad_sample_size(df, "name", report)
+        validator.check_bad_sample_size(df, FILENAME, report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_n_missing"
 
     def test_lt_min_missing_allowed(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         validator.params.missing_sample_size_allowed = True
         df = pd.DataFrame([[1, 0, 10], [1, np.nan, np.nan], [
                           1, np.nan, np.nan]], columns=["val", "se", "sample_size"])
-        validator.check_bad_sample_size(df, "name", report)
+        validator.check_bad_sample_size(df, FILENAME, report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_n_missing_or_gt_min"
 
     def test_lt_min_missing_not_allowed(self):
         validator = StaticValidator(self.params)
-        report = ValidationReport(set())
+        report = ValidationReport([])
         validator.params.missing_sample_size_allowed = False
         df = pd.DataFrame([[1, 0, 10], [1, np.nan, 240], [
                           1, np.nan, 245]], columns=["val", "se", "sample_size"])
-        validator.check_bad_sample_size(df, "name", report)
+        validator.check_bad_sample_size(df, FILENAME, report)
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_n_gt_min"

--- a/validator/tests/test_validator.py
+++ b/validator/tests/test_validator.py
@@ -40,7 +40,8 @@ class TestValidatorInitialization:
 
     def test_incorrect_suppressed_errors(self):
         """Test initialization with improperly coded suppressed errors."""
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError, match='suppressed_errors may only have fields '
+                                                 '"check_name", "date", "geo_type", "signal"'):
             # entry with invalid keys
             Validator({
                 "global": {
@@ -58,7 +59,7 @@ class TestValidatorInitialization:
                 }
             })
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(AssertionError, match="suppressed_errors must be a list of objects"):
             # entry that is not a list
             Validator({
                 "global": {

--- a/validator/tests/test_validator.py
+++ b/validator/tests/test_validator.py
@@ -25,27 +25,36 @@ class TestValidatorInitialization:
                 "data_source": "",
                 "span_length": 0,
                 "end_date": "2020-09-01",
-                "suppressed_errors": [["a", None, None, "b"],
-                                      ["c", None, None, "d"]]
+                "suppressed_errors": [{"check_name": "a",
+                                       "date": None,
+                                       "signal": "b"},
+                                      {"check_name":"c",
+                                       "date": None,
+                                       "geo_type": "d"}]
             }
         }
 
         validator = Validator(params)
-        assert validator.suppressed_errors == [ValidationFailure("a", None, None, "b", ""),
-                                               ValidationFailure("c", None, None, "d", "")]
+        assert validator.suppressed_errors == [ValidationFailure("a", None, None, "b"),
+                                               ValidationFailure("c", None, "d", "None")]
 
     def test_incorrect_suppressed_errors(self):
         """Test initialization with improperly coded suppressed errors."""
         with pytest.raises(AssertionError):
-            # entry of length not equal to 2
+            # entry with invalid keys
             Validator({
                 "global": {
                     "data_source": "",
                     "span_length": 0,
                     "end_date": "2020-09-01",
-                    "suppressed_errors": [["a", None, None, "b"],
-                                          ["c", None, None, "d"],
-                                          ["ab"]]
+                    "suppressed_errors": [{"check_name": "a",
+                                           "date": None,
+                                           "signal": "b"},
+                                          {"check_name":"c",
+                                           "date": None,
+                                           "geo_type": "d"},
+                                          {"check_name": "a",
+                                           "fake": "b"}]
                 }
             })
 
@@ -56,8 +65,12 @@ class TestValidatorInitialization:
                     "data_source": "",
                     "span_length": 0,
                     "end_date": "2020-09-01",
-                    "suppressed_errors": [["a", None, None, "b"],
-                                          ["c", None, None, "d"],
-                                          "ab"]
+                    "suppressed_errors": [{"check_name": "a",
+                                           "date": None,
+                                           "signal": "b"},
+                                          {"check_name":"c",
+                                           "date": None,
+                                           "geo_type": "d"},
+                                          ["ab"]]
                 }
             })

--- a/validator/tests/test_validator.py
+++ b/validator/tests/test_validator.py
@@ -1,5 +1,6 @@
 """Tests for Validator"""
 import pytest
+from delphi_validator.errors import ValidationFailure
 from delphi_validator.validate import Validator
 
 class TestValidatorInitialization:
@@ -15,7 +16,7 @@ class TestValidatorInitialization:
         }
         validator = Validator(params)
         assert len(validator.suppressed_errors) == 0
-        assert isinstance(validator.suppressed_errors, set)
+        assert isinstance(validator.suppressed_errors, list)
 
     def test_suppressed_errors(self):
         """Test initialization with suppressed errors."""
@@ -24,12 +25,14 @@ class TestValidatorInitialization:
                 "data_source": "",
                 "span_length": 0,
                 "end_date": "2020-09-01",
-                "suppressed_errors": [["a", "b"], ["c", "d"], ["a", "b"]]
+                "suppressed_errors": [["a", None, None, "b"],
+                                      ["c", None, None, "d"]]
             }
         }
 
         validator = Validator(params)
-        assert validator.suppressed_errors == set([("a", "b"), ("c", "d")])
+        assert validator.suppressed_errors == [ValidationFailure("a", None, None, "b", ""),
+                                               ValidationFailure("c", None, None, "d", "")]
 
     def test_incorrect_suppressed_errors(self):
         """Test initialization with improperly coded suppressed errors."""
@@ -40,7 +43,9 @@ class TestValidatorInitialization:
                     "data_source": "",
                     "span_length": 0,
                     "end_date": "2020-09-01",
-                    "suppressed_errors": [["a", "b"], ["c", "d"], ["ab"]]
+                    "suppressed_errors": [["a", None, None, "b"],
+                                          ["c", None, None, "d"],
+                                          ["ab"]]
                 }
             })
 
@@ -51,6 +56,8 @@ class TestValidatorInitialization:
                     "data_source": "",
                     "span_length": 0,
                     "end_date": "2020-09-01",
-                    "suppressed_errors": [["a", "b"], ["c", "d"], "ab"]
+                    "suppressed_errors": [["a", None, None, "b"],
+                                          ["c", None, None, "d"],
+                                          "ab"]
                 }
             })


### PR DESCRIPTION
### Description
Change the way we disable specific validation checks to allow disabling based on  geo resolution, signal, and date.


To accommodate these additional parameters, the `params.json` syntax for disabling checks has changed from a list of length-2 lists to a list of objects whose keys are some subset of `check_name`, `geo_type`, `date`, and `signal`.  Any of these parameters absent from the object are interpreted as wildcards (i.e. `check_name: a, geo_type: b` disables `check_name: a, geo_type:b, signal:c, date: 2021-01-24`.

### Changelog
- `errors.py`:  overhaul to `ValidationFailure`
    - `None` is now the wildcard
    - Use custom `__eq__()` method for comparison
- `validate.py`:  change method of reading suppressions from `params.json`
- `datafetcher.py`, `dynamic.py`, `static.py`:  change `ValidationFailure` constructor
- `report.py`:  pass around `ValidationFailure` objects in suppression list

### Fixes 
- Fixes #719 
