### PR TITLE
Remove wip from nchs signal names

### DIFF
--- a/nchs_mortality/delphi_nchs_mortality/run.py
+++ b/nchs_mortality/delphi_nchs_mortality/run.py
@@ -57,7 +57,7 @@ def run_module():
             df["se"] = np.nan
             df["sample_size"] = np.nan
             df = df[~df["val"].isnull()]
-            sensor_name = "_".join(["wip", SENSOR_NAME_MAP[metric]])
+            sensor_name = "_".join([SENSOR_NAME_MAP[metric]])
             export_csv(
                 df,
                 geo_name=GEO_RES,
@@ -76,7 +76,7 @@ def run_module():
                 df["se"] = np.nan
                 df["sample_size"] = np.nan
                 df = df[~df["val"].isnull()]
-                sensor_name = "_".join(["wip", SENSOR_NAME_MAP[metric], sensor])
+                sensor_name = "_".join([SENSOR_NAME_MAP[metric], sensor])
                 export_csv(
                     df,
                     geo_name=GEO_RES,

--- a/nchs_mortality/tests/test_run.py
+++ b/nchs_mortality/tests/test_run.py
@@ -41,11 +41,11 @@ class TestRun:
             for date in dates:
                 for metric in metrics:
                     if metric == "deaths_percent_of_expected":
-                        expected_files += ["weekly_" + date + "_state_wip_" \
+                        expected_files += ["weekly_" + date + "_state_" \
                                            + metric + ".csv"]
                     else:
                         for sensor in sensors:
-                            expected_files += ["weekly_" + date + "_state_wip_" \
+                            expected_files += ["weekly_" + date + "_state_" \
                                                + metric + "_" + sensor + ".csv"]
             assert set(expected_files).issubset(set(csv_files))
 
@@ -59,6 +59,6 @@ class TestRun:
 
         for output_folder in folders:
             df = pd.read_csv(
-                join(output_folder, "weekly_202026_state_wip_deaths_covid_incidence_prop.csv")
+                join(output_folder, "weekly_202026_state_deaths_covid_incidence_prop.csv")
             )
             assert (df.columns.values == ["geo_id", "val", "se", "sample_size"]).all()


### PR DESCRIPTION
### Description
NCHS signals were still erroneously designated as wips.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Remove "wip" from signal names and update tests

### Fixes 
- Fixes #772 
