### PR TITLE
Have replace_geocode ignore megafips populations

### DIFF
--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -424,9 +424,9 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
             df.loc[megafips_to_zero, "population"] = 0
             print(megafips_to_zero)
         if from_code == "fips" and not pop_col:
-            warnings.warn("Without specifying a population column, megaFIPS populations be double "
-                          "counted later on. If working with populations, add the FIPS column "
-                          "before replacing the geocode.")
+            warnings.warn("Without specifying a population column, megaFIPS populations may be "
+                          "double counted later on. If working with populations, add the FIPS "
+                          "column before replacing the geocode.")
         df = self.add_geocode(
             df, from_code, new_code, from_col=from_col, new_col=new_col, dropna=dropna
         ).drop(columns=from_col)

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -401,10 +401,13 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         date_col: str or None, default "date"
             Specify which column contains the date values. Used for value aggregation.
             If None, then the aggregation is done only on geo_id.
+        pop_col: str or None
+            Specify which columns contains population values. Used for correcting for double
+            counting if a megafips is present.
         data_cols: list, default None
             A list of data column names to aggregate when doing a weighted coding. If set to
             None, then all the columns are used except for date_col and new_col.
-        dropna: bool, default False
+        dropna: bool, default True
             Determines how the merge with the crosswalk file is done. If True, the join is inner,
             and if False, the join is left. The inner join will drop records from the input database
             that have no translation in the crosswalk, while the outer join will keep those records

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -428,8 +428,8 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
             df.loc[megafips_to_zero_mask, "population"] = 0
         if from_code == "fips" and not pop_col:
             warnings.warn("Without specifying a population column, megaFIPS populations may be "
-                          "double counted later on. If working with populations, add the population "
-                          "column before replacing the geocode.")
+                          "double counted later on. If working with populations, add the "
+                          "population column before replacing the geocode.")
         df = self.add_geocode(
             df, from_code, new_code, from_col=from_col, new_col=new_col, dropna=dropna
         ).drop(columns=from_col)

--- a/_delphi_utils_python/tests/test_geomap.py
+++ b/_delphi_utils_python/tests/test_geomap.py
@@ -315,13 +315,13 @@ class TestGeoMapper:
     def test_megafips_zeroed(self):
         gmpr = GeoMapper()
         pd.testing.assert_frame_equal(
-            gmpr.replace_geocode(self.fips_data_2, "fips", "state_id", pop_col="population"),
+            gmpr.replace_geocode(self.fips_data_2, "fips", "state_code", pop_col="population"),
             pd.DataFrame({
                 "date": [pd.Timestamp("2018-01-01")] * 4,
-                "state_id": ["ak", "al", "az", "in"],
-                "count": [21., 2., 6., 10026.],
-                "total": [401., 4., 20., 100011.],
-                "population": [2, 1, 7, 9]
+                "state_code": ["01", "02", "04", "18"],
+                "count": [2., 21., 6., 10026.],
+                "total": [4., 401., 20., 100011.],
+                "population": [1, 2, 7, 9]
             })
         )
         with pytest.warns(UserWarning):
@@ -331,4 +331,4 @@ class TestGeoMapper:
         gmpr = GeoMapper()
         test_fips_set = ["01001", "01003", "01000", "02000", "03001",
                          "04000", "04001", "05000", "06001", "06002"]
-        assert gmpr._megafips_to_zero(test_fips_set) == {"01000", "04000"}
+        assert gmpr._megafips_to_zero(test_fips_set) == {"01000", "03000", "04000", "06000"}

--- a/_delphi_utils_python/tests/test_geomap.py
+++ b/_delphi_utils_python/tests/test_geomap.py
@@ -324,6 +324,8 @@ class TestGeoMapper:
                 "population": [2, 1, 7, 9]
             })
         )
+        with pytest.warns(UserWarning):
+            gmpr.replace_geocode(self.fips_data_2, "fips", "state_id")
 
     def test__megafips_to_zero(self):
         gmpr = GeoMapper()

--- a/_delphi_utils_python/tests/test_geomap.py
+++ b/_delphi_utils_python/tests/test_geomap.py
@@ -17,10 +17,11 @@ class TestGeoMapper:
     )
     fips_data_2 = pd.DataFrame(
         {
-            "fips": ["01123", "02340", "02002", "18633", "18181"],
-            "date": [pd.Timestamp("2018-01-01")] * 5,
-            "count": [2, 1, 20, np.nan, 10021],
-            "total": [4, 1, 400, np.nan, 100001],
+            "fips": ["01123", "02122", "02000", "18023", "18025", "18000", "04000"],
+            "date": [pd.Timestamp("2018-01-01")] * 7,
+            "count": [2, 1, 20, np.nan, 10021, 5, 6],
+            "total": [4, 1, 400, np.nan, 100001, 10, 20],
+            "population": [1, 2, 3, 4, 5, 6, 7]
         }
     )
     fips_data_3 = pd.DataFrame(
@@ -252,7 +253,7 @@ class TestGeoMapper:
         )
 
         # hrr -> nation
-        with pytest.raises(ValueError):    
+        with pytest.raises(ValueError):
             new_data = gmpr.replace_geocode(self.zip_data, "zip", "hrr")
             new_data2 = gmpr.replace_geocode(new_data, "hrr", "nation")
 
@@ -310,3 +311,22 @@ class TestGeoMapper:
         assert len(gmpr.get_geo_values("fips")) == 3287
         assert len(gmpr.get_geo_values("state_id")) == 60
         assert len(gmpr.get_geo_values("zip")) == 32976
+
+    def test_megafips_zeroed(self):
+        gmpr = GeoMapper()
+        pd.testing.assert_frame_equal(
+            gmpr.replace_geocode(self.fips_data_2, "fips", "state_id", pop_col="population"),
+            pd.DataFrame({
+                "date": [pd.Timestamp("2018-01-01")] * 4,
+                "state_id": ["ak", "al", "az", "in"],
+                "count": [21., 2., 6., 10026.],
+                "total": [401., 4., 20., 100011.],
+                "population": [2, 1, 7, 9]
+            })
+        )
+
+    def test__megafips_to_zero(self):
+        gmpr = GeoMapper()
+        test_fips_set = ["01001", "01003", "01000", "02000", "03001",
+                         "04000", "04001", "05000", "06001", "06002"]
+        assert gmpr._megafips_to_zero(test_fips_set) == {"01000", "04000"}


### PR DESCRIPTION
### Description
See https://github.com/cmu-delphi/covidcast-indicators/issues/537#issuecomment-771299794

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add a population column arg to replace_geocode that will be used to null out megafips, with a warning thrown if it is not specified
- Add logic to only null the megafips population if there are other fips reported in that state
- unit tests and update docstrings. Also updated an unrelated docstring entry that was wrong.

### Fixes 
- Partially addresses #537 
