### PR TITLE
[fb-package] Specify environment timezone

### DIFF
--- a/facebook/delphiFacebook/R/dates.R
+++ b/facebook/delphiFacebook/R/dates.R
@@ -1,5 +1,6 @@
 # Time zone to use throughout package.
 tz_to <- "America/Los_Angeles"
+Sys.setenv(TZ=tz_to)
 
 #' Get the date of the first day of the previous month.
 #'


### PR DESCRIPTION
### Description
Explicitly sets R environment timezone to LA/Pacific time.

### Fixes 
Fixes potential problem where we could get different output if we run the pipeline on a computer with a different system timezone. Based on some profiling, a small but not insignificant amount of run time is taken up by checking the computer's timezone setting, so this change stands to improve run time slightly.

### Impact
Currently, the FB pipeline runs on a machine in Pittsburgh (Eastern time), so this change may impact indicator values. TBD: what is the magnitude of this change?