### PR TITLE
Remove old mask signal from consideration by Sir Complains-a-lot

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -38,7 +38,8 @@
     },
     "fb-survey": {
       "max_age": 3,
-      "maintainers": ["U01069KCRS7"]
+      "maintainers": ["U01069KCRS7"],
+      "retired-signals": ["smoothed_wearing_mask"]
     },
     "indicator-combination": {
       "max_age": 4,

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -38,7 +38,8 @@
     },
     "fb-survey": {
       "max_age": 3,
-      "maintainers": ["U01069KCRS7"]
+      "maintainers": ["U01069KCRS7"],
+      "retired-signals": ["smoothed_wearing_mask"]
     },
     "indicator-combination": {
       "max_age": 3,


### PR DESCRIPTION
### Description
Wave 8 replaced the old `smoothed_wearing_mask` signal with `smoothed_wearing_mask_7d`, so we should stop checking the old signal for lag in Sir CAL.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- add `smoothed_wearing_mask` to retired signals in dev and prod parameters