### PR TITLE
Add Jeffreys correction for Quidel

### DIFF
--- a/quidel_covidtest/delphi_quidel_covidtest/data_tools.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/data_tools.py
@@ -166,7 +166,8 @@ def raw_positive_prop(positives, tests, min_obs):
     # nan out any days where there are insufficient observations
     # this also elegantly sidesteps 0/0 division.
     tests[tests < min_obs] = np.nan
-    positive_prop = positives / tests
+    # Jeffreys Correction for estimates
+    positive_prop = (positives+0.5) / (tests+1)
     se = np.sqrt(_prop_var(positive_prop, tests))
     sample_size = tests
     return positive_prop, se, sample_size

--- a/quidel_covidtest/tests/test_data_tools.py
+++ b/quidel_covidtest/tests/test_data_tools.py
@@ -92,11 +92,13 @@ class TestDataTools:
     @pytest.mark.parametrize("min_obs, expected_pos_prop, expected_se, expected_sample_sz", [
         (3,  # one case of tests < min_obs
          np.array([np.nan, 2.5/5, 3.5/7, 4.5/11]),
-         np.array([np.nan, np.sqrt(2.5**2/5**2/4), np.sqrt(3.5**2/7**2/6), np.sqrt(4.5*6.5/11**2/10)]),
+         np.array([np.nan, np.sqrt(2.5*(5-2.5)/5/5/4), np.sqrt(3.5*(7-3.5)/7/7/6),
+                   np.sqrt(4.5*(11-4.5)/11/11/10)]),
          np.array([np.nan, 4, 6, 10])),
         (1,  # no cases of tests < min_obs
          np.array([1.5/3, 2.5/5, 3.5/7, 4.5/11]),
-         np.array([np.sqrt(1.5**2/3**2/2), np.sqrt(2.5**2/5**2/4), np.sqrt(3.5**2/7**2/6), np.sqrt(4.5*6.5/11**2/10)]),
+         np.array([np.sqrt(1.5*(3-1.5)/3/3/2), np.sqrt(2.5*(5-2.5)/5/5/4),
+                   np.sqrt(3.5*(7-3.5)/7/7/6), np.sqrt(4.5*(11-4.5)/11/11/10)]),
          np.array([2, 4, 6, 10])),
     ])
     def test_raw_positive_prop(self, min_obs, expected_pos_prop, expected_se, expected_sample_sz):
@@ -124,7 +126,8 @@ class TestDataTools:
          None,
          None,
          np.array([np.nan, 3.5/7, 5.5/11, 7.5/17]),
-         np.array([np.nan, np.sqrt(3.5**2/7**2/6), np.sqrt(5.5**2/11**2/10), np.sqrt(7.5*9.5/17**2/16)]),
+         np.array([np.nan, np.sqrt(3.5*(7-3.5)/7/7/6), np.sqrt(5.5*(11-5.5)/11/11/10), 
+                   np.sqrt(7.5*(17-7.5)/17/17/16)]),
          np.array([np.nan, 6, 10, 16]),
          ),
         (3,  # parents case
@@ -132,7 +135,8 @@ class TestDataTools:
          np.array([3, 7, 9, 11]),
          np.array([5, 10, 15, 20]),
          np.array([(1 + 0.6 + 0.5)/(2 + 1 + 1), 3.5/7, 5.5/11, 7.5/17]),
-         np.array([np.sqrt(2.1 * 1.9/4**2/3), np.sqrt(3.5**2/7**2/6), np.sqrt(5.5**2/11**2/10), np.sqrt(7.5*9.5/17**2/16)]),
+         np.array([np.sqrt(2.1*(4-2.1)/4/4/3), np.sqrt(3.5*(7-3.5)/7/7/6), 
+                   np.sqrt(5.5*(11-5.5)/11/11/10), np.sqrt(7.5*(17-7.5)/17/17/16)]),
          np.array([3, 6, 10, 16]),
          ),
     ])

--- a/quidel_covidtest/tests/test_data_tools.py
+++ b/quidel_covidtest/tests/test_data_tools.py
@@ -91,12 +91,12 @@ class TestDataTools:
 
     @pytest.mark.parametrize("min_obs, expected_pos_prop, expected_se, expected_sample_sz", [
         (3,  # one case of tests < min_obs
-         np.array([np.nan, 1/2, 1/2, 4/10]),
-         np.array([np.nan, np.sqrt(0.25/4), np.sqrt(0.25/6), np.sqrt(0.24/10)]),
+         np.array([np.nan, 2.5/5, 3.5/7, 4.5/11]),
+         np.array([np.nan, np.sqrt(2.5**2/5**2/4), np.sqrt(3.5**2/7**2/6), np.sqrt(4.5*6.5/11**2/10)]),
          np.array([np.nan, 4, 6, 10])),
         (1,  # no cases of tests < min_obs
-         np.array([1/2, 2/4, 3/6, 4/10]),
-         np.array([np.sqrt(0.25/2), np.sqrt(0.25/4), np.sqrt(0.25/6), np.sqrt(0.24/10)]),
+         np.array([1.5/3, 2.5/5, 3.5/7, 4.5/11]),
+         np.array([np.sqrt(1.5**2/3**2/2), np.sqrt(2.5**2/5**2/4), np.sqrt(3.5**2/7**2/6), np.sqrt(4.5*6.5/11**2/10)]),
          np.array([2, 4, 6, 10])),
     ])
     def test_raw_positive_prop(self, min_obs, expected_pos_prop, expected_se, expected_sample_sz):
@@ -123,16 +123,16 @@ class TestDataTools:
          2,
          None,
          None,
-         np.array([np.nan, 1/2, 1/2, 7/16]),
-         np.array([np.nan, np.sqrt(0.25/6), np.sqrt(0.25/10), np.sqrt(63/256/16)]),
+         np.array([np.nan, 3.5/7, 5.5/11, 7.5/17]),
+         np.array([np.nan, np.sqrt(3.5**2/7**2/6), np.sqrt(5.5**2/11**2/10), np.sqrt(7.5*9.5/17**2/16)]),
          np.array([np.nan, 6, 10, 16]),
          ),
         (3,  # parents case
          2,
          np.array([3, 7, 9, 11]),
          np.array([5, 10, 15, 20]),
-         np.array([1.6/3, 1/2, 1/2, 7/16]),
-         np.array([np.sqrt(56/225/3), np.sqrt(0.25/6), np.sqrt(0.25/10), np.sqrt(63/256/16)]),
+         np.array([(1 + 0.6 + 0.5)/(2 + 1 + 1), 3.5/7, 5.5/11, 7.5/17]),
+         np.array([np.sqrt(2.1 * 1.9/4**2/3), np.sqrt(3.5**2/7**2/6), np.sqrt(5.5**2/11**2/10), np.sqrt(7.5*9.5/17**2/16)]),
          np.array([3, 6, 10, 16]),
          ),
     ])


### PR DESCRIPTION
### Description
We never added Jeffreys correction for Quidel which results in 0 se when val = 0. In order to avoid this case, we add Jeffreys correction to raw proportional estimates. 

### Changelog
Itemize code/test/documentation changes and files added/removed.
- update `raw_positive_prop()` in `data_tools.py`. The raw estimates are changed to be (count+0.5)/(total + 1). 
- update corresponding unit tests,

### Fixes 
- Fixes #255 
