### PR TITLE
Add item V2 (# vaccine doses) to pipeline

### DIFF
--- a/facebook/delphiFacebook/R/binary.R
+++ b/facebook/delphiFacebook/R/binary.R
@@ -75,6 +75,8 @@ get_binary_indicators <- function() {
     "smoothed_wcovid_vaccinated", "weight", "v_covid_vaccinated", 6, compute_binary_response, jeffreys_binary,
     "smoothed_worried_vaccine_side_effects", "weight_unif", "v_worried_vaccine_side_effects", 6, compute_binary_response, jeffreys_binary,
     "smoothed_wworried_vaccine_side_effects", "weight", "v_worried_vaccine_side_effects", 6, compute_binary_response, jeffreys_binary,
+    "smoothed_received_2_vaccine_doses", "weight_unif", "v_received_2_vaccine_doses", 6, compute_binary_response, jeffreys_binary,
+    "smoothed_wreceived_2_vaccine_doses", "weight", "v_received_2_vaccine_doses", 6, compute_binary_response, jeffreys_binary,
 
     # who would make more likely to accept vaccine
     "smoothed_vaccine_likely_friends", "weight_unif", "v_vaccine_likely_friends", 6, compute_binary_response, jeffreys_binary,

--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -238,6 +238,18 @@ code_vaccines <- function(input_data) {
   } else {
     input_data$v_covid_vaccinated <- NA_real_
   }
+  
+  if ("V2" %in% names(input_data)) {
+    # coded as 1 = 1 dose/vaccination, 2 = 2 doses, 3 = don't know.
+    input_data$v_received_2_vaccine_doses <- case_when(
+      input_data$V1 == 1 ~ 0,
+      input_data$V1 == 2 ~ 1,
+      input_data$V1 == 3 ~ NA_real_,
+      TRUE ~ NA_real_
+    )
+  } else {
+    input_data$v_received_2_vaccine_doses <- NA_real_
+  }
 
   if ("V3" %in% names(input_data)) {
     input_data$v_accept_covid_vaccine <- (


### PR DESCRIPTION
### Description
Add item V2 to pipeline as percent of respondents who have received 2 doses; respondents reporting receiving 1 dose are included in the denominator. "I don't know"s are rare (0.3-0.4% of responses) and are ignored for this calculation.