### PR TITLE
[fb-survey] Switch to filtering with dplyr::filter

### DIFF
--- a/facebook/delphiFacebook/R/responses.R
+++ b/facebook/delphiFacebook/R/responses.R
@@ -185,23 +185,25 @@ load_response_one <- function(input_filename, params) {
 #' @param params named list containing values "static_dir", "start_time", and
 #'   "end_time"
 #'
-#' @importFrom dplyr anti_join
+#' @importFrom dplyr anti_join filter
 #' @importFrom rlang .data
 #' @export
 filter_responses <- function(input_data, params) {
-  # take only the first instance of each token
   input_data <- arrange(input_data, .data$StartDate)
-  input_data <- input_data[input_data$token != "",]
-  input_data <- input_data[!duplicated(input_data$token),]
-
-  input_data <- input_data[input_data$S1 == 1, ]
-  input_data <- input_data[input_data$DistributionChannel != "preview", ]
-
-  # take the right dates. We don't filter the start date because the aggregate
+  
+  ## Remove invalid, duplicated, and out-of-range observations.
+  # Take only the first instance of each token.
+  # Take the right dates. We don't filter the start date because the aggregate
   # and individual data pipelines handle that themselves (aggregate in
   # particular needs data well before start_date)
-  input_data <- input_data[as.Date(input_data$date) <= params$end_date, ]
-
+  input_data <- filter(input_data, 
+                       token != "", 
+                       !duplicated(token), 
+                       S1 == 1, 
+                       DistributionChannel != "preview",
+                       as.Date(date) <= params$end_date
+  )
+  
   return(input_data)
 }
 
@@ -290,18 +292,20 @@ create_data_for_aggregatation <- function(input_data)
 #'   `start_date`, so estimates on `start_date` are based on the correct data.
 #'
 #' @export
+#' 
+#' @importFrom dplyr filter
 filter_data_for_aggregatation <- function(df, params, lead_days = 12L)
 {
   # Exclude responses with bad zips
   known_zips <- produce_zip_metadata(params$static_dir)
-  df <- df[df$zip5 %in% known_zips$zip5,]
-
-  df <- df[!is.na(df$hh_number_sick) & !is.na(df$hh_number_total), ]
-  df <- df[dplyr::between(df$hh_number_sick, 0L, 30L), ]
-  df <- df[dplyr::between(df$hh_number_total, 1L, 30L), ]
-  df <- df[df$hh_number_sick <= df$hh_number_total, ]
-
-  df <- df[df$day >= (as.Date(params$start_date) - lead_days), ]
+  df <- filter(df, 
+               zip5 %in% known_zips$zip5,
+               !is.na(hh_number_sick) & !is.na(hh_number_total),
+               dplyr::between(hh_number_sick, 0L, 30L),
+               dplyr::between(hh_number_total, 1L, 30L),
+               hh_number_sick <= hh_number_total,
+               day >= (as.Date(params$start_date) - lead_days),
+  )
 
   return(df)
 }

--- a/facebook/delphiFacebook/tests/testthat/test-responses.R
+++ b/facebook/delphiFacebook/tests/testthat/test-responses.R
@@ -93,6 +93,52 @@ test_that("in case of duplicates, new input takes precedence", {
   expect_equal(!!out$some_value, !!expected$some_value)
 })
 
+test_that("filter_responses works correctly", {
+  params <- list(end_date=as.Date("2021-02-01"))
+    
+  input <- tibble(
+    token = c("", 1, 1, 2, 3, 4, 5, 6, 7),
+    S1 = c(1, 1, 1, 1, 1, 1, 0, 1, 1),
+    DistributionChannel = c("notpreview", "notpreview", "notpreview", "notpreview", NA, "notpreview", "notpreview", "preview", "notpreview"),
+    StartDate = c("2021-01-01", "2021-01-01", "2021-01-02", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-02-24"),
+    date = c("2021-01-01", "2021-01-01", "2021-01-02", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-02-24")
+  )
+  
+  expected <- tibble(
+    token = c("1", "2", "4"),
+    S1 = c(1, 1, 1),
+    DistributionChannel = c("notpreview", "notpreview", "notpreview"),
+    StartDate = c("2021-01-01", "2021-01-01", "2021-01-01"),
+    date = c("2021-01-01", "2021-01-01", "2021-01-01")
+  )
+  
+  expect_equal(filter_responses(input, params), 
+               expected)
+})
+
+test_that("filter_data_for_aggregatation works correctly", {
+  params <- list(start_date=as.Date("2021-01-05"), static_dir=test_path("static"))
+  
+  input <- tibble(
+    zip5 = c("00000", "10001", "10001", "10001", "10001", "10001", "10001", "10001", "10001", "10001", "10001", "10001", "10001"),
+    hh_number_sick = c(0, NA, 4, -5, 55, 5, 5, 5, 3, 3, 0, 30, 1),
+    hh_number_total = c(1, 4, NA, 5, 5, -5, 100, 5, 5, 1, 1, 30, 1),
+    day = c("2021-01-01", "2021-01-01", "2021-01-02", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2020-01-01"),
+    date = c("2021-01-01", "2021-01-01", "2021-01-02", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01", "2020-01-01")
+  )
+  
+  expected <- tibble(
+    zip5 = c("10001", "10001", "10001", "10001"),
+    hh_number_sick = c(5, 3, 0, 30),
+    hh_number_total = c(5, 5, 1, 30),
+    day = c("2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01"),
+    date = c("2021-01-01", "2021-01-01", "2021-01-01", "2021-01-01")
+  )
+
+  expect_equal(filter_data_for_aggregatation(input, params), 
+               expected)
+})
+
 test_that("V4 bodge works correctly", {
   foo <- tibble(
     UserLanguage = c("EN", "ES", "EN", NA, "ZH"),


### PR DESCRIPTION
### Description
`filter_responses` and `filter_data_for_aggregation` previously used bracket filtering (`df[logical_row_selection, ]`), which is slow and has unexpected behavior when a variable used for filtering contains `NA` (a missing value). This change swaps in dplyr's `filter` to fix these issues, and adds tests to check filter correctness and behavior with missing values.

### Changelog
- Move all `filter_data_for_aggregatation` filters to using `dplyr::filter`
- Move all `filter_responses` filters to using `dplyr::filter`
- Add tests for both functions

### FIxes
Motivating historical bug via @capnrefsmmat : "we once had a response with DistributionChannel = NA, and it turns out that with [, indexing with a logical vector containing an NA gives you a row that's completely NA... i.e. foo[c(TRUE, NA, FALSE), ] gives a df with two rows, one entirely NA"