### PR TITLE
hhs_hosp: adjust run target to work in production

### DIFF
--- a/hhs_hosp/Makefile
+++ b/hhs_hosp/Makefile
@@ -25,6 +25,5 @@ clean:
 	rm -f params.json
 
 run:
-	. env/bin/activate; \
-	python -m $(dir) 2>errlog.txt && \
-	python -m delphi_utils.archive --archive_type s3 --indicator_prefix $(dir) 2>errlog.txt
+	env/bin/python -m $(dir)
+	env/bin/python -m delphi_utils.archive --archive_type s3 --indicator_prefix $(dir)


### PR DESCRIPTION
### Description
Turns out `. env/bin/activate` is not something that works when running in Automation. This PR converts those lines to use `env/bin/python` instead.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Makefile:run

### Fixes 
- Release process: test in staging
