### PR TITLE
hhs hosp state daily: makefile and production params

### DIFF
--- a/ansible/templates/hhs_hosp-params-prod.json.j2
+++ b/ansible/templates/hhs_hosp-params-prod.json.j2
@@ -2,5 +2,12 @@
   "static_file_dir": "./static",
   "export_dir": "/common/covidcast/receiving/hhs",
   "cache_dir": "./cache",
-  "wip_signal": ""
+  "wip_signal": "",
+  "aws_credentials": {
+    "aws_access_key_id": "{{ delphi_aws_access_key_id }}",
+    "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"
+  },
+  "bucket_name": "delphi-covidcast-indicator-output",
+  "log_filename": "/var/log/indicators/hhs_hosp.log"
+
 }

--- a/hhs_hosp/Makefile
+++ b/hhs_hosp/Makefile
@@ -23,3 +23,8 @@ test:
 clean:
 	rm -rf env
 	rm -f params.json
+
+run:
+	. env/bin/activate; \
+	python -m $(dir) 2>errlog.txt && \
+	python -m delphi_utils.archive --archive_type s3 --indicator_prefix $(dir) 2>errlog.txt

--- a/hhs_hosp/params.json.template
+++ b/hhs_hosp/params.json.template
@@ -2,5 +2,11 @@
   "static_file_dir": "./static",
   "export_dir": "./receiving",
   "cache_dir": "./cache",
-  "wip_signal": ""
+  "wip_signal": "",
+  "aws_credentials": {
+    "aws_access_key_id": "",
+    "aws_secret_access_key": ""
+  },
+  "bucket_name": "",
+  "log_filename": "hhs_hosp.log"
 }


### PR DESCRIPTION
### Description
Adds a Makefile target for running the indicator, and updates the production params to include the AWS credentials.

The `delphi_hhs` folder has been added to `delphi-covidcast-indicator-output` in S3.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Makefile - new target
- params.json.template - new keys (blanked for dev environments)
- ansible template params - new keys (with templated constants for credentials)
