### PR TITLE
[fb survey] `is_selected` to map missing responses to `NA`

### DIFF
--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -19,6 +19,9 @@ split_options <- function(column) {
 
 #' Test if a specific selection is selected
 #'
+#' Checking whether a specific selection is selected in either "" (empty
+#' string) or `NA` responses will produce `NA`s.
+#'
 #' @param vec A list whose entries are character vectors, such as c("14", "15").
 #' @param selection one string, such as "14"
 #' @return a logical vector; for each list entry, whether selection is contained
@@ -28,8 +31,10 @@ is_selected <- function(vec, selection) {
     vec,
     function(resp) {
       if (length(resp) == 0 || all(is.na(resp))) {
-        # All our selection items include "None of the above" or similar, so
-        # treat no selection the same as missingness.
+        # Qualtrics files code no selection as "" (empty string), which is
+        # parsed by `read_csv` as `NA` (missing) by default. Since all our
+        # selection items include "None of the above" or similar, treat both no
+        # selection ("") or missing (NA) as missing, for generality.
         NA
       } else {
         selection %in% resp

--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -27,7 +27,7 @@ is_selected <- function(vec, selection) {
   selections <- sapply(
     vec,
     function(resp) {
-      if (length(resp) == 0) {
+      if (length(resp) == 0 || all(is.na(resp))) {
         # All our selection items include "None of the above" or similar, so
         # treat no selection the same as missingness.
         NA

--- a/facebook/delphiFacebook/tests/testthat/test-variables.R
+++ b/facebook/delphiFacebook/tests/testthat/test-variables.R
@@ -12,12 +12,30 @@ test_that("is_selected handles selections correctly", {
   expect_equal(is_selected(split_options(c("", "14", "4", "4,6,8")), "1"),
                c(NA, FALSE, FALSE, FALSE))
 
-  expect_equal(is_selected(split_options(c("1", "15", "14", NA)), "14"),
-               c(FALSE, FALSE, TRUE, FALSE))
+  expect_equal(is_selected(split_options(c("1", "15", "14", NA, "")), "14"),
+               c(FALSE, FALSE, TRUE, NA, NA))
 
   expect_equal(is_selected(split_options(c("4,54", "3,6,2,54", "5,4,45")),
                            "54"),
                c(TRUE, TRUE, FALSE))
+})
+
+test_that("activities items correctly coded", {
+  input_data <- data.frame(
+    C13 = c(NA, "1,2,4", "3", "", "6", "2,4")
+  )
+  
+  out <- code_activities(input_data)
+  
+  # expected result
+  input_data$a_work_outside_home_1d <- c(NA, TRUE, FALSE, NA, FALSE, FALSE)
+  input_data$a_shop_1d <- c(NA, TRUE, FALSE, NA, FALSE, TRUE)
+  input_data$a_restaurant_1d <- c(NA, FALSE, TRUE, NA, FALSE, FALSE)
+  input_data$a_spent_time_1d <- c(NA, TRUE, FALSE, NA, FALSE, TRUE)
+  input_data$a_large_event_1d <- c(NA, FALSE, FALSE, NA, FALSE, FALSE)
+  input_data$a_public_transit_1d <- c(NA, FALSE, FALSE, NA, TRUE, FALSE)
+
+  expect_equal(out, input_data)
 })
 
 test_that("mask items correctly coded", {


### PR DESCRIPTION
### Description
The `is_selected` function is used to check if a given response code appears in a vector of multi-select responses. It currently maps responses of the format "" (empty string) to `NA`, under the assumption that "" corresponds to a respondent not answering the question. This does match the formatting raw Qualtrics files use, but "" is mapped to `NA` by default by `read_csv` in `load_response_one`. Thus, `is_selected` never sees the "" formatting, and erroneously maps `NA` to `FALSE`.

This results in metrics that use `is_selected` (all indicators derived from item C13) including inappropriate `FALSE` values, which biases percent calculations down. The change here remaps missing responses to `NA`.

### Changelog
- Change `is_selected` to report `NA` when a response is missing (`NA`)
- Add new test for `code_activities`
- Modify existing test for `is_selected` to expect `NA` for `NA` responses, not `FALSE`

### Impact
Historical C13-derived indicators will need to be reissued with the new definition of `is_selected`. Comparing national results for 2021-02-14 using old and new function definitions, we see increases across the board, as expected.

![weighted_metric_comparisons](https://user-images.githubusercontent.com/42820733/108576738-b174c400-72ec-11eb-819c-60a67936ff09.png)

Sample sizes decrease by about 11%, which corresponds well to the 10-15% missingness rate we generally see on the survey.

![sample_size_comparisons](https://user-images.githubusercontent.com/42820733/108576745-b89bd200-72ec-11eb-9768-451b307b66b2.png)