### PR TITLE
Restructure SirCAL to use API data for lag calculation

### DIFF
--- a/sir_complainsalot/delphi_sir_complainsalot/check_source.py
+++ b/sir_complainsalot/delphi_sir_complainsalot/check_source.py
@@ -65,13 +65,37 @@ def check_source(data_source, meta, params, grace, logger):
            row["signal"] in source_config["retired-signals"]:
             continue
 
-        # Check max age
-        age = (now - row["max_time"]).days
+        logger.info("Retrieving signal",
+            source=data_source,
+            signal=row["signal"],
+            start_day=(datetime.now() - timedelta(days = 14)).strftime("%Y-%m-%d"),
+            end_day=datetime.now().strftime("%Y-%m-%d"),
+            geo_type=row["geo_type"])
 
-        if age > source_config["max_age"] + grace:
+        latest_data = covidcast.signal(
+            data_source, row["signal"],
+            start_day=datetime.now() - timedelta(days = 14),
+            end_day=datetime.now(),
+            geo_type=row["geo_type"]
+        )
+
+        if latest_data is None:
+            logger.info("No signal data retrieved")
+            continue
+
+        unique_dates = [pd.to_datetime(val).date()
+                        for val in latest_data["time_value"].unique()]
+        current_lag_in_days = (datetime.now().date() - max(unique_dates)).days
+        logger.info("Signal lag",
+                    current_lag_in_days = current_lag_in_days,
+                    data_source = data_source,
+                    signal = row["signal"],
+                    geo_type=row["geo_type"])
+
+        if current_lag_in_days > source_config["max_age"] + grace:
             if row["signal"] not in age_complaints:
                 age_complaints[row["signal"]] = Complaint(
-                    "is more than {age} days old".format(age=age),
+                    "is {current_lag_in_days} days old".format(current_lag_in_days=current_lag_in_days),
                     data_source,
                     row["signal"],
                     [row["geo_type"]],
@@ -85,37 +109,10 @@ def check_source(data_source, meta, params, grace, logger):
             # No gap detection for this source
             continue
 
-        logger.info("Retrieving signal",
-                    source=data_source,
-                    signal=row["signal"],
-                    start_day=(datetime.now() - timedelta(days = 14)).strftime("%Y-%m-%d"),
-                    end_day=datetime.now().strftime("%Y-%m-%d"),
-                    geo_type=row["geo_type"])
-
-        latest_data = covidcast.signal(
-            data_source, row["signal"],
-            start_day=datetime.now() - timedelta(days = 14),
-            end_day=datetime.now(),
-            geo_type=row["geo_type"]
-        )
-
-        if latest_data is None:
-            logger.info("No signal data retrieved")
-            continue
-
         # convert numpy datetime values to pandas datetimes and then to
         # datetime.date, so we can work with timedeltas after
-        unique_dates = [pd.to_datetime(val).date()
-                        for val in latest_data["time_value"].unique()]
         unique_issues = [pd.to_datetime(val).date()
                         for val in latest_data["issue"].unique()]
-
-        current_lag_in_days = (datetime.now().date() - max(unique_dates)).days
-        logger.info("Signal lag",
-                    current_lag_in_days = current_lag_in_days,
-                    data_source = data_source,
-                    signal = row["signal"],
-                    geo_type=row["geo_type"])
 
         gap_days = [(day - prev_day).days
                     for day, prev_day in zip(unique_dates[1:], unique_dates[:-1])]


### PR DESCRIPTION
### Description
Restructure SirCAL to use API data for lag calculation

### Changelog
- Move API retrieval up so that it runs for all signals
- Use the API lag data to generate alert (instead of the metadata lag)

### Fixes 
- Fixes #862 
