### PR TITLE
[fb-survey] improve qualtrics error reporting

### DIFF
--- a/facebook/delphiFacebook/python/delphi_facebook/qualtrics.py
+++ b/facebook/delphiFacebook/python/delphi_facebook/qualtrics.py
@@ -94,7 +94,7 @@ def get(fetch,post,params):
                 print()
             wait,waitt = progress(t)
         if progressStatus=="failed":
-            return r
+            raise Exception(f"ERROR: could not download \"{surv['name']}\"\n{json.dumps(r.json(),sort_keys=True,indent=2)}")
         fileId = r.json()['result']['fileId']
         r = fetch(f"{base}{fileId}/file")
         if not r.ok: return r


### PR DESCRIPTION
### Description
If we fail to download a Qualtrics file, that's a major problem that should halt the pipeline. This PR ensures that will happen.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- qualtrics.py: throw exception instead of printing error with early return
