### PR TITLE
Add parsing for - delimited dates

### DIFF
--- a/usafacts/delphi_usafacts/pull.py
+++ b/usafacts/delphi_usafacts/pull.py
@@ -108,7 +108,8 @@ def pull_usafacts_data(base_url: str, metric: str, geo_mapper: GeoMapper) -> pd.
         columns.remove("fips")
         columns.remove("population")
         # Detects whether there is a non-date string column -- not perfect
-        _ = [int(x.replace("/", "")) for x in columns]
+        # USAFacts has used both / and -, so account for both cases.
+        _ = [int(x.replace("/", "").replace("-", "")) for x in columns]
     except ValueError as e:
         raise ValueError(
             "Detected unexpected column(s) "

--- a/usafacts/tests/test_data/small_deaths.csv
+++ b/usafacts/tests/test_data/small_deaths.csv
@@ -1,4 +1,4 @@
-countyFIPS,County Name,State,stateFIPS,2/29/20,3/1/20,3/2/20,3/3/20,3/4/20,3/5/20,3/6/20,3/7/20,3/8/20,3/9/20,3/10/20
+countyFIPS,County Name,State,stateFIPS,2-29-20,3-1-20,3-2-20,3-3-20,3-4-20,3-5-20,3-6-20,3-7-20,3-8-20,3-9-20,3-10-20
 1041,Crenshaw County,AL,1,0,0,0,0,0,0,0,0,0,0,0
 1067,Henry County,AL,1,0,0,0,0,0,0,0,0,0,0,0
 2158,Kusilvak Census Area,AK,2,0,0,0,0,0,0,0,0,0,0,0


### PR DESCRIPTION
### Description
USAFacts switched up their date separators :/. Adding a statement that works for both `/` and `-`
 
### Changelog
Itemize code/test/documentation changes and files added/removed.
- Have `-` be stripped from column names during check on top of `/`
- Change one test dataset to use `-`

### Fixes 
- Fixes #(issue)
