### PR TITLE
Update makefiles to fix linting failures not failing

### DIFF
--- a/_delphi_utils_python/Makefile
+++ b/_delphi_utils_python/Makefile
@@ -11,9 +11,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/_delphi_utils_python/delphi_utils/export.py
+++ b/_delphi_utils_python/delphi_utils/export.py
@@ -66,5 +66,4 @@ def create_export_csv(
         if remove_null_samples:
             export_df = export_df[export_df["sample_size"].notnull()]
         export_df.to_csv(export_file, index=False, na_rep="NA")
-    
     return dates

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -306,7 +306,8 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         df = df.copy()
         from_col = from_code if from_col is None else from_col
         new_col = new_code if new_col is None else new_col
-        assert from_col != new_col, f"Can't use the same column '{from_col}' for both from_col and to_col"
+        assert from_col != new_col, \
+            f"Can't use the same column '{from_col}' for both from_col and to_col"
         state_codes = ["state_code", "state_id", "state_name"]
 
         if not is_string_dtype(df[from_col]):
@@ -325,7 +326,8 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
             return df
         elif new_code == "nation":
             raise ValueError(
-                f"Conversion to the nation level is not supported from {from_code}; try fips, zip, or state_*"
+                f"Conversion to the nation level is not supported "
+                f"from {from_code}; try fips, zip, or state_*"
             )
 
         # state codes are all stored in one table

--- a/_template_python/Makefile
+++ b/_template_python/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/cdc_covidnet/Makefile
+++ b/cdc_covidnet/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/changehc/Makefile
+++ b/changehc/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/changehc/delphi_changehc/run.py
+++ b/changehc/delphi_changehc/run.py
@@ -150,10 +150,9 @@ def run_module():
                 su_inst.update_sensor(
                     data,
                     params["export_dir"]
-                )            
+                )
             logger.info("finished processing", geo = geo)
-    
+
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
     logger.info("Completed indicator run",
         elapsed_time_in_seconds = elapsed_time_in_seconds)
-

--- a/claims_hosp/Makefile
+++ b/claims_hosp/Makefile
@@ -12,10 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir)
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/combo_cases_and_deaths/Makefile
+++ b/combo_cases_and_deaths/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -196,7 +196,7 @@ def run_module():
             df[df["timestamp"] == date_][["geo_id", "val", "se", "sample_size", ]].to_csv(
                 f"{export_dir}/{export_fn}", index=False, na_rep="NA"
             )
-    
+
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
     logger.info("Completed indicator run",
         elapsed_time_in_seconds = elapsed_time_in_seconds)

--- a/covid_act_now/Makefile
+++ b/covid_act_now/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/google_health/Makefile
+++ b/google_health/Makefile
@@ -12,8 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/google_symptoms/Makefile
+++ b/google_symptoms/Makefile
@@ -12,13 +12,11 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
-	. env/bin/activate ;\
-	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
+	. env/bin/activate ; (cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:
 	rm -rf env

--- a/google_symptoms/delphi_google_symptoms/run.py
+++ b/google_symptoms/delphi_google_symptoms/run.py
@@ -4,22 +4,22 @@
 This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m delphi_google_symptoms`.
 """
+import time
 from datetime import datetime
 from itertools import product
 
 import numpy as np
-import time
 from delphi_utils import (
-    read_params, 
-    create_export_csv, 
+    read_params,
+    create_export_csv,
     geomap,
     get_structured_logger
 )
 
-from .pull import pull_gs_data
-from .geo import geo_map
 from .constants import (METRICS, COMBINED_METRIC,
                         GEO_RESOLUTIONS, SMOOTHERS, SMOOTHERS_MAP)
+from .geo import geo_map
+from .pull import pull_gs_data
 
 
 def run_module():
@@ -66,7 +66,7 @@ def run_module():
                 metric=metric.lower(),
                 geo_res=geo_res,
                 sensor=sensor_name)
-            
+
             if not exported_csv_dates.empty:
                 csv_export_count += exported_csv_dates.size
                 if not oldest_final_export_date:

--- a/hhs_facilities/Makefile
+++ b/hhs_facilities/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/hhs_hosp/Makefile
+++ b/hhs_hosp/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/jhu/Makefile
+++ b/jhu/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/nchs_mortality/Makefile
+++ b/nchs_mortality/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/nowcast/Makefile
+++ b/nowcast/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir) --match-dir '(?!nowcast_fusion)'
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir) --match-dir '(?!nowcast_fusion)'
 
 test:
 	. env/bin/activate ;\

--- a/quidel/Makefile
+++ b/quidel/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/quidel/delphi_quidel/data_tools.py
+++ b/quidel/delphi_quidel/data_tools.py
@@ -6,7 +6,7 @@ import pandas as pd
 def _prop_var(p, n):
     """
     Calculate variance of proportion.
-    
+
     var(X/n) = 1/(n^2)var(X) = (npq)/(n^2) = pq/n
     """
     return p * (1 - p) / n
@@ -64,7 +64,7 @@ def _slide_window_sum(arr, k):
 
 def _geographical_pooling(tpooled_tests, tpooled_ptests, min_obs, max_borrow_obs):
     """
-    Calculate proportion of parent samples (tests) that must be "borrowed" in order to compute the statistic.
+    Calculate proportion of parent samples (tests) that must be "borrowed" to compute the statistic.
 
     If there are no samples available in the parent, the borrow_prop is 0.  If the parent does not
     have enough samples, we return a borrow_prop of 1, and the fact that the
@@ -119,7 +119,7 @@ def _geographical_pooling(tpooled_tests, tpooled_ptests, min_obs, max_borrow_obs
 
 def raw_positive_prop(positives, tests, min_obs):
     """
-    Calculate the proportion of positive tests for a single geographic location, without any temporal smoothing.
+    Calculate proportion of positive tests for a single location with no temporal smoothing.
 
     If on any day t, tests[t] < min_obs, then we report np.nan.
 
@@ -172,7 +172,7 @@ def raw_positive_prop(positives, tests, min_obs):
 def smoothed_positive_prop(positives, tests, min_obs, max_borrow_obs, pool_days,
                            parent_positives=None, parent_tests=None):
     """
-    Calculate the proportion of negative tests for a single geographic location, with temporal smoothing.
+    Calculate the proportion of negative tests for a single location with temporal smoothing.
 
     For a given day t, if sum(tests[(t-pool_days+1):(t+1)]) < min_obs, then we
     'borrow' min_obs - sum(tests[(t-pool_days+1):(t+1)]) observations from the
@@ -307,7 +307,7 @@ def raw_tests_per_device(devices, tests, min_obs):
 def smoothed_tests_per_device(devices, tests, min_obs, max_borrow_obs, pool_days,
                               parent_devices=None, parent_tests=None):
     """
-    Calculate the ratio of tests per device for a single geographic location, with temporal smoothing.
+    Calculate the ratio of tests per device for a single location with temporal smoothing.
 
     For a given day t, if sum(tests[(t-pool_days+1):(t+1)]) < min_obs, then we
     'borrow' min_obs - sum(tests[(t-pool_days+1):(t+1)]) observations from the

--- a/quidel/delphi_quidel/pull.py
+++ b/quidel/delphi_quidel/pull.py
@@ -62,7 +62,7 @@ def read_historical_data():
 
 def regulate_column_names(df, test_type):
     """
-    Regulate column names for flu_ag test data since Quidel changed their column names multiple times.
+    Regulate column names for flu_ag test data since Quidel changed the column names multiple times.
 
     We want to finalize the column name list to be:
         ['SofiaSerNum', 'TestDate', 'Facility',
@@ -311,7 +311,7 @@ def check_intermediate_file(cache_dir, pull_start_dates):
 
 def pull_quidel_data(params):
     """
-    Pull the quidel test data and decide whether to combine the new data with stored historical records in ./cache.
+    Pull new quidel test data and decide whether to combine it with historical records in ./cache.
 
     Parameters:
         params: dict
@@ -402,7 +402,10 @@ def check_export_end_date(input_export_end_dates, _end_date,
 def check_export_start_date(export_start_dates, export_end_dates,
                             export_day_range):
     """
-    Update export_start_date according to the export_end_date so that it could be export_end_date - EXPORT_DAY_RANGE.
+    Update export_start_date according to the export_end_date.
+
+    Update export_start_date according to the export_end_date so that
+    it could be export_end_date - EXPORT_DAY_RANGE.
 
     Parameters:
         export_start_date: dict

--- a/quidel/delphi_quidel/run.py
+++ b/quidel/delphi_quidel/run.py
@@ -4,10 +4,10 @@
 This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m MODULE_NAME`.
 """
+import time
 from os.path import join
 
 import pandas as pd
-import time
 from delphi_utils import (
     read_params,
     add_prefix,
@@ -15,15 +15,16 @@ from delphi_utils import (
     get_structured_logger
 )
 
+from .constants import (END_FROM_TODAY_MINUS, EXPORT_DAY_RANGE,
+                        GEO_RESOLUTIONS, SENSORS)
+from .generate_sensor import (generate_sensor_for_states,
+                              generate_sensor_for_other_geores)
 from .geo_maps import geo_map
 from .pull import (pull_quidel_data,
                    check_export_start_date,
                    check_export_end_date,
                    update_cache_file)
-from .generate_sensor import (generate_sensor_for_states,
-                              generate_sensor_for_other_geores)
-from .constants import (END_FROM_TODAY_MINUS, EXPORT_DAY_RANGE,
-                        GEO_RESOLUTIONS, SENSORS)
+
 
 def run_module():
     """Run Quidel flu test module."""

--- a/quidel_covidtest/Makefile
+++ b/quidel_covidtest/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -13,17 +13,18 @@ from delphi_utils import (
     get_structured_logger
 )
 
+from .constants import (END_FROM_TODAY_MINUS, EXPORT_DAY_RANGE,
+                        SMOOTHED_POSITIVE, RAW_POSITIVE,
+                        SMOOTHED_TEST_PER_DEVICE, RAW_TEST_PER_DEVICE,
+                        GEO_RESOLUTIONS, SENSORS, SMOOTHERS)
+from .generate_sensor import (generate_sensor_for_states,
+                              generate_sensor_for_other_geores)
 from .geo_maps import geo_map
 from .pull import (pull_quidel_covidtest,
                    check_export_start_date,
                    check_export_end_date,
                    update_cache_file)
-from .generate_sensor import (generate_sensor_for_states,
-                              generate_sensor_for_other_geores)
-from .constants import (END_FROM_TODAY_MINUS, EXPORT_DAY_RANGE,
-                        SMOOTHED_POSITIVE, RAW_POSITIVE,
-                        SMOOTHED_TEST_PER_DEVICE, RAW_TEST_PER_DEVICE,
-                        GEO_RESOLUTIONS, SENSORS, SMOOTHERS)
+
 
 def run_module():
     """Run the quidel_covidtest indicator."""

--- a/safegraph/Makefile
+++ b/safegraph/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/safegraph_patterns/Makefile
+++ b/safegraph_patterns/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/safegraph_patterns/delphi_safegraph_patterns/process.py
+++ b/safegraph_patterns/delphi_safegraph_patterns/process.py
@@ -114,7 +114,11 @@ def aggregate(df, metric, geo_res):
     gmpr = GeoMapper()
     geo_key = GEO_KEY_DICT[geo_res]
     df = gmpr.add_population_column(df, "zip")
-    df = gmpr.replace_geocode(df, "zip", geo_key, date_col="timestamp", data_cols=[metric_count_name, "population"])
+    df = gmpr.replace_geocode(df,
+                              "zip",
+                              geo_key,
+                              date_col="timestamp",
+                              data_cols=[metric_count_name, "population"])
 
     df[metric_prop_name] = df[metric_count_name] / df["population"] \
                             * INCIDENCE_BASE

--- a/sir_complainsalot/Makefile
+++ b/sir_complainsalot/Makefile
@@ -12,8 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\

--- a/usafacts/Makefile
+++ b/usafacts/Makefile
@@ -12,9 +12,8 @@ install: venv
 	pip install -e .
 
 lint:
-	. env/bin/activate; \
-	pylint $(dir); \
-	pydocstyle $(dir)
+	. env/bin/activate; pylint $(dir)
+	. env/bin/activate; pydocstyle $(dir)
 
 test:
 	. env/bin/activate ;\


### PR DESCRIPTION
### Description
See https://github.com/cmu-delphi/covidcast-indicators/pull/699#issuecomment-769932078. Having both lint commands run in the same line means that if the first fails but the second succeeds, the command exits with status code 0 and the CI passes. 

One thing we might experience is some existing PRs getting merged in that altered this code but dont pass linting, and we'll just have to fix them if they come up

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Update all makefiles to split command into 2 lines.
- Fix linting errors that snuck by.

### Fixes 
