### PR TITLE
CAN PCR Total Tests

### DIFF
--- a/covid_act_now/delphi_covid_act_now/constants.py
+++ b/covid_act_now/delphi_covid_act_now/constants.py
@@ -11,4 +11,5 @@ GEO_RESOLUTIONS = [
 
 SIGNALS = [
     "pcr_specimen_positivity_rate",
+    "pcr_specimen_total_tests",
 ]

--- a/covid_act_now/delphi_covid_act_now/run.py
+++ b/covid_act_now/delphi_covid_act_now/run.py
@@ -5,6 +5,8 @@ This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m delphi_covid_act_now`.
 """
 
+import numpy as np
+
 from delphi_utils import (
     read_params,
     create_export_csv,
@@ -43,14 +45,22 @@ def run_module():
         print(f"Processing {geo_res}")
         df = geo_map(df_county_testing, geo_res)
 
-        # Only 1 signal for now
-        signal = SIGNALS[0]
-
+        # Export 'pcr_specimen_positivity_rate'
         exported_csv_dates = create_export_csv(
             df,
             export_dir=export_dir,
             geo_res=geo_res,
-            sensor=signal)
+            sensor=SIGNALS[0])
+
+        # Export 'pcr_specimen_total_tests'
+        df["val"] = df["sample_size"]
+        df["sample_size"] = np.nan
+        df["se"] = np.nan
+        exported_csv_dates = create_export_csv(
+            df,
+            export_dir=export_dir,
+            geo_res=geo_res,
+            sensor=SIGNALS[1])
 
         earliest, latest = min(exported_csv_dates), max(exported_csv_dates)
         print(f"Exported dates: {earliest} to {latest}")

--- a/covid_act_now/tests/test_run.py
+++ b/covid_act_now/tests/test_run.py
@@ -4,16 +4,17 @@ from os.path import join
 import pandas as pd
 import pytest
 
-from delphi_covid_act_now.constants import GEO_RESOLUTIONS
+from delphi_covid_act_now.constants import GEO_RESOLUTIONS, SIGNALS
 
 class TestRun:
     def test_output_files(self, run_as_module):
         csv_files = set(listdir("receiving"))
         csv_files.discard(".gitignore")
 
-        expected_files = {
-            f"20210101_{geo}_pcr_specimen_positivity_rate.csv"
-            for geo in GEO_RESOLUTIONS}
+        expected_files = set()
+        for signal in SIGNALS:
+            for geo in GEO_RESOLUTIONS:
+                expected_files.add(f"20210101_{geo}_{signal}.csv")
 
         # All output files exist
         assert csv_files == expected_files


### PR DESCRIPTION
### Description
Adds `pcr_specimen_total_tests` as its own signal for the COVID Act Now indicator.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- `delphi_covid_act_now/constants.py`: Add new signal name
- `delphi_covid_act_now/run.py`: Export the new signal
- `tests/test_run.py`: Update tests to check for new signal export
