### PR TITLE
changehc: convert chained assignment to .loc

### DIFF
--- a/changehc/delphi_changehc/load_data.py
+++ b/changehc/delphi_changehc/load_data.py
@@ -60,9 +60,7 @@ def load_chng_data(filepath, dropdate, base_geo,
         ]
 
     # counts between 1 and 3 are coded as "3 or less", we convert to 1
-    data[counts_col][
-        data[counts_col] == "3 or less"
-        ] = "1"
+    data.loc[data[counts_col] == "3 or less", counts_col] = "1"
     data[counts_col] = data[counts_col].astype(int)
 
     assert (


### PR DESCRIPTION
### Description
changehc.load_data was using the following chained assignment:

https://github.com/cmu-delphi/covidcast-indicators/blob/47bfd62fb26ba60849f467eacd30aca744a12a60/changehc/delphi_changehc/load_data.py#L63-L65

Chained assignment is one of the "missing stairs" of pandas -- it makes intuitive sense but can fail badly in unpredictable ways. Whether pandas does the assignment on the original data frame or a copy (which then gets discarded) is dependent on a ton of factors, many of which are only determined at runtime (like memory layout).

This instance of chained assignment generates a warning:
```
/home/indicators/runtime/changehc/delphi_changehc/load_data.py:63: SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame

See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
  data[counts_col][
```

Now it won't do that.

### Changelog
- load_data.py: Convert chained assignment to .loc

