### PR TITLE
Add empty array check to USAFacts disbursal

### DIFF
--- a/usafacts/delphi_usafacts/geo.py
+++ b/usafacts/delphi_usafacts/geo.py
@@ -54,8 +54,9 @@ def disburse(df: pd.DataFrame, pooled_fips: str, fips_list: list):
     for col in cols:
         # Get values from the aggregated county:
         vals = df.loc[df["fips"] == pooled_fips, col].values / len(fips_list)
-        for fips in fips_list:
-            df.loc[df["fips"] == fips, col] += vals
+        if len(vals) > 0:
+            for fips in fips_list:
+                df.loc[df["fips"] == fips, col] += vals
     return df
 
 

--- a/usafacts/tests/test_data/small_confirmed.csv
+++ b/usafacts/tests/test_data/small_confirmed.csv
@@ -72,7 +72,6 @@ countyFIPS,County Name,State,stateFIPS,2/29/20,3/1/20,3/2/20,3/3/20,3/4/20,3/5/2
 32510,Carson City,NV,32,0,0,0,0,0,0,0,0,0,0,0
 33003,Carroll County,NH,33,0,0,0,0,0,0,0,0,0,0,0
 35045,San Juan County,NM,35,0,0,0,0,0,0,0,0,0,0,0
-1,New York City Unallocated/Probable,NY,36,0,0,0,0,0,0,0,0,0,0,0
 36005,Bronx County,NY,36,0,0,0,0,0,0,0,0,1,2,3
 36009,Cattaraugus County,NY,36,0,0,0,0,0,0,0,0,0,0,0
 36035,Fulton County,NY,36,0,0,0,0,0,0,0,0,0,0,0

--- a/usafacts/tests/test_geo.py
+++ b/usafacts/tests/test_geo.py
@@ -123,8 +123,8 @@ class TestGeoMap:
             pd.DataFrame({
                 "geo_id": ["31420", "49340"],
                 "timestamp": ["2020-02-15"]*2,
-                "new_counts": [2.0, 13.0],
-                "cumulative_counts": [45.0, 60.0],
+                "new_counts": [2, 13],
+                "cumulative_counts": [45, 60],
                 "population": [300, 25],
                 "incidence": [666.66667, 52000.0],
                 "cumulative_prop": [15000.0, 240000.0]
@@ -137,8 +137,8 @@ class TestGeoMap:
             pd.DataFrame({
                 "geo_id": ["1", "4"],
                 "timestamp": ["2020-02-15"]*2,
-                "new_counts": [13.0, 27.0],
-                "cumulative_counts": [60.0, 165.0],
+                "new_counts": [13, 27],
+                "cumulative_counts": [60, 165],
                 "population": [25, 2500],
                 "incidence": [52000.0, 1080.0],
                 "cumulative_prop": [240000.0, 6600.0]
@@ -151,8 +151,8 @@ class TestGeoMap:
             pd.DataFrame({
                 "geo_id": ["us"],
                 "timestamp": ["2020-02-15"],
-                "new_counts": [40.0],
-                "cumulative_counts": [225.0],
+                "new_counts": [40],
+                "cumulative_counts": [225],
                 "population": [2525],
                 "incidence": [1584.15842],
                 "cumulative_prop": [8910.89109]


### PR DESCRIPTION
### Description
After #774, a bug was introduced where if non nyc row occurred, you'd end up with a 0 length array and it would throw an error when trying to add it to something else. This was not caught by tests since the test data always had the nyc row.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Skip the NYC disbursal if there are no values to disburse.
- Remove the NYC row from one of the test files. I've verified this causes tests to fail on main. Some of the test assertions were also updated from float -> int since the disbursal wasn't happening anymore, so the original ints stayed the same type.

### Fixes 
- Fixes #(issue)
