### PR TITLE
Use 7 decimals of precision for value and se floats

### DIFF
--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -75,10 +75,10 @@ def diff_export_csv(
 
     before_df = pd.read_csv(before_csv, dtype=export_csv_dtypes)
     before_df.set_index("geo_id", inplace=True)
-
+    before_df = before_df.round(7)
     after_df = pd.read_csv(after_csv, dtype=export_csv_dtypes)
     after_df.set_index("geo_id", inplace=True)
-
+    after_df = after_df.round(7)
     deleted_idx = before_df.index.difference(after_df.index)
     common_idx = before_df.index.intersection(after_df.index)
     added_idx = after_df.index.difference(before_df.index)

--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -54,6 +54,8 @@ def diff_export_csv(
     """
     Find differences in exported covidcast CSVs, using geo_id as the index.
 
+    The signal and standard error values are rounded to 7 decimal places before comparison.
+
     Treats NA == NA as True.
 
     Parameters
@@ -75,10 +77,10 @@ def diff_export_csv(
 
     before_df = pd.read_csv(before_csv, dtype=export_csv_dtypes)
     before_df.set_index("geo_id", inplace=True)
-    before_df = before_df.round(7)
+    before_df = before_df.round({"val": 7, "se": 7})
     after_df = pd.read_csv(after_csv, dtype=export_csv_dtypes)
     after_df.set_index("geo_id", inplace=True)
-    after_df = after_df.round(7)
+    after_df = after_df.round({"val": 7, "se": 7})
     deleted_idx = before_df.index.difference(after_df.index)
     common_idx = before_df.index.intersection(after_df.index)
     added_idx = after_df.index.difference(before_df.index)

--- a/_delphi_utils_python/delphi_utils/export.py
+++ b/_delphi_utils_python/delphi_utils/export.py
@@ -65,6 +65,6 @@ def create_export_csv(
         export_df = df[df["timestamp"] == date][["geo_id", "val", "se", "sample_size",]]
         if remove_null_samples:
             export_df = export_df[export_df["sample_size"].notnull()]
-        export_df.round({"val": 7, "se": 7})
+        export_df = export_df.round({"val": 7, "se": 7})
         export_df.to_csv(export_file, index=False, na_rep="NA")
     return dates

--- a/_delphi_utils_python/delphi_utils/export.py
+++ b/_delphi_utils_python/delphi_utils/export.py
@@ -65,5 +65,6 @@ def create_export_csv(
         export_df = df[df["timestamp"] == date][["geo_id", "val", "se", "sample_size",]]
         if remove_null_samples:
             export_df = export_df[export_df["sample_size"].notnull()]
+        export_df.round({"val": 7, "se": 7})
         export_df.to_csv(export_file, index=False, na_rep="NA")
     return dates

--- a/_delphi_utils_python/delphi_utils/export.py
+++ b/_delphi_utils_python/delphi_utils/export.py
@@ -19,6 +19,8 @@ def create_export_csv(
 ):
     """Export data in the format expected by the Delphi API.
 
+    This function will round the signal and standard error values to 7 decimals places.
+
     Parameters
     ----------
     df: pd.DataFrame

--- a/_delphi_utils_python/tests/test_archive.py
+++ b/_delphi_utils_python/tests/test_archive.py
@@ -19,14 +19,14 @@ CSVS_BEFORE = {
     # Common
     "csv0": pd.DataFrame({
         "geo_id": ["1", "2", "3"],
-        "val": [1.0, 2.0, 3.0],
+        "val": [1.000000001, 2.00000002, 3.00000003],
         "se": [0.1, 0.2, 0.3],
         "sample_size": [10.0, 20.0, 30.0]}),
 
     "csv1": pd.DataFrame({
         "geo_id": ["1", "2", "3"],
         "val": [1.0, 2.0, 3.0],
-        "se": [np.nan, 0.2, 0.3],
+        "se": [np.nan, 0.20000002, 0.30000003],
         "sample_size": [10.0, 20.0, 30.0]}),
 
     # Deleted
@@ -42,7 +42,7 @@ CSVS_AFTER = {
     "csv0": pd.DataFrame({
         "geo_id": ["1", "2", "3"],
         "val": [1.0, 2.0, 3.0],
-        "se": [0.1, 0.2, 0.3],
+        "se": [0.10000001, 0.20000002, 0.30000003],
         "sample_size": [10.0, 20.0, 30.0]}),
 
     "csv1": pd.DataFrame({
@@ -54,7 +54,7 @@ CSVS_AFTER = {
     # Added
     "csv3": pd.DataFrame({
         "geo_id": ["2"],
-        "val": [2.0],
+        "val": [2.0000002],
         "se": [0.2],
         "sample_size": [20.0]}),
 }

--- a/_delphi_utils_python/tests/test_export.py
+++ b/_delphi_utils_python/tests/test_export.py
@@ -37,7 +37,7 @@ class TestExport:
         {
             "geo_id": ["51093", "51175", "51175", "51620"],
             "timestamp": TIMES,
-            "val": [3.6, 2.1, 2.2, 2.6],
+            "val": [3.12345678910, 2.1, 2.2, 2.6],
             "se": [0.15, 0.22, 0.20, 0.34],
             "sample_size": [100, 100, 101, 100],
         }
@@ -67,6 +67,28 @@ class TestExport:
                 "20200301_county_deaths_test.csv",
                 "20200315_county_deaths_test.csv",
             ]
+        )
+
+    def test_export_rounding(self):
+        """Test that exporting CSVs with the `metrics` argument yields the correct files."""
+
+        # Clean receiving directory
+        _clean_directory(self.TEST_DIR)
+
+        create_export_csv(
+            df=self.DF,
+            start_date=datetime.strptime("2020-02-15", "%Y-%m-%d"),
+            export_dir=self.TEST_DIR,
+            metric="deaths",
+            geo_res="county",
+            sensor="test",
+        )
+        pd.testing.assert_frame_equal(
+            pd.read_csv(join(self.TEST_DIR, "20200215_county_deaths_test.csv")),
+            pd.DataFrame({"geo_id": [51093, 51175],
+                          "val": [round(3.12345678910, 7), 2.1],
+                          "se": [0.15, 0.22],
+                          "sample_size": [100, 100]})
         )
 
     def test_export_without_metric(self):


### PR DESCRIPTION
### Description
See #769. Convert export and archive differ to round values and standard errors to 7 decimals. 

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add rounding just before csv export
- Add rounding to archive differ comparison
- Unit tests

### Fixes 
- Fixes #769 