### PR TITLE
Drop weighted mask signal from consideration by sirCAL

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -39,7 +39,7 @@
     "fb-survey": {
       "max_age": 3,
       "maintainers": ["U01069KCRS7"],
-      "retired-signals": ["smoothed_wearing_mask"]
+      "retired-signals": ["smoothed_wearing_mask", "smoothed_wwearing_mask"]
     },
     "indicator-combination": {
       "max_age": 4,

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -39,7 +39,7 @@
     "fb-survey": {
       "max_age": 3,
       "maintainers": ["U01069KCRS7"],
-      "retired-signals": ["smoothed_wearing_mask"]
+      "retired-signals": ["smoothed_wearing_mask", "smoothed_wwearing_mask"]
     },
     "indicator-combination": {
       "max_age": 3,


### PR DESCRIPTION
### Description
This was mistakenly left out of #883

### Changelog
Itemize code/test/documentation changes and files added/removed.
- production and dev template params: include smoothed_wwearing_mask in retired signals list

### Fixes 
- Fixes increasing max lag for fb-survey in dashboard
