### PR TITLE
Update PR condition for JHU

### DIFF
--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -113,7 +113,7 @@ def combine_usafacts_and_jhu(signal, geo, date_range, fetcher=covidcast.signal):
     elif geo_to_fetch == 'county':
         combined_df = maybe_append(
             usafacts_df,
-            jhu_df if jhu_df is None else jhu_df[jhu_df["geo_value"] == '72000'])
+            jhu_df if jhu_df is None else jhu_df[jhu_df["geo_value"].str.startswith("72")])
     # For MSA and HRR level, they are the same
     else:
         combined_df = usafacts_df

--- a/combo_cases_and_deaths/tests/test_run.py
+++ b/combo_cases_and_deaths/tests/test_run.py
@@ -101,7 +101,7 @@ def test_combine_usafacts_and_jhu_special_geos(mock_covidcast_signal):
         pd.DataFrame({"geo_value": ["01000", "01001"],
                       "value": [50, 100],
                       "timestamp": [20200101, 20200101]}),
-        pd.DataFrame({"geo_value": ["72000", "01001"],
+        pd.DataFrame({"geo_value": ["72001", "01001"],
                       "value": [200, 100],
                       "timestamp": [20200101, 20200101]}),
     ] * 3
@@ -123,7 +123,7 @@ def test_combine_usafacts_and_jhu_special_geos(mock_covidcast_signal):
     )
     pd.testing.assert_frame_equal(
         combine_usafacts_and_jhu("confirmed_incidence_num", "county", date_range=(0, 1), fetcher=mock_covidcast_signal),
-        pd.DataFrame({"geo_id": ["01000", "01001", "72000"],
+        pd.DataFrame({"geo_id": ["01000", "01001", "72001"],
                       "val": [50, 100, 200],
                       "timestamp": [20200101, 20200101, 20200101]},
                      index=[0, 1, 0])


### PR DESCRIPTION
### Description
JHU now reports PR counties instead of just the megafips, so adjusting the combo indicator PR condition.
```
In [8]: df= covidcast.signal("jhu-csse", "confirmed_incidence_num", date(2020, 5, 1), date(2020, 5, 7), "county")                                       

In [9]: df[df.geo_value.str.startswith("72")]                                  
Out[9]: 
     geo_value                   signal  ... geo_type data_source
3200     72000  confirmed_incidence_num  ...   county    jhu-csse
3201     72001  confirmed_incidence_num  ...   county    jhu-csse
3202     72003  confirmed_incidence_num  ...   county    jhu-csse
3203     72005  confirmed_incidence_num  ...   county    jhu-csse
3204     72007  confirmed_incidence_num  ...   county    jhu-csse
...        ...                      ...  ...      ...         ...
3274     72145  confirmed_incidence_num  ...   county    jhu-csse
3275     72147  confirmed_incidence_num  ...   county    jhu-csse
3276     72149  confirmed_incidence_num  ...   county    jhu-csse
3277     72151  confirmed_incidence_num  ...   county    jhu-csse
3278     72153  confirmed_incidence_num  ...   county    jhu-csse


```
### Changelog
Itemize code/test/documentation changes and files added/removed.
- Change == 72000 to startswith(72)
- Update a test to use 72001 instead of 72000

### Fixes 
- Fixes #792 
