### PR TITLE
Switch nowcast to epidata async call and add tests

### DIFF
--- a/nowcast/delphi_nowcast/data_containers.py
+++ b/nowcast/delphi_nowcast/data_containers.py
@@ -42,11 +42,15 @@ class LocationSeries:
     @property
     def dates(self) -> list:
         """Check if there is no stored data in the class."""
+        if not self.data:
+            raise ValueError("No data.")
         return list(self.data.keys())
 
     @property
     def values(self) -> list:
         """Check if there is no stored data in the class."""
+        if not self.data:
+            raise ValueError("No data.")
         return list(self.data.values())
 
     def get_data_range(self,

--- a/nowcast/delphi_nowcast/data_containers.py
+++ b/nowcast/delphi_nowcast/data_containers.py
@@ -42,15 +42,11 @@ class LocationSeries:
     @property
     def dates(self) -> list:
         """Check if there is no stored data in the class."""
-        if not self.data:
-            raise ValueError("No data.")
         return list(self.data.keys())
 
     @property
     def values(self) -> list:
         """Check if there is no stored data in the class."""
-        if not self.data:
-            raise ValueError("No data.")
         return list(self.data.values())
 
     def get_data_range(self,

--- a/nowcast/delphi_nowcast/get_epidata.py
+++ b/nowcast/delphi_nowcast/get_epidata.py
@@ -5,40 +5,12 @@ from itertools import product
 
 from numpy import isnan
 from pandas import date_range
-from aiohttp import ClientSession
 
-# from ..delphi_epidata import Epidata  # used for local testing
 from delphi_epidata import Epidata
 
-from ..data_containers import LocationSeries, SensorConfig
+from delphi_nowcast.data_containers import LocationSeries, SensorConfig
 
 EPIDATA_START_DATE = 20200101
-
-async def get(params, session, sensor, location):
-    """Helper function to make Epidata GET requests."""
-    async with session.get(Epidata.BASE_URL, params=params) as response:
-        return await response.json(), sensor, location
-
-
-async def fetch_epidata(combos, as_of):
-    """Helper function to asynchronously make and aggregate Epidata GET requests."""
-    tasks = []
-    async with ClientSession() as session:
-        for sensor, location in combos:
-            params = {
-                    "endpoint": "covidcast",
-                    "data_source": sensor.source,
-                    "signals": sensor.signal,
-                    "time_type": "day",
-                    "geo_type": location.geo_type,
-                    "time_values": f"{EPIDATA_START_DATE}-{as_of}",
-                    "geo_value": location.geo_value,
-                    "as_of": as_of
-                }
-            task = asyncio.create_task(get(params, session, sensor, location))
-            tasks.append(task)
-        responses = await asyncio.gather(*tasks)
-        return responses
 
 
 def get_indicator_data(sensors: List[SensorConfig],
@@ -61,29 +33,41 @@ def get_indicator_data(sensors: List[SensorConfig],
     # gets all available data up to as_of day for now, could be optimized to only get a window
     output = {}
     all_combos = product(sensors, locations)
-    loop = asyncio.get_event_loop()
-    future = asyncio.ensure_future(fetch_epidata(all_combos, as_of.strftime("%Y%m%d")))
-    responses = loop.run_until_complete(future)
-    for response, sensor, location in responses:
+    all_params = [
+        {"source": "covidcast",
+         "data_source": sensor.source,
+         "signals": sensor.signal,
+         "time_type": "day",
+         "geo_type": location.geo_type,
+         "geo_value": location.geo_value,
+         "time_values": f"{EPIDATA_START_DATE}-{as_of.strftime('%Y%m%d')}",
+         "as_of": as_of.strftime("%Y%m%d")}
+        for sensor, location in all_combos
+    ]
+    responses = Epidata.async_epidata(all_params)
+    for response, params in responses:
         # -2 = no results, 1 = success. Truncated data or server errors may lead to this Exception.
         if response["result"] not in (-2, 1):
             raise Exception(f"Bad result from Epidata: {response['message']}")
         data = LocationSeries(
-            geo_value=location.geo_value,
-            geo_type=location.geo_type,
-            data={datetime.strptime(i["time_value"], "%Y%m%d").date(): i["value"]
+            geo_value=params["geo_value"],
+            geo_type=params["geo_type"],
+            data={datetime.strptime(str(i["time_value"]), "%Y%m%d").date(): i["value"]
                   for i in response.get("epidata", []) if not isnan(i["value"])}
         )
         if data.data:
-            output[(sensor.source, sensor.signal, location.geo_type, location.geo_value)] = data
+            output[(params["data_source"],
+                    params["signals"],
+                    params["geo_type"],
+                    params["geo_value"])] = data
     return output
 
 
 def get_historical_sensor_data(sensor: SensorConfig,
                                geo_value: str,
                                geo_type: str,
-                               end_date: date,
-                               start_date: date) -> Tuple[LocationSeries, list]:
+                               start_date: date,
+                               end_date: date) -> Tuple[LocationSeries, list]:
     """
     Query Epidata API for historical sensorization data.
     Will only return values if they are not null. If any days are null or are not available,
@@ -114,6 +98,7 @@ def get_historical_sensor_data(sensor: SensorConfig,
         geo_value=geo_value,
         sensor_names=sensor.name,
         lag=sensor.lag)
+    all_dates = [i.date() for i in date_range(start_date, end_date)]
     if response["result"] == 1:
         output = LocationSeries(
             geo_value=geo_value,
@@ -121,11 +106,11 @@ def get_historical_sensor_data(sensor: SensorConfig,
             data={datetime.strptime(str(i["time_value"]), "%Y%m%d").date(): i["value"]
                   for i in response.get("epidata", []) if not isnan(i["value"])}
         )
+        missing_dates = [i for i in all_dates if i not in output.dates]
+        return output, missing_dates
     elif response["result"] == -2:  # no results
         print("No historical results found")
         output = LocationSeries(geo_value=geo_value, geo_type=geo_type)
-    else:
-        raise Exception(f"Bad result from Epidata: {response['message']}")
-    all_dates = [i.date() for i in date_range(start_date, end_date)]
-    missing_dates = [i for i in all_dates if i not in output.dates]
-    return output, missing_dates
+        return output, all_dates
+    raise Exception(f"Bad result from Epidata: {response['message']}")
+

--- a/nowcast/delphi_nowcast/get_epidata.py
+++ b/nowcast/delphi_nowcast/get_epidata.py
@@ -8,7 +8,7 @@ from pandas import date_range
 
 from delphi_epidata import Epidata
 
-from delphi_nowcast.data_containers import LocationSeries, SensorConfig
+from .data_containers import LocationSeries, SensorConfig
 
 EPIDATA_START_DATE = 20200101
 

--- a/nowcast/delphi_nowcast/get_epidata.py
+++ b/nowcast/delphi_nowcast/get_epidata.py
@@ -35,6 +35,7 @@ def get_indicator_data(sensors: List[SensorConfig],
     # gets all available data up to as_of day for now, could be optimized to only get a window
     output = {}
     all_combos = product(sensors, locations)
+    as_of_str = as_of.strftime("%Y%m%d")
     all_params = [
         {"source": "covidcast",
          "data_source": sensor.source,
@@ -42,8 +43,8 @@ def get_indicator_data(sensors: List[SensorConfig],
          "time_type": "day",
          "geo_type": location.geo_type,
          "geo_value": location.geo_value,
-         "time_values": f"{EPIDATA_START_DATE}-{as_of.strftime('%Y%m%d')}",
-         "as_of": as_of.strftime("%Y%m%d")}
+         "time_values": f"{EPIDATA_START_DATE}-{as_of_str}",
+         "as_of": as_of_str}
         for sensor, location in all_combos
     ]
     responses = Epidata.async_epidata(all_params)

--- a/nowcast/delphi_nowcast/get_epidata.py
+++ b/nowcast/delphi_nowcast/get_epidata.py
@@ -1,12 +1,11 @@
-import asyncio
+"""Retrieve data from Epidata API."""
 from datetime import datetime, date
-from typing import Tuple, List, Dict
 from itertools import product
-
-from numpy import isnan
-from pandas import date_range
+from typing import Tuple, List, Dict
 
 from delphi_epidata import Epidata
+from numpy import isnan
+from pandas import date_range
 
 from .data_containers import LocationSeries, SensorConfig
 
@@ -18,6 +17,7 @@ def get_indicator_data(sensors: List[SensorConfig],
                        as_of: date) -> Dict[Tuple, LocationSeries]:
     """
     Given a list of sensors and locations, asynchronously gets covidcast data for all combinations.
+
     Parameters
     ----------
     sensors
@@ -29,6 +29,8 @@ def get_indicator_data(sensors: List[SensorConfig],
         Date that the data should be retrieved as of.
     Returns
     -------
+        Dictionary of {(source, signal, geo_type, geo_value): LocationSeries} containing indicator
+        data,
     """
     # gets all available data up to as_of day for now, could be optimized to only get a window
     output = {}
@@ -70,8 +72,10 @@ def get_historical_sensor_data(sensor: SensorConfig,
                                end_date: date) -> Tuple[LocationSeries, list]:
     """
     Query Epidata API for historical sensorization data.
+
     Will only return values if they are not null. If any days are null or are not available,
     they will be listed as missing.
+
     Parameters
     ----------
     sensor
@@ -108,9 +112,8 @@ def get_historical_sensor_data(sensor: SensorConfig,
         )
         missing_dates = [i for i in all_dates if i not in output.dates]
         return output, missing_dates
-    elif response["result"] == -2:  # no results
+    if response["result"] == -2:  # no results
         print("No historical results found")
         output = LocationSeries(geo_value=geo_value, geo_type=geo_type)
         return output, all_dates
     raise Exception(f"Bad result from Epidata: {response['message']}")
-

--- a/nowcast/delphi_nowcast/sensorization/sensor.py
+++ b/nowcast/delphi_nowcast/sensorization/sensor.py
@@ -7,8 +7,8 @@ from datetime import timedelta, date
 import numpy as np
 
 from .ar_model import compute_ar_sensor
-from .get_epidata import get_indicator_data, get_historical_sensor_data
 from .regression_model import compute_regression_sensor
+from ..get_epidata import get_indicator_data, get_historical_sensor_data
 from ..data_containers import LocationSeries, SensorConfig
 from ..constants import AR_ORDER, AR_LAMBDA, REG_INTERCEPT
 

--- a/nowcast/tests/test_get_epidata.py
+++ b/nowcast/tests/test_get_epidata.py
@@ -1,0 +1,163 @@
+from unittest.mock import patch
+from datetime import date
+
+import pytest
+import numpy as np
+
+from delphi_nowcast.get_epidata import get_indicator_data, get_historical_sensor_data, \
+    EPIDATA_START_DATE
+from delphi_nowcast.data_containers import LocationSeries, SensorConfig
+
+
+class TestGetIndicatorData:
+
+    @patch("delphi_epidata.Epidata.async_epidata")
+    def test_results(self, mock_epidata):
+        mock_epidata.return_value = [
+            ({"result": 1, "epidata": [{"time_value": 20200101, "value": 1},
+                                       {"time_value": 20200102, "value": np.nan}]},
+             {"data_source": "src1", "signals": "sig1", "geo_type": "state", "geo_value": "ca"}),
+            ({"result": 1, "epidata": [{"time_value": 20200101, "value": 2.5}]},
+             {"data_source": "src1", "signals": "sig1", "geo_type": "county", "geo_value": "01001"}),
+            ({"result": -2},
+             {"data_source": "src2", "signals": "sig2", "geo_type": "state", "geo_value": "ca"}),
+            ({"result": -2},
+             {"data_source": "src2", "signals": "sig2", "geo_type": "county", "geo_value": "01001"}),
+        ]
+        test_output = get_indicator_data(
+            [SensorConfig("src1", "sig1", None, None), SensorConfig("src2", "sig2", None, None)],
+            [LocationSeries("ca", "state"), LocationSeries("01001", "county")],
+            date(2020, 1, 1)
+        )
+        assert test_output == {
+            ("src1", "sig1", "state", "ca"): LocationSeries("ca", "state", {date(2020, 1, 1): 1}),
+            ("src1", "sig1", "county", "01001"): LocationSeries("01001", "county", {date(2020, 1, 1): 2.5})
+        }
+        mock_epidata.assert_called_once_with([
+            {"source": "covidcast",
+             "data_source": "src1",
+             "signals": "sig1",
+             "time_type": "day",
+             "geo_type": "state",
+             "geo_value": "ca",
+             "time_values": f"{EPIDATA_START_DATE}-20200101",
+             "as_of": "20200101"},
+            {"source": "covidcast",
+             "data_source": "src1",
+             "signals": "sig1",
+             "time_type": "day",
+             "geo_type": "county",
+             "geo_value": "01001",
+             "time_values": f"{EPIDATA_START_DATE}-20200101",
+             "as_of": "20200101"},
+            {"source": "covidcast",
+             "data_source": "src2",
+             "signals": "sig2",
+             "time_type": "day",
+             "geo_type": "state",
+             "geo_value": "ca",
+             "time_values": f"{EPIDATA_START_DATE}-20200101",
+             "as_of": "20200101"},
+            {"source": "covidcast",
+             "data_source": "src2",
+             "signals": "sig2",
+             "time_type": "day",
+             "geo_type": "county",
+             "geo_value": "01001",
+             "time_values": f"{EPIDATA_START_DATE}-20200101",
+             "as_of": "20200101"}
+        ])
+
+    @patch("delphi_epidata.Epidata.async_epidata")
+    def test_no_results(self, mock_epidata):
+        mock_epidata.return_value = [
+            ({"result": -2},
+             {"data_source": "src1", "signals": "sig1", "geo_type": "state", "geo_value": "ca"}),
+            ({"result": -2},
+             {"data_source": "src1", "signals": "sig1", "geo_type": "county", "geo_value": "01001"}),
+        ]
+        test_output = get_indicator_data(
+            [SensorConfig("src1", "sig1", None, None), SensorConfig("src2", "sig2", None, None)],
+            [LocationSeries("ca", "state")],
+            date(2020, 1, 1)
+        )
+        assert test_output == {}
+        mock_epidata.assert_called_once_with([
+            {"source": "covidcast",
+             "data_source": "src1",
+             "signals": "sig1",
+             "time_type": "day",
+             "geo_type": "state",
+             "geo_value": "ca",
+             "time_values": f"{EPIDATA_START_DATE}-20200101",
+             "as_of": "20200101"},
+            {"source": "covidcast",
+             "data_source": "src2",
+             "signals": "sig2",
+             "time_type": "day",
+             "geo_type": "state",
+             "geo_value": "ca",
+             "time_values": f"{EPIDATA_START_DATE}-20200101",
+             "as_of": "20200101"},
+        ])
+
+    @patch("delphi_epidata.Epidata.async_epidata")
+    def test_error(self, mock_epidata):
+        mock_epidata.return_value = [({"result": -3, "message": "test failure"}, {})]
+        with pytest.raises(Exception, match="Bad result from Epidata: test failure"):
+            get_indicator_data([SensorConfig(None, None, None, None)],
+                               [LocationSeries(None, None)],
+                               date(2020, 1, 1))
+        mock_epidata.assert_called_once_with([
+            {"source": "covidcast",
+             "data_source": None,
+             "signals": None,
+             "time_type": "day",
+             "geo_type": None,
+             "geo_value": None,
+             "time_values": f"{EPIDATA_START_DATE}-20200101",
+             "as_of": "20200101"}
+        ])
+
+
+class TestGetHistoricalSensorData:
+
+    @patch("delphi_epidata.Epidata.covidcast_nowcast")
+    def test_results(self, mock_epidata):
+        mock_epidata.return_value = {
+            "result": 1,
+            "epidata": [{"time_value": 20200101, "value": 1},
+                        {"time_value": 20200102, "value": np.nan}]
+        }
+        test_output = get_historical_sensor_data(SensorConfig(None, None, None, None),
+                                                 None,
+                                                 None,
+                                                 date(2020, 1, 1),
+                                                 date(2020, 1, 4))
+
+        assert test_output == (LocationSeries(None, None, {date(2020, 1, 1): 1}),
+                               [date(2020, 1, 2),
+                                date(2020, 1, 3),
+                                date(2020, 1, 4)])
+
+    @patch("delphi_epidata.Epidata.covidcast_nowcast")
+    def test_no_results(self, mock_epidata):
+        mock_epidata.return_value = {"result": -2}
+        test_output = get_historical_sensor_data(SensorConfig(None, None, None, None),
+                                                 None,
+                                                 None,
+                                                 date(2020, 1, 1),
+                                                 date(2020, 1, 4))
+
+        assert test_output == (LocationSeries(None, None), [date(2020, 1, 1), date(2020, 1, 2),
+                                                            date(2020, 1, 3), date(2020, 1, 4)])
+
+    @patch("delphi_epidata.Epidata.covidcast_nowcast")
+    def test_error(self, mock_epidata):
+        mock_epidata.return_value = {"result": -3, "message": "test failure"}
+        with pytest.raises(Exception, match="Bad result from Epidata: test failure"):
+            get_historical_sensor_data(SensorConfig(None, None, None, None),
+                                       None,
+                                       None,
+                                       date(2020, 1, 1),
+                                       date(2020, 1, 4))


### PR DESCRIPTION
### Description
Previously nowcasting had it's own async implementation, but after epidata 0.0.11, we can use the client's version. This PR changes that, and also adds tests for the epidata calls.

cc @mariajahja FYI

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Replace old async code with new Epidata.async_epidata() call
- Fix some argument ordering I had switched
- Move get_epidata up on directory since it's used by deconvolution code too.
- Add tests for the epidata calls

### Fixes 
- Fixes #(issue)
