### PR TITLE
Add symptom survey item V9 ("concerned about vaccine side effects") to API

### DIFF
--- a/facebook/delphiFacebook/R/binary.R
+++ b/facebook/delphiFacebook/R/binary.R
@@ -70,6 +70,8 @@ get_binary_indicators <- function() {
     "smoothed_waccept_covid_vaccine", "weight", "v_accept_covid_vaccine", 6, compute_binary_response, jeffreys_binary,
     "smoothed_covid_vaccinated", "weight_unif", "v_covid_vaccinated", 6, compute_binary_response, jeffreys_binary,
     "smoothed_wcovid_vaccinated", "weight", "v_covid_vaccinated", 6, compute_binary_response, jeffreys_binary,
+    "smoothed_worried_vaccine_side_effects", "weight_unif", "v_worried_vaccine_side_effects", 6, compute_binary_response, jeffreys_binary,
+    "smoothed_wworried_vaccine_side_effects", "weight", "v_worried_vaccine_side_effects", 6, compute_binary_response, jeffreys_binary,
 
     # who would make more likely to accept vaccine
     "smoothed_vaccine_likely_friends", "weight_unif", "v_vaccine_likely_friends", 6, compute_binary_response, jeffreys_binary,
@@ -84,6 +86,7 @@ get_binary_indicators <- function() {
     "smoothed_wvaccine_likely_politicians", "weight", "v_vaccine_likely_politicians", 6, compute_binary_response, jeffreys_binary
 
   )
+
 
   ind$skip_mixing <- TRUE
 

--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -260,6 +260,14 @@ code_vaccines <- function(input_data) {
     input_data$v_vaccine_likely_govt_health <- NA_real_
     input_data$v_vaccine_likely_politicians <- NA_real_
   }
-
+  
+  if ("V9" %in% names(input_data)) {
+    input_data$v_worried_vaccine_side_effects <- (
+      input_data$V9 == 1 | input_data$V9 == 2
+    )
+  } else {
+    input_data$v_worried_vaccine_side_effects <- NA_real_
+  }
+  
   return(input_data)
 }


### PR DESCRIPTION
### Description
Response codes "Very concerned" and "Moderately concerned" in item V9 are mapped to `1`. The resulting variable is used to produce a weighted and an unweighted binary response.

### Changelog
- Binary variable definition added to `variables::code_vaccines`
- Aggregates added to `binary::get_binary_indicators`