### PR TITLE
Set minimum epidata version for combo cases/deaths

### DIFF
--- a/combo_cases_and_deaths/setup.py
+++ b/combo_cases_and_deaths/setup.py
@@ -7,7 +7,7 @@ required = [
     "pytest",
     "pytest-cov",
     "pylint",
-    "delphi-utils",
+    "delphi-utils>=0.0.12",
     "covidcast>=0.1.4"
 ]
 


### PR DESCRIPTION
### Description
Enforces at least delphi-epidata 0.0.12 in combod cases/deaths setup.py. This *should* cut down on the unreliability & content-type pipeline failures we've been seeing.

### Changelog
- setup.py
