### PR TITLE
Refactor params reading for HHS Hosp

### DIFF
--- a/hhs_hosp/delphi_hhs/__main__.py
+++ b/hhs_hosp/delphi_hhs/__main__.py
@@ -5,7 +5,7 @@ This file indicates that calling the module (`python -m delphi_hhs`) will
 call the function `run_module` found within the run.py file. There should be
 no need to change this template.
 """
-
+from delphi_utils import read_params
 from .run import run_module  # pragma: no cover
 
-run_module()  # pragma: no cover
+run_module(read_params())  # pragma: no cover

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -7,7 +7,6 @@ when the module is run with `python -m delphi_hhs`.
 from datetime import date, datetime, timedelta
 
 from delphi_epidata import Epidata
-from delphi_utils import read_params
 from delphi_utils.export import create_export_csv
 from delphi_utils.geomap import GeoMapper
 import numpy as np
@@ -63,14 +62,22 @@ def generate_date_ranges(start, end):
     return output
 
 
-def run_module():
-    """Generate ground truth HHS hospitalization data."""
-    params = read_params()
+def run_module(params):
+    """
+    Generate ground truth HHS hospitalization data.
+
+    Parameters
+    ----------
+    params
+        Dictionary containing indicator configuration. Expected to have the following structure:
+        - "common":
+            - "export_dir": str, directory to write output
+    """
     mapper = GeoMapper()
     request_all_states = ",".join(mapper.get_geo_values("state_id"))
 
     today = date.today()
-    past_reference_day = date(year=2020, month=1, day=1) # first available date in DB
+    past_reference_day = date(year=2020, month=1, day=1)  # first available date in DB
     date_range = generate_date_ranges(past_reference_day, today)
     dfs = []
     for r in date_range:

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -72,6 +72,7 @@ def run_module(params):
         Dictionary containing indicator configuration. Expected to have the following structure:
         - "common":
             - "export_dir": str, directory to write output
+            - "log_filename" (optional): str, name of file to write logs
     """
     mapper = GeoMapper()
     request_all_states = ",".join(mapper.get_geo_values("state_id"))

--- a/hhs_hosp/tests/params.json.template
+++ b/hhs_hosp/tests/params.json.template
@@ -1,5 +1,0 @@
-{
-  "common": {
-    "export_dir": "./receiving"
-  }
-}

--- a/hhs_hosp/tests/test_run.py
+++ b/hhs_hosp/tests/test_run.py
@@ -125,4 +125,9 @@ def test_ignore_last_range_no_results(mock_covid_hosp, mock_export):
         {"result": -2, "message": "no results"}
     ]
     mock_export.return_value = None
-    assert not run_module()  # function should not raise value error and has no return value
+    params = {
+        "common": {
+            "export_dir": "./receiving"
+        }
+    }
+    assert not run_module(params)  # function should not raise value error and has no return value


### PR DESCRIPTION
### Description
Refactor HHS Hosp so that `run_module()` accepts a `params` argument corresponding to parameters read from the json file. 

### Changelog
- Change signature of `run_module()`
- Document required and optional parameters in comments of `run_module()`
- Update test to use a fixed param

### Fixes
-  Partially addresses #814.
