### PR TITLE
Refactor params reading in HHS Facilities

### DIFF
--- a/hhs_facilities/delphi_hhs_facilities/__main__.py
+++ b/hhs_facilities/delphi_hhs_facilities/__main__.py
@@ -5,7 +5,7 @@ This file indicates that calling the module (`python -m delphi_hhs_facilities`) 
 call the function `run_module` found within the run.py file. There should be
 no need to change this template.
 """
-
+from delphi_utils import read_params
 from .run import run_module  # pragma: no cover
 
-run_module()  # pragma: no cover
+run_module(read_params())  # pragma: no cover

--- a/hhs_facilities/delphi_hhs_facilities/run.py
+++ b/hhs_facilities/delphi_hhs_facilities/run.py
@@ -3,8 +3,6 @@
 
 from itertools import product
 
-# from delphi_epidata import Epidata
-from delphi_utils import read_params
 from delphi_utils.export import create_export_csv
 from delphi_utils.geomap import GeoMapper
 
@@ -14,9 +12,17 @@ from .geo import convert_geo, fill_missing_fips
 from .pull import pull_data
 
 
-def run_module() -> None:
-    """Run entire hhs_facilities indicator."""
-    params = read_params()
+def run_module(params) -> None:
+    """
+    Run entire hhs_facilities indicator.
+
+    Parameters
+    ----------
+    params
+        Dictionary containing indicator configuration. Expected to have the following structure:
+        - "common":
+            - "export_dir": str, directory to write output
+    """
     raw_df = pull_data()
     gmpr = GeoMapper()
     filled_fips_df = fill_missing_fips(raw_df, gmpr)

--- a/hhs_facilities/tests/test_run.py
+++ b/hhs_facilities/tests/test_run.py
@@ -13,9 +13,8 @@ from delphi_hhs_facilities.constants import GEO_RESOLUTIONS, SIGNALS
 
 class TestRun:
 
-    @patch("delphi_hhs_facilities.run.read_params")
     @patch("delphi_hhs_facilities.run.pull_data")
-    def test_run_module(self, pull_data, params):
+    def test_run_module(self, pull_data):
         pull_data.return_value = pd.DataFrame({
             "timestamp": [pd.Timestamp("20200201")]*4,
             "fips_code": ["25013", "25013", np.nan, np.nan],
@@ -29,8 +28,8 @@ class TestRun:
         with tempfile.TemporaryDirectory() as tmp:
             # when adding tests for new signals, change tmp to './expected' to generate new expected files.
             # tests will fail but the files will be created.
-            params.return_value = {"common": {"export_dir": tmp}}
-            run_module()
+            params = {"common": {"export_dir": tmp}}
+            run_module(params)
             expected_files = ["_".join(["20200131", geo, sig[0]]) + ".csv" for geo, sig
                               in product(GEO_RESOLUTIONS, SIGNALS)]
             assert sorted(os.listdir(tmp)) == sorted(expected_files)


### PR DESCRIPTION
### Description
Refactor HHS Facilities so that `run_module()` accepts a `params` argument corresponding to parameters read from the json file. 

### Changelog
- Change signature of `run_module()`
- Document required and optional parameters in comments of `run_module()`
- Update test to use a fixed param

### Fixes
-  Partially addresses #814.
