### PR TITLE
Refactor params for cdc covidnet

### DIFF
--- a/cdc_covidnet/delphi_cdc_covidnet/run.py
+++ b/cdc_covidnet/delphi_cdc_covidnet/run.py
@@ -21,36 +21,36 @@ def run_module():
 
     logging.basicConfig(level=logging.DEBUG)
 
-    start_date = datetime.strptime(params["start_date"], "%Y-%m-%d")
+    start_date = datetime.strptime(params["indicator"]["start_date"], "%Y-%m-%d")
 
     # If no end_date is specified, assume it is the current date
-    if params["end_date"] == "":
+    if params["indicator"]["end_date"] == "":
         end_date = datetime.now()
     else:
-        end_date = datetime.strptime(params["end_date"], "%Y-%m-%d")
+        end_date = datetime.strptime(params["indicator"]["end_date"], "%Y-%m-%d")
 
     logging.info("start date:\t%s", start_date.date())
     logging.info("end date:\t%s", end_date.date())
 
-    logging.info("outpath:\t%s", params["export_dir"])
-    logging.info("parallel:\t%s", params["parallel"])
+    logging.info("outpath:\t%s", params["common"]["export_dir"])
+    logging.info("parallel:\t%s", params["indicator"]["parallel"])
 
     # Only geo is state, and no weekday adjustment for now
     # COVID-NET data is by weeks anyway, not daily
     logging.info("starting state, no adj")
 
     # Download latest COVID-NET files into the cache directory first
-    mappings_file = join(params["cache_dir"], "init.json")
+    mappings_file = join(params["indicator"]["input_cache_dir"], "init.json")
     CovidNet.download_mappings(outfile=mappings_file)
     _, mmwr_info, _ = CovidNet.read_mappings(mappings_file)
     state_files = CovidNet.download_all_hosp_data(
-        mappings_file, params["cache_dir"],
-        parallel=params["parallel"])
+        mappings_file, params["indicator"]["input_cache_dir"],
+        parallel=params["indicator"]["parallel"])
 
     update_sensor(
         state_files,
         mmwr_info,
-        params["export_dir"],
+        params["common"]["export_dir"],
         start_date,
         end_date)
 

--- a/cdc_covidnet/delphi_cdc_covidnet/update_sensor.py
+++ b/cdc_covidnet/delphi_cdc_covidnet/update_sensor.py
@@ -101,7 +101,9 @@ def update_sensor(
     hosp_df["sample_size"] = np.nan
 
     # Write results
-    signals = add_prefix(SIGNALS, wip_signal=read_params()["wip_signal"], prefix="wip_")
+    signals = add_prefix(SIGNALS,
+                         wip_signal=read_params()["indicator"]["wip_signal"],
+                         prefix="wip_")
     for signal in signals:
         write_to_csv(hosp_df, signal, output_path)
     return hosp_df

--- a/cdc_covidnet/params.json.template
+++ b/cdc_covidnet/params.json.template
@@ -5,7 +5,7 @@
   "indicator": {
     "start_date": "2020-03-07",
     "end_date": "",
-    "parallel": false
+    "parallel": false,
     "static_file_dir": "./static",
     "wip_signal": "",
     "input_cache_dir": "./cache"

--- a/cdc_covidnet/params.json.template
+++ b/cdc_covidnet/params.json.template
@@ -1,9 +1,13 @@
 {
-  "static_file_dir": "./static",
-  "export_dir": "./receiving",
-  "cache_dir": "./cache",
-  "start_date": "2020-03-07",
-  "end_date": "",
-  "parallel": false,
-  "wip_signal": ""
+  "common": {
+    "export_dir": "./receiving"
+  },
+  "indicator": {
+    "start_date": "2020-03-07",
+    "end_date": "",
+    "parallel": false
+    "static_file_dir": "./static",
+    "wip_signal": "",
+    "input_cache_dir": "./cache"
+  }
 }

--- a/cdc_covidnet/tests/params.json.template
+++ b/cdc_covidnet/tests/params.json.template
@@ -1,9 +1,13 @@
 {
-  "static_file_dir": "../static",
-  "export_dir": "./receiving",
-  "cache_dir": "./cache",
-  "start_date": "2020-03-07",
-  "end_date": "",
-  "parallel": true,
-  "wip_signal": ""
+  "common": {
+    "export_dir": "./receiving"
+  },
+  "indicator": {
+    "start_date": "2020-03-07",
+    "end_date": "",
+    "parallel": true,
+    "static_file_dir": "./static",
+    "wip_signal": "",
+    "input_cache_dir": "./cache"
+  }
 }

--- a/cdc_covidnet/tests/test_update_sensor.py
+++ b/cdc_covidnet/tests/test_update_sensor.py
@@ -10,7 +10,7 @@ from delphi_utils import read_params
 from delphi_cdc_covidnet.update_sensor import update_sensor
 
 params = read_params()
-STATIC_DIR = params["static_file_dir"]
+STATIC_DIR = params["indicator"]["static_file_dir"]
 
 class TestUpdateSensor:
 


### PR DESCRIPTION
### Description
Refactors cdccovidnet params files in accordance with #795.


### Changelog
Itemize code/test/documentation changes and files added/removed.
- Refactor cdc covidnet params files to new structure
- Rename  `cache_dir` to `input_cache_dir` to disambiguate with the forthcoming `cache_dir` parameter in the `archive` module.

### Fixes 
- Partially addresses #795
