### PR TITLE
CAN update parquet file URL

### DIFF
--- a/ansible/templates/covid_act_now-params-prod.json.j2
+++ b/ansible/templates/covid_act_now-params-prod.json.j2
@@ -2,8 +2,7 @@
   "static_file_dir": "./static",
   "export_dir": "/common/covidcast/receiving/covid_act_now",
   "cache_dir": "./cache",
-  "wip_signal": "",
-  "parquet_url": "https://storage.googleapis.com/us-east4-data-eng-scrapers-a02dc940-bucket/data/final/can_scrape_api_covid_us.parquet",
+  "parquet_url": "https://storage.googleapis.com/can-scrape-outputs/final/can_scrape_api_covid_us.parquet",
   "aws_credentials": {
     "aws_access_key_id": "{{ delphi_aws_access_key_id }}",
     "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"

--- a/covid_act_now/params.json.template
+++ b/covid_act_now/params.json.template
@@ -2,7 +2,7 @@
   "static_file_dir": "./static",
   "export_dir": "./receiving",
   "cache_dir": "./cache",
-  "parquet_url": "https://storage.googleapis.com/us-east4-data-eng-scrapers-a02dc940-bucket/data/final/can_scrape_api_covid_us.parquet",
+  "parquet_url": "https://storage.googleapis.com/can-scrape-outputs/final/can_scrape_api_covid_us.parquet",
   "aws_credentials": {
     "aws_access_key_id": "",
     "aws_secret_access_key": ""


### PR DESCRIPTION
### Description
The previous parquet file link stopped having updates somewhere towards the end of January.
COVID Act Now confirmed the link was outdated and has provided us with the new link that for now has the most updated PCR testing data.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- `covid_act_now/params.json.template`: Update with new URL
- `ansible/templates/covid_act_now-params-prod.json.j2`: Update production params with new URL
