### PR TITLE
Remote USAFacts NY dummy row

### DIFF
--- a/usafacts/delphi_usafacts/pull.py
+++ b/usafacts/delphi_usafacts/pull.py
@@ -87,7 +87,6 @@ def pull_usafacts_data(base_url: str, metric: str, geo_mapper: GeoMapper) -> pd.
     # in the call to `add_population_column()`.  We pull it out here to
     # reinsert it after the population data is added.
     nyc_dummy_row = df[df["fips"] == "00001"]
-    assert len(nyc_dummy_row) == 1
 
     # Merge in population LOWERCASE, consistent across confirmed and deaths
     # Population for unassigned cases/deaths is NAN


### PR DESCRIPTION
### Description
This assertion no longer needs to be met since USAFacts does not report this row. Did not entirely remove the logic in case it ever comes back.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Delete assertion for presence of nyc dummy row

### Fixes 
- Fixes #773 
