### PR TITLE
Combo indicator speedup

### DIFF
--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -28,6 +28,8 @@ COLUMN_MAPPING = {"time_value": "timestamp",
                   "stderr": "se",
                   "sample_size": "sample_size"}
 
+covidcast.covidcast._ASYNC_CALL = True
+
 
 def check_none_data_frame(data_frame, label, date_range):
     """Log and return True when a data frame is None."""
@@ -251,7 +253,6 @@ def run_module(params):
             df[df["timestamp"] == date_][["geo_id", "val", "se", "sample_size", ]].to_csv(
                 f"{export_dir}/{export_fn}", index=False, na_rep="NA"
             )
-
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
     logger.info("Completed indicator run",
         elapsed_time_in_seconds = elapsed_time_in_seconds)

--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -28,7 +28,7 @@ COLUMN_MAPPING = {"time_value": "timestamp",
                   "stderr": "se",
                   "sample_size": "sample_size"}
 
-covidcast.covidcast._ASYNC_CALL = True
+covidcast.covidcast._ASYNC_CALL = True  # pylint: disable=protected-access
 
 
 def check_none_data_frame(data_frame, label, date_range):
@@ -253,6 +253,7 @@ def run_module(params):
             df[df["timestamp"] == date_][["geo_id", "val", "se", "sample_size", ]].to_csv(
                 f"{export_dir}/{export_fn}", index=False, na_rep="NA"
             )
+
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
     logger.info("Completed indicator run",
         elapsed_time_in_seconds = elapsed_time_in_seconds)

--- a/combo_cases_and_deaths/setup.py
+++ b/combo_cases_and_deaths/setup.py
@@ -8,7 +8,7 @@ required = [
     "pytest-cov",
     "pylint",
     "delphi-utils",
-    "covidcast"
+    "covidcast>=0.1.4"
 ]
 
 setup(


### PR DESCRIPTION
### Description
**Depends on https://github.com/cmu-delphi/covidcast/pull/429** 

Speed up combo indicator by making covidcast calls async. Each particular combo seems to vary quite a bit, but total run time of each loop goes from 10-30s down to ~3s on my laptop.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Enable async covidcast calls

### Fixes 
- Fixes #(issue)
