### PR TITLE
Refactor params for quidel and quidel_covidtest

### DIFF
--- a/ansible/templates/quidel_covidtest-params-prod.json.j2
+++ b/ansible/templates/quidel_covidtest-params-prod.json.j2
@@ -1,17 +1,21 @@
 {
-  "static_file_dir": "./static",
-  "export_dir": "/common/covidcast/receiving/quidel",
-  "cache_dir": "./cache",
-  "export_start_date": "2020-05-26",
-  "export_end_date": "",
-  "pull_start_date": "2020-05-26",
-  "pull_end_date":"",
-  "aws_credentials": {
-    "aws_access_key_id": "{{ quidel_aws_access_key_id }}",
-    "aws_secret_access_key": "{{ quidel_aws_secret_access_key }}"
+  "common": {
+    "export_dir": "/common/covidcast/receiving/quidel",
+    "log_filename": "/var/log/indicators/quidel_covidtest.log"
   },
-  "bucket_name": "{{ quidel_aws_bucket_name }}",
-  "wip_signal": [""],
-  "mode": "",
-  "log_filename": "/var/log/indicators/quidel_covidtest.log"
+  "indicator": {
+    "static_file_dir": "./static",
+    "input_cache_dir": "./cache",
+    "export_start_date": "2020-05-26",
+    "export_end_date": "",
+    "pull_start_date": "2020-05-26",
+    "pull_end_date":"",
+    "aws_credentials": {
+      "aws_access_key_id": "{{ quidel_aws_access_key_id }}",
+      "aws_secret_access_key": "{{ quidel_aws_secret_access_key }}"
+    },
+    "bucket_name": "{{ quidel_aws_bucket_name }}",
+    "wip_signal": [""],
+    "mode": ""
+  }
 } 

--- a/quidel/delphi_quidel/pull.py
+++ b/quidel/delphi_quidel/pull.py
@@ -330,7 +330,7 @@ def pull_quidel_data(params):
         datetime.datetime
             the last date of the report
     """
-    cache_dir = params["cache_dir"]
+    cache_dir = params["input_cache_dir"]
 
     mail_server = params["mail_server"]
     account = params["account"]

--- a/quidel/delphi_quidel/run.py
+++ b/quidel/delphi_quidel/run.py
@@ -31,19 +31,19 @@ def run_module():
     start_time = time.time()
     params = read_params()
     logger = get_structured_logger(
-        __name__, filename=params.get("log_filename"),
-        log_exceptions=params.get("log_exceptions", True))
-    cache_dir = params["cache_dir"]
-    export_dir = params["export_dir"]
-    static_file_dir = params["static_file_dir"]
-    export_start_dates = params["export_start_date"]
-    export_end_dates = params["export_end_date"]
+        __name__, filename=params["common"].get("log_filename"),
+        log_exceptions=params["common"].get("log_exceptions", True))
+    cache_dir = params["indicator"]["input_cache_dir"]
+    export_dir = params["common"]["export_dir"]
+    static_file_dir = params["indicator"]["static_file_dir"]
+    export_start_dates = params["indicator"]["export_start_date"]
+    export_end_dates = params["indicator"]["export_end_date"]
     map_df = pd.read_csv(
         join(static_file_dir, "fips_prop_pop.csv"), dtype={"fips": int}
     )
 
     # Pull data and update export date
-    dfs, _end_date = pull_quidel_data(params)
+    dfs, _end_date = pull_quidel_data(params["indicator"])
     if _end_date is None:
         print("The data is up-to-date. Currently, no new data to be ingested.")
         return
@@ -55,7 +55,7 @@ def run_module():
 
     # Add prefix, if required
     sensors = add_prefix(list(SENSORS.keys()),
-                         wip_signal=params["wip_signal"],
+                         wip_signal=params["indicator"]["wip_signal"],
                          prefix="wip_")
 
     for sensor in sensors:

--- a/quidel/params.json.template
+++ b/quidel/params.json.template
@@ -1,16 +1,20 @@
 {
-  "static_file_dir": "./static",
-  "export_dir": "./receiving",
-  "cache_dir": "./cache",
-  "export_start_date": {"covid_ag": "2020-05-26", "flu_ag": "2020-02-02"},
-  "export_end_date": {"covid_ag": "", "flu_ag": ""},
-  "pull_start_date": {"covid_ag": "2020-05-26", "flu_ag": "2020-05-08"},
-  "pull_end_date": {"covid_ag": "", "flu_ag": ""},
-  "mail_server": "imap.exchange.andrew.cmu.edu",
-  "account": "delphi-datadrop@andrew.cmu.edu",
-  "password": "",
-  "sender": "",
-  "wip_signal": [""],
-  "mode": "",
-  "log_exceptions": false
+  "common": {
+    "export_dir": "./receiving",
+    "log_exceptions": false
+  },
+  "indicator": {
+    "static_file_dir": "./static",
+    "input_cache_dir": "./cache",
+    "export_start_date": {"covid_ag": "2020-05-26", "flu_ag": "2020-02-02"},
+    "export_end_date": {"covid_ag": "", "flu_ag": ""},
+    "pull_start_date": {"covid_ag": "2020-05-26", "flu_ag": "2020-05-08"},
+    "pull_end_date": {"covid_ag": "", "flu_ag": ""},
+    "mail_server": "imap.exchange.andrew.cmu.edu",
+    "account": "delphi-datadrop@andrew.cmu.edu",
+    "password": "",
+    "sender": "",
+    "wip_signal": [""],
+    "mode": ""
+  }
 }

--- a/quidel/tests/params.json.template
+++ b/quidel/tests/params.json.template
@@ -1,15 +1,19 @@
 {
-  "static_file_dir": "../static",
-  "export_dir": "./receiving",
-  "cache_dir": "./cache",
-  "export_start_date": {"covid_ag": "2020-06-30", "flu_ag": "2020-05-30"},
-  "export_end_date": {"covid_ag": "2020-07-09", "flu_ag": "2020-07-05"},
-  "pull_start_date": {"covid_ag": "2020-07-09","flu_ag": "2020-07-05"},
-  "pull_end_date": {"covid_ag": "", "flu_ag": "2020-07-10"},
-  "mail_server": "imap.exchange.andrew.cmu.edu",
-  "account": "delphi-datadrop@andrew.cmu.edu",
-  "password": "",
-  "sender": "",
-  "wip_signal": [""],
-  "mode": "test"
+  "common": {
+    "export_dir": "./receiving"
+  },
+  "indicator": {
+    "static_file_dir": "../static",
+    "input_cache_dir": "./cache",
+    "export_start_date": {"covid_ag": "2020-06-30", "flu_ag": "2020-05-30"},
+    "export_end_date": {"covid_ag": "2020-07-09", "flu_ag": "2020-07-05"},
+    "pull_start_date": {"covid_ag": "2020-07-09","flu_ag": "2020-07-05"},
+    "pull_end_date": {"covid_ag": "", "flu_ag": "2020-07-10"},
+    "mail_server": "imap.exchange.andrew.cmu.edu",
+    "account": "delphi-datadrop@andrew.cmu.edu",
+    "password": "",
+    "sender": "",
+    "wip_signal": [""],
+    "mode": "test"
+  }
 }

--- a/quidel/tests/test_pull.py
+++ b/quidel/tests/test_pull.py
@@ -41,7 +41,7 @@ class TestingPullData:
         
         params = read_params()
         
-        dfs, _ = pull_quidel_data(params) 
+        dfs, _ = pull_quidel_data(params["indicator"]) 
         
         # For covid_ag
         df = dfs["covid_ag"]

--- a/quidel/tests/test_run.py
+++ b/quidel/tests/test_run.py
@@ -43,7 +43,7 @@ class TestRun:
 
         geos = GEO_RESOLUTIONS.copy()
         sensors = add_prefix(list(SENSORS.keys()),
-                             wip_signal=params["wip_signal"],
+                             wip_signal=params["indicator"]["wip_signal"],
                              prefix="wip_")
 
         expected_files = []

--- a/quidel_covidtest/delphi_quidel_covidtest/pull.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/pull.py
@@ -217,7 +217,7 @@ def pull_quidel_covidtest(params):
             the last date of the report
 
     """
-    cache_dir = params["cache_dir"]
+    cache_dir = params["input_cache_dir"]
 
     test_mode = (params["mode"] == "test")
 

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -31,15 +31,15 @@ def run_module():
     start_time = time.time()
     params = read_params()
     logger = get_structured_logger(
-        __name__, filename=params.get("log_filename"),
-        log_exceptions=params.get("log_exceptions", True))
-    cache_dir = params["cache_dir"]
-    export_dir = params["export_dir"]
-    export_start_date = params["export_start_date"]
-    export_end_date = params["export_end_date"]
+        __name__, filename=params["common"].get("log_filename"),
+        log_exceptions=params["common"].get("log_exceptions", True))
+    cache_dir = params["indicator"]["input_cache_dir"]
+    export_dir = params["common"]["export_dir"]
+    export_start_date = params["indicator"]["export_start_date"]
+    export_end_date = params["indicator"]["export_end_date"]
 
     # Pull data and update export date
-    df, _end_date = pull_quidel_covidtest(params)
+    df, _end_date = pull_quidel_covidtest(params["indicator"])
     if _end_date is None:
         print("The data is up-to-date. Currently, no new data to be ingested.")
         return
@@ -56,7 +56,7 @@ def run_module():
 
     # Add prefix, if required
     sensors = add_prefix(SENSORS,
-                         wip_signal=read_params()["wip_signal"],
+                         wip_signal=params["indicator"]["wip_signal"],
                          prefix="wip_")
     smoothers = SMOOTHERS.copy()
 

--- a/quidel_covidtest/params.json.template
+++ b/quidel_covidtest/params.json.template
@@ -1,17 +1,21 @@
 {
-  "static_file_dir": "./static",
-  "export_dir": "./receiving",
-  "cache_dir": "./cache",
-  "export_start_date": "2020-05-26",
-  "export_end_date": "",
-  "pull_start_date": "2020-05-26",
-  "pull_end_date":"",
-  "aws_credentials": {
-    "aws_access_key_id": "",
-    "aws_secret_access_key": ""
+  "common": {
+    "export_dir": "./receiving",
+    "log_exceptions": false
   },
-  "bucket_name": "",
-  "wip_signal": [""],
-  "mode": "",
-  "log_exceptions": false
+  "indicator": {
+    "static_file_dir": "./static",
+    "input_cache_dir": "./cache",
+    "export_start_date": "2020-05-26",
+    "export_end_date": "",
+    "pull_start_date": "2020-05-26",
+    "pull_end_date":"",
+    "aws_credentials": {
+      "aws_access_key_id": "",
+      "aws_secret_access_key": ""
+    },
+    "bucket_name": "",
+    "wip_signal": [""],
+    "mode": ""
+  }
 }

--- a/quidel_covidtest/tests/params.json.template
+++ b/quidel_covidtest/tests/params.json.template
@@ -1,16 +1,20 @@
 {
-  "static_file_dir": "../static",
-  "export_dir": "./receiving",
-  "cache_dir": "./cache",
-  "export_start_date": "2020-06-30",
-  "export_end_date": "",
-  "pull_start_date": "2020-07-09",
-  "pull_end_date":"",
-  "aws_credentials": {
-    "aws_access_key_id": "",
-    "aws_secret_access_key": ""
+  "common": {
+    "export_dir": "./receiving"
   },
-  "bucket_name": "",
-  "wip_signal": "",
-  "mode": "test"
+  "indicator": {
+    "static_file_dir": "../static",
+    "input_cache_dir": "./cache",
+    "export_start_date": "2020-06-30",
+    "export_end_date": "",
+    "pull_start_date": "2020-07-09",
+    "pull_end_date":"",
+    "aws_credentials": {
+      "aws_access_key_id": "",
+      "aws_secret_access_key": ""
+    },
+    "bucket_name": "",
+    "wip_signal": "",
+    "mode": "test"
+  }
 }

--- a/quidel_covidtest/tests/test_pull.py
+++ b/quidel_covidtest/tests/test_pull.py
@@ -41,7 +41,7 @@ class TestingPullData:
         
         params = read_params()
         
-        df, _ = pull_quidel_covidtest(params) 
+        df, _ = pull_quidel_covidtest(params["indicator"]) 
         
         first_date = df["timestamp"].min().date() 
         last_date = df["timestamp"].max().date() 

--- a/quidel_covidtest/tests/test_run.py
+++ b/quidel_covidtest/tests/test_run.py
@@ -23,7 +23,7 @@ class TestRun:
         ]
         geos = GEO_RESOLUTIONS.copy()
         sensors = add_prefix(SENSORS,
-                             wip_signal=read_params()["wip_signal"],
+                             wip_signal=read_params()["indicator"]["wip_signal"],
                              prefix="wip_")
 
         expected_files = []


### PR DESCRIPTION
### Description
Refactors `quidel` and `quidel_covidtest` `params.json` files in accordance with #795.

Also renames `cache_dir` to `input_cache_dir` to disambiguate with the forthcoming `cache_dir` parameter in the `archive` module.