### PR TITLE
hhs_hosp: change signal names to leave space for influenza later

### DIFF
--- a/hhs_hosp/delphi_hhs/constants.py
+++ b/hhs_hosp/delphi_hhs/constants.py
@@ -1,6 +1,6 @@
 """Registry for signal names."""
-CONFIRMED = "confirmed_admissions_1d"
-SUM_CONF_SUSP = "sum_confirmed_suspected_admissions_1d"
+CONFIRMED = "confirmed_admissions_covid_1d"
+SUM_CONF_SUSP = "sum_confirmed_suspected_admissions_covid_1d"
 
 
 SIGNALS = [


### PR DESCRIPTION
### Description
Signal name change as recommended by Roni during the approval process. This signal is not yet released.

### Changelog
- constants.py

### Fixes 
- Signal name approval step of signal release procedure
