### PR TITLE
Lowercase column names in USAFacts data

### DIFF
--- a/usafacts/delphi_usafacts/pull.py
+++ b/usafacts/delphi_usafacts/pull.py
@@ -6,10 +6,10 @@ from delphi_utils import GeoMapper
 
 # Columns to drop the the data frame.
 DROP_COLUMNS = [
-    "FIPS",
-    "County Name",
-    "State",
-    "stateFIPS"
+    "countyfips",
+    "county name",
+    "state",
+    "statefips"
 ]
 
 
@@ -54,12 +54,13 @@ def pull_usafacts_data(base_url: str, metric: str, geo_mapper: GeoMapper) -> pd.
         Dataframe as described above.
     """
     # Read data
-    df = pd.read_csv(base_url.format(metric=metric)).rename({"countyFIPS":"FIPS"}, axis=1)
+    df = pd.read_csv(base_url.format(metric=metric))
+    df.columns = [i.lower() for i in df.columns]
     # Clean commas in count fields in case the input file included them
     df[df.columns[4:]] = df[df.columns[4:]].applymap(
         lambda x: int(x.replace(",", "")) if isinstance(x, str) else x)
     # Check missing FIPS
-    null_mask = pd.isnull(df["FIPS"])
+    null_mask = pd.isnull(df["countyfips"])
     assert null_mask.sum() == 0
 
     unexpected_columns = [x for x in df.columns if "Unnamed" in x]
@@ -71,16 +72,16 @@ def pull_usafacts_data(base_url: str, metric: str, geo_mapper: GeoMapper) -> pd.
 
     # Ignore Grand Princess Cruise Ship and Wade Hampton Census Area in AK
     df = df[
-        (df["FIPS"] != 6000)
-        & (df["FIPS"] != 2270)
+        (df["countyfips"] != 6000)
+        & (df["countyfips"] != 2270)
     ]
 
     # Change FIPS from 0 to XX000 for statewise unallocated cases/deaths
-    unassigned_index = (df['FIPS'] == 0)
-    df.loc[unassigned_index, "FIPS"] = df["stateFIPS"].loc[unassigned_index].values * 1000
+    unassigned_index = (df["countyfips"] == 0)
+    df.loc[unassigned_index, "countyfips"] = df["statefips"].loc[unassigned_index].values * 1000
 
     # Conform FIPS
-    df["fips"] = df["FIPS"].apply(lambda x: f"{int(x):05d}")
+    df["fips"] = df["countyfips"].apply(lambda x: f"{int(x):05d}")
 
     # The FIPS code 00001 is a dummy for unallocated NYC data.  It doesn't have
     # a corresponding population entry in the GeoMapper so it will be dropped

--- a/usafacts/tests/test_data/small_confirmed.csv
+++ b/usafacts/tests/test_data/small_confirmed.csv
@@ -1,4 +1,4 @@
-countyFIPS,County Name,State,stateFIPS,2/29/20,3/1/20,3/2/20,3/3/20,3/4/20,3/5/20,3/6/20,3/7/20,3/8/20,3/9/20,3/10/20
+countyFIPS,County Name,State,StateFIPS,2/29/20,3/1/20,3/2/20,3/3/20,3/4/20,3/5/20,3/6/20,3/7/20,3/8/20,3/9/20,3/10/20
 1041,Crenshaw County,AL,1,0,0,0,0,0,0,0,0,0,0,0
 1067,Henry County,AL,1,0,0,0,0,0,0,0,0,0,0,0
 2158,Kusilvak Census Area,AK,2,0,0,0,0,0,0,0,0,0,0,0


### PR DESCRIPTION
### Description
[Sigh](https://delphi-org.slack.com/archives/C0130CSQRN3/p1612892460049100?thread_ts=1612557010.031300&cid=C0130CSQRN3)

Verified that the indicator ran fine (minus archive differ)

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Lowercase the df column names in usafacts and update relevant constants.
- Removed a rename that wasn't that necessary
- change one test file with new casing.

### Fixes 
- Fixes #(issue)
