### PR TITLE
Replace JHU megafips zeroing logic with replace_geocode

### DIFF
--- a/jhu/delphi_jhu/geo.py
+++ b/jhu/delphi_jhu/geo.py
@@ -33,19 +33,15 @@ def geo_map(df: pd.DataFrame, geo_res: str):
 
     gmpr = GeoMapper()
     if geo_res == "county":
-        df.rename(columns={'fips': 'geo_id'}, inplace=True)
+        df.rename(columns={"fips": "geo_id"}, inplace=True)
     elif geo_res == "state":
-        df = df.set_index("fips")
-        # Zero out the state FIPS population to avoid double counting.
-        state_fips_codes = {str(x).zfill(2) + "000" for x in range(1,73)}
-        subset_state_fips_codes = set(df.index.values) & state_fips_codes
-        df.loc[subset_state_fips_codes, "population"] = 0
-        df = df.reset_index()
-        df = gmpr.replace_geocode(df, "fips", "state_id", new_col="geo_id", date_col="timestamp")
+        df = gmpr.replace_geocode(df, "fips", "state_id",
+                                  new_col="geo_id", date_col="timestamp", pop_col="population")
     else:
-        df = gmpr.replace_geocode(df, "fips", geo_res, new_col="geo_id", date_col="timestamp")
+        df = gmpr.replace_geocode(df, "fips", geo_res,
+                                  new_col="geo_id", date_col="timestamp", pop_col="population")
     df["incidence"] = df["new_counts"] / df["population"] * INCIDENCE_BASE
     df["cumulative_prop"] = df["cumulative_counts"] / df["population"] * INCIDENCE_BASE
-    df['new_counts'] = df['new_counts']
-    df['cumulative_counts'] = df['cumulative_counts']
+    df["new_counts"] = df["new_counts"]
+    df["cumulative_counts"] = df["cumulative_counts"]
     return df

--- a/jhu/tests/test_geo.py
+++ b/jhu/tests/test_geo.py
@@ -73,7 +73,7 @@ class TestGeoMap:
             test_df = jhu_confirmed_test_data
             new_df = geo_map(test_df, geo)
             gmpr = GeoMapper()
-            test_df = gmpr.replace_geocode(test_df, "fips", geo, date_col="timestamp")
+            test_df = gmpr.replace_geocode(test_df, "fips", geo, date_col="timestamp", pop_col="population")
 
             new_df = new_df.set_index(["geo_id", "timestamp"]).sort_index()
             test_df = test_df.set_index([geo, "timestamp"]).sort_index()
@@ -90,13 +90,9 @@ class TestGeoMap:
             assert not new_df["cumulative_prop"].eq(np.inf).any()
 
     def test_populations(self, jhu_confirmed_test_data):
-        gmpr = GeoMapper()
-        new_df = gmpr.replace_geocode(jhu_confirmed_test_data, "fips", "state_id",
-                                      date_col="timestamp", pop_col="population")
+        new_df = geo_map(jhu_confirmed_test_data, "state")
         assert new_df.loc[0, "population"] == 723231
-        new_df = gmpr.replace_geocode(jhu_confirmed_test_data, "fips", "hhs",
-                                      date_col="timestamp", pop_col="population")
+        new_df = geo_map(jhu_confirmed_test_data, "hhs")
         assert new_df.loc[0, "population"] == 14845063
-        new_df = gmpr.replace_geocode(jhu_confirmed_test_data, "fips", "nation",
-                                      date_col="timestamp", pop_col="population")
+        new_df = geo_map(jhu_confirmed_test_data, "nation")
         assert new_df.loc[0, "population"] == 331940098

--- a/jhu/tests/test_geo.py
+++ b/jhu/tests/test_geo.py
@@ -38,7 +38,7 @@ class TestGeoMap:
     def test_state(self, jhu_confirmed_test_data):
         df = jhu_confirmed_test_data
         new_df = geo_map(df, "state")
-        assert new_df.loc[0, "population"] == 723231
+
         gmpr = GeoMapper()
         test_df = gmpr.replace_geocode(df, "fips", "state_id", date_col="timestamp", new_col="state")
 
@@ -73,7 +73,7 @@ class TestGeoMap:
             test_df = jhu_confirmed_test_data
             new_df = geo_map(test_df, geo)
             gmpr = GeoMapper()
-            test_df = gmpr.replace_geocode(test_df, "fips", geo, date_col="timestamp", pop_col="population")
+            test_df = gmpr.replace_geocode(test_df, "fips", geo, date_col="timestamp")
 
             new_df = new_df.set_index(["geo_id", "timestamp"]).sort_index()
             test_df = test_df.set_index([geo, "timestamp"]).sort_index()

--- a/jhu/tests/test_geo.py
+++ b/jhu/tests/test_geo.py
@@ -38,7 +38,7 @@ class TestGeoMap:
     def test_state(self, jhu_confirmed_test_data):
         df = jhu_confirmed_test_data
         new_df = geo_map(df, "state")
-
+        assert new_df.loc[0, "population"] == 723231
         gmpr = GeoMapper()
         test_df = gmpr.replace_geocode(df, "fips", "state_id", date_col="timestamp", new_col="state")
 
@@ -73,7 +73,7 @@ class TestGeoMap:
             test_df = jhu_confirmed_test_data
             new_df = geo_map(test_df, geo)
             gmpr = GeoMapper()
-            test_df = gmpr.replace_geocode(test_df, "fips", geo, date_col="timestamp")
+            test_df = gmpr.replace_geocode(test_df, "fips", geo, date_col="timestamp", pop_col="population")
 
             new_df = new_df.set_index(["geo_id", "timestamp"]).sort_index()
             test_df = test_df.set_index([geo, "timestamp"]).sort_index()
@@ -88,3 +88,15 @@ class TestGeoMap:
             # Make sure the prop signals don't have inf values
             assert not new_df["incidence"].eq(np.inf).any()
             assert not new_df["cumulative_prop"].eq(np.inf).any()
+
+    def test_populations(self, jhu_confirmed_test_data):
+        gmpr = GeoMapper()
+        new_df = gmpr.replace_geocode(jhu_confirmed_test_data, "fips", "state_id",
+                                      date_col="timestamp", pop_col="population")
+        assert new_df.loc[0, "population"] == 723231
+        new_df = gmpr.replace_geocode(jhu_confirmed_test_data, "fips", "hhs",
+                                      date_col="timestamp", pop_col="population")
+        assert new_df.loc[0, "population"] == 14845063
+        new_df = gmpr.replace_geocode(jhu_confirmed_test_data, "fips", "nation",
+                                      date_col="timestamp", pop_col="population")
+        assert new_df.loc[0, "population"] == 331940098


### PR DESCRIPTION
### Description
Merge after #759.

Use the megafips zeroing logic in replace_geocode instead of in the JHU code. should also fix an hhs/nation bug where the megafips were double counted.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Delete old megafips zeroing logic and use replace_geocode instead
- Fixed some single/double quote disparities.
- Add tests for population, verified by manually doing the population computations on the test csv file.

### Fixes 
na