### PR TITLE
delphi_utils: Add filesystem differ

### DIFF
--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -607,7 +607,8 @@ class FilesystemArchiveDiffer(ArchiveDiffer):
             fails: Empty list
         """
         self._exports_archived = True
-        return exported_files,[]
+        return exported_files, []
+
     def update_cache(self):
         """Handle cache updates with a no-op.
 
@@ -641,9 +642,9 @@ if __name__ == "__main__":
     run_module(args.archive_type,
                params["cache_dir"],
                params["export_dir"],
-               aws_credentials=params.get("aws_credentials",{}),
+               aws_credentials=params.get("aws_credentials", {}),
                branch_name=args.branch_name,
-               bucket_name=params.get("bucket_name",""),
+               bucket_name=params.get("bucket_name", ""),
                commit_message=args.commit_message,
                commit_partial_success=args.commit_partial_success,
                indicator_prefix=args.indicator_prefix,

--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -580,10 +580,41 @@ class GitArchiveDiffer(ArchiveDiffer):
         return archive_success, archive_fail
 
 class FilesystemArchiveDiffer(ArchiveDiffer):
+    """Filesystem-based backend for archiving.
+
+    This backend is only intended for use to reconstruct historical issues whose
+    versioning history has already been tracked elsewhere. No versioning is
+    performed by this backend and the cache directory is modified in-place
+    without backups. Do not use it for new issues.
+    """
+
     def archive_exports(self, exported_files):
+        """Handle file archiving with a no-op.
+
+        FilesystemArchiveDiffer does not track versioning information, so this
+        just does enough to convince the caller that it's okay to proceed with
+        the next step.
+
+        Parameters
+        ----------
+        exported_files: Files
+            List of files to be archived. Usually new and changed files.
+
+        Returns
+        -------
+        (successes, fails): Tuple[Files, Files]
+            successes: All files from input
+            fails: Empty list
+        """
         self._exports_archived = True
         return exported_files,[]
     def update_cache(self):
+        """Handle cache updates with a no-op.
+
+        FilesystemArchiveDiffer does not track versioning information, so this
+        just does enough to convince the caller that it's okay to proceed with
+        the next step.
+        """
         self._cache_updated = True
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
The existing archive differ does two things:
1. compare new indicator output to a cache, and reduce the output to include only new or modified files and rows
2. version the cache using git or s3

For repairs like the one we're doing for covidcast running out of integers, we just need to figure out what diffs were submitted  during the outage period given two successive cache images. We don't care about versioning here, we just need task (1).

This PR implements a filesystem-based archive differ that compares the output directory with the cache directory, updates the cache in place, and converts the output to a diff. No versioning is done by this implementation, so it's meant only to be used to reproduce historical issues where the version history is already tracked elsewhere.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- archive.py - new subclass of ArchiveDiffer

### Fixes 
- Tool for making repairs to issues skipped during the ran-out-of-integers outage
