### PR TITLE
HHS Hosp: Have last date range get ignored if no epidata

### DIFF
--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -75,8 +75,11 @@ def run_module():
     dfs = []
     for r in date_range:
         response = Epidata.covid_hosp(request_all_states, r)
-        if response['result'] != 1:
+        # The last date range might only have recent days that don't have any data, so don't error.
+        if response["result"] != 1 and r != date_range[-1]:
             raise Exception(f"Bad result from Epidata: {response['message']}")
+        if response["result"] == -2 and r == date_range[-1]:
+            continue
         dfs.append(pd.DataFrame(response['epidata']))
     all_columns = pd.concat(dfs)
 
@@ -96,7 +99,6 @@ def run_module():
 
 def make_geo(state, geo, geo_mapper):
     """Transform incoming geo (state) to another geo."""
-    exported = None
     if geo == "state":
         exported = state.rename(columns={"state":"geo_id"})
     else:

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -78,7 +78,7 @@ def run_module():
         # The last date range might only have recent days that don't have any data, so don't error.
         if response["result"] != 1 and r != date_range[-1]:
             raise Exception(f"Bad result from Epidata: {response['message']}")
-        if response["result"] == -2 and r == date_range[-1]:
+        if response["result"] == -2 and r == date_range[-1]:  # -2 code means no results
             continue
         dfs.append(pd.DataFrame(response['epidata']))
     all_columns = pd.concat(dfs)

--- a/hhs_hosp/setup.py
+++ b/hhs_hosp/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "freezegun",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/hhs_hosp/tests/test_run.py
+++ b/hhs_hosp/tests/test_run.py
@@ -1,9 +1,11 @@
 from datetime import datetime, date
+from unittest.mock import patch
 
 from delphi_hhs.run import _date_to_int, int_date_to_previous_day_datetime, generate_date_ranges, \
-    make_signal, make_geo
+    make_signal, make_geo, run_module
 from delphi_hhs.constants import CONFIRMED, SUM_CONF_SUSP
 from delphi_utils.geomap import GeoMapper
+from freezegun import freeze_time
 import numpy as np
 import pandas as pd
 import pytest
@@ -104,4 +106,23 @@ def test_make_geo():
         for series in ["geo_id", "timestamp", "val", "se", "sample_size"]:
             pd.testing.assert_series_equal(expected[series], result[series], obj=f"{geo}:{series}")
 
-    
+
+@freeze_time("2020-02-03")
+@patch("delphi_hhs.run.create_export_csv")
+@patch("delphi_epidata.Epidata.covid_hosp")
+def test_ignore_last_range_no_results(mock_covid_hosp, mock_export):
+    mock_covid_hosp.side_effect = [
+        {"result": 1,
+         "epidata":
+             {"state": ["placeholder"],
+              "date": ["20200101"],
+              "previous_day_admission_adult_covid_confirmed": [0],
+              "previous_day_admission_adult_covid_suspected": [0],
+              "previous_day_admission_pediatric_covid_confirmed": [0],
+              "previous_day_admission_pediatric_covid_suspected": [0]
+              }
+         },
+        {"result": -2, "message": "no results"}
+    ]
+    mock_export.return_value = None
+    assert not run_module()  # function should not raise value error and has no return value


### PR DESCRIPTION
### Description
For HHS Hosp, to ensure the Epidata calls do not hit the row limit, windows of data are retrieved sequentually. For example, to get data from 2020/11/6 to 2021/2/8, the following ranges are queried:
```
 {'from': 20201106, 'to': 20201206},
 {'from': 20201207, 'to': 20210106},
 {'from': 20210107, 'to': 20210206},
 {'from': 20210207, 'to': 20210208}
```

This last date range may be anywhere from 1-30 days, and if it is a short range it will be recent enough such that the entire range returns no results and the indicator errors. This PR adds a statement to not throw an error if that is the case.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add conditional statement to ignore a "no results" output if the date range is the last one.
- Add unit test
- Removed an unused variable I stumbled upon

### Fixes 
- Fixes #(issue)
