### PR TITLE
Move nowcast parameters to constants file and add placeholders

### DIFF
--- a/nowcast/delphi_nowcast/constants.py
+++ b/nowcast/delphi_nowcast/constants.py
@@ -18,4 +18,3 @@ AR_LAMBDA = 0.1
 # Regression Sensor parameters
 REG_SENSORS = [SensorConfig("placeholder", "placeholder", "placeholder", 0),]
 REG_INTERCEPT = True
-

--- a/nowcast/delphi_nowcast/constants.py
+++ b/nowcast/delphi_nowcast/constants.py
@@ -1,3 +1,21 @@
-"""Registry for signal names."""
+"""Registry for constants."""
+from .data_containers import SensorConfig
 
-SIGNALS = []
+
+# Ground truth parameters
+GROUND_TRUTH_INDICATOR = SensorConfig("placeholder", "placeholder", "placeholder", 0)
+
+# Delay distribution
+DELAY_DISTRIBUTION = []
+
+# Deconvolution parameters
+FIT_FUNC = "placeholder"
+
+# AR Sensor parameters
+AR_ORDER = 3
+AR_LAMBDA = 0.1
+
+# Regression Sensor parameters
+REG_SENSORS = [SensorConfig("placeholder", "placeholder", "placeholder", 0),]
+REG_INTERCEPT = True
+

--- a/nowcast/delphi_nowcast/sensorization/ar_model.py
+++ b/nowcast/delphi_nowcast/sensorization/ar_model.py
@@ -8,8 +8,8 @@ from ..data_containers import LocationSeries
 
 def compute_ar_sensor(day: date,
                       values: LocationSeries,
-                      ar_size: int = 3,
-                      lambda_: float = 0.1) -> float:
+                      ar_size: int,
+                      lambda_: float) -> float:
     """
     Fit AR model through least squares and get sensorization value for a given date.
 

--- a/nowcast/delphi_nowcast/sensorization/regression_model.py
+++ b/nowcast/delphi_nowcast/sensorization/regression_model.py
@@ -10,7 +10,7 @@ MIN_SAMPLE_SIZE = 5  # arbitrarily chosen for now.
 def compute_regression_sensor(day: date,
                               covariate: LocationSeries,
                               response: LocationSeries,
-                              include_intercept: bool = False) -> float:
+                              include_intercept: bool) -> float:
     """
     Fit regression model and get sensorization value for a given date.
 

--- a/nowcast/tests/sensorization/test_ar_model.py
+++ b/nowcast/tests/sensorization/test_ar_model.py
@@ -73,11 +73,11 @@ class TestComputeARSensor:
         values = LocationSeries(
             data={date(2020, 1, 1): -4.27815483, date(2020, 1, 2): -4.83962077}
         )
-        assert np.isnan(compute_ar_sensor(date(2020, 1, 2), values))
-        assert np.isnan(compute_ar_sensor(date(2020, 1, 7), values))
+        assert np.isnan(compute_ar_sensor(date(2020, 1, 2), values, 1, 0))
+        assert np.isnan(compute_ar_sensor(date(2020, 1, 7), values, 1, 0))
 
     def test_compute_ar_sensor_out_of_range(self):
         values = LocationSeries(
             data={date(2020, 1, 1): -4.27815483, date(2020, 1, 2): -4.83962077}
         )
-        assert np.isnan(compute_ar_sensor(date(2020, 1, 7), values))
+        assert np.isnan(compute_ar_sensor(date(2020, 1, 7), values, 1, 0))

--- a/nowcast/tests/sensorization/test_regression_model.py
+++ b/nowcast/tests/sensorization/test_regression_model.py
@@ -53,8 +53,8 @@ class TestComputeRegressionSensor:
                   date(2020, 1, 4): 29, date(2020, 1, 5): 28, date(2020, 1, 6): 35,
                   date(2020, 1, 7): 42}
         )
-        assert np.isnan(compute_regression_sensor(date(2020, 1, 1), test_covariate, test_response))
-        assert np.isnan(compute_regression_sensor(date(2020, 1, 6), test_covariate, test_response))
+        assert np.isnan(compute_regression_sensor(date(2020, 1, 1), test_covariate, test_response, False))
+        assert np.isnan(compute_regression_sensor(date(2020, 1, 6), test_covariate, test_response, False))
 
     def test_compute_regression_sensor_out_of_range(self):
         test_covariate = LocationSeries(
@@ -67,4 +67,4 @@ class TestComputeRegressionSensor:
                   date(2020, 1, 4): 29, date(2020, 1, 5): 28, date(2020, 1, 6): 35,
                   date(2020, 1, 7): 42}
         )
-        assert np.isnan(compute_regression_sensor(date(2020, 1, 16), test_covariate, test_response))
+        assert np.isnan(compute_regression_sensor(date(2020, 1, 16), test_covariate, test_response, False))

--- a/nowcast/tests/test_constants.py
+++ b/nowcast/tests/test_constants.py
@@ -1,0 +1,15 @@
+"""This test is to ensure the constants are not accidentally altered."""
+
+from delphi_nowcast import constants
+from delphi_nowcast.data_containers import SensorConfig
+
+
+def test_constants():
+    assert len(dir(constants)) == 16
+    assert constants.GROUND_TRUTH_INDICATOR == SensorConfig("placeholder", "placeholder", "placeholder", 0)
+    assert constants.DELAY_DISTRIBUTION == []
+    assert constants.FIT_FUNC == "placeholder"
+    assert constants.AR_ORDER == 3
+    assert constants.AR_LAMBDA == 0.1
+    assert constants.REG_SENSORS == [SensorConfig("placeholder", "placeholder", "placeholder", 0),]
+    assert constants.REG_INTERCEPT is True

--- a/nowcast/tests/test_constants.py
+++ b/nowcast/tests/test_constants.py
@@ -5,6 +5,12 @@ from delphi_nowcast.data_containers import SensorConfig
 
 
 def test_constants():
+    """If any of these tests fail, please verify that the constant changes are intended.
+
+    If any sensorization constants are changed, verify that you have updated the sensor name in
+    constants.py so you do not mix the newly configured sensor values with values from previous
+    configurations.
+    """
     assert len(dir(constants)) == 16
     assert constants.GROUND_TRUTH_INDICATOR == SensorConfig("placeholder", "placeholder", "placeholder", 0)
     assert constants.DELAY_DISTRIBUTION == []


### PR DESCRIPTION
### Description
Moving relevant constants for nowcasting to their own file and adding a test that duplicates each value and will fail if any are changed. This is to ensure changes to parameters are done explicitely. Values are placeholders for now.

cc @mariajahja 

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add parameters to a constants files and use them instead of function default parameters
- update tests to reflect lack of default constants
- Change export_data bool to export_dir string to prepare for putting export _dir into the params file and passing it in after read_params() is called.


