### PR TITLE
Repair hhs hosp production credentials

### DIFF
--- a/ansible/templates/hhs_hosp-params-prod.json.j2
+++ b/ansible/templates/hhs_hosp-params-prod.json.j2
@@ -2,5 +2,14 @@
   "common": {
     "export_dir": "/common/covidcast/receiving/hhs",
     "log_filename": "/var/log/indicators/hhs_hosp.log"
+  },
+  "archive": {
+    "aws_credentials": {
+      "aws_access_key_id": "{{ delphi_aws_access_key_id }}",
+      "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"
+    },
+    "bucket_name": "delphi-covidcast-indicator-output",
+    "cache_dir": "./cache"
   }
+
 }


### PR DESCRIPTION
### Description
We accidentally dropped the AWS credentials from the HHS production params during the refactor; this PR puts them back.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- ansible template for hhs_hosp

### Fixes 
- hhs_hosp crashing in production
