### PR TITLE
Add "acceptance or already vaccinated" signal

### DIFF
--- a/facebook/delphiFacebook/R/binary.R
+++ b/facebook/delphiFacebook/R/binary.R
@@ -68,6 +68,9 @@ get_binary_indicators <- function() {
     # vaccines
     "smoothed_accept_covid_vaccine", "weight_unif", "v_accept_covid_vaccine", 6, compute_binary_response, jeffreys_binary,
     "smoothed_waccept_covid_vaccine", "weight", "v_accept_covid_vaccine", 6, compute_binary_response, jeffreys_binary,
+    "smoothed_covid_vaccinated_or_accept", "weight_unif", "v_covid_vaccinated_or_accept", 6, compute_binary_response, jeffreys_binary,
+    "smoothed_wcovid_vaccinated_or_accept", "weight", "v_covid_vaccinated_or_accept", 6, compute_binary_response, jeffreys_binary,
+
     "smoothed_covid_vaccinated", "weight_unif", "v_covid_vaccinated", 6, compute_binary_response, jeffreys_binary,
     "smoothed_wcovid_vaccinated", "weight", "v_covid_vaccinated", 6, compute_binary_response, jeffreys_binary,
 

--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -247,6 +247,22 @@ code_vaccines <- function(input_data) {
     input_data$v_accept_covid_vaccine <- NA_real_
   }
 
+  if ("V3" %in% names(input_data) && "V1" %in% names(input_data)) {
+    # "acceptance plus" means you either
+    # - already have the vaccine (V1 == 1), or
+    # - would get it if offered (V3 == 1 or 2)
+    input_data$v_covid_vaccinated_or_accept <- case_when(
+      input_data$V1 == 1 ~ 1,
+      input_data$V3 == 1 ~ 1,
+      input_data$V3 == 2 ~ 1,
+      input_data$V3 == 3 ~ 0,
+      input_data$V3 == 4 ~ 0,
+      TRUE ~ NA_real_
+    )
+  } else {
+    input_data$v_covid_vaccinated_or_accept <- NA_real_
+  }
+
   if ("V4_1" %in% names(input_data)) {
     input_data$v_vaccine_likely_friends <- input_data$V4_1 == 1
     input_data$v_vaccine_likely_local_health <- input_data$V4_2 == 1

--- a/facebook/delphiFacebook/tests/testthat/test-variables.R
+++ b/facebook/delphiFacebook/tests/testthat/test-variables.R
@@ -51,3 +51,15 @@ test_that("household size correctly imputes zeros", {
 
   expect_equal(out, input_data)
 })
+
+test_that("vaccine acceptance is coded", {
+  input_data <- data.frame(
+    V1 = c(2, 3, 2, NA, 1, NA),
+    V3 = c(1, 2, 3, 4, NA, NA)
+  )
+
+  out <- code_vaccines(input_data)
+
+  expect_equal(out$v_accept_covid_vaccine_plus,
+               c(1, 1, 0, 0, 1, NA))
+})


### PR DESCRIPTION
For use in the survey dashboard as a replacement for the acceptance signal, particularly as more people get vaccinated.