### PR TITLE
[combo cases/deaths] restrict issues fetched

### DIFF
--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -86,7 +86,7 @@ def compute_special_geo_dfs(df, signal, geo):
     return df
 
 
-def combine_usafacts_and_jhu(signal, geo, date_range, fetcher=covidcast.signal):
+def combine_usafacts_and_jhu(signal, geo, date_range, issue_range=None, fetcher=covidcast.signal):
     """Add rows for PR from JHU signals to USA-FACTS signals.
 
     For hhs and nation, fetch the county `num` data so we can compute the proportions correctly
@@ -95,10 +95,18 @@ def combine_usafacts_and_jhu(signal, geo, date_range, fetcher=covidcast.signal):
     is_special_geo = geo in ["hhs", "nation"]
     geo_to_fetch = "county" if is_special_geo else geo
     signal_to_fetch = signal.replace("_prop", "_num") if is_special_geo else signal
-    print("Fetching usa-facts...")
-    usafacts_df = fetcher("usa-facts", signal_to_fetch, date_range[0], date_range[1], geo_to_fetch)
-    print("Fetching jhu-csse...")
-    jhu_df = fetcher("jhu-csse", signal_to_fetch, date_range[0], date_range[1], geo_to_fetch)
+    usafacts_df = fetcher(
+        "usa-facts", signal_to_fetch,
+        date_range[0], date_range[1],
+        geo_to_fetch,
+        issues=issue_range
+    )
+    jhu_df = fetcher(
+        "jhu-csse", signal_to_fetch,
+        date_range[0], date_range[1],
+        geo_to_fetch,
+        issues=issue_range
+    )
     if check_none_data_frame(usafacts_df, "USA-FACTS", date_range) and \
        (geo_to_fetch not in ('state', 'county') or
         check_none_data_frame(jhu_df, "JHU", date_range)):
@@ -167,44 +175,65 @@ def configure(variants, params):
     """Validate params file and set date range."""
     params['indicator']['export_start_date'] = date(*params['indicator']['export_start_date'])
     yesterday = date.today() - timedelta(days=1)
-    if params['indicator']['date_range'] == 'new':
+    next_day = next_missing_day(
+        params['indicator']["source"],
+        set(signal[-1] for signal in variants)
+    )
+    configure_range(params, 'date_range', yesterday, next_day)
+    # pad issue range in case we caught jhu but not usafacts or v/v in the last N issues
+    configure_range(params, 'issue_range', yesterday, next_day - timedelta(days=7))
+    return params
+
+def configure_range(params, range_param, yesterday, next_day):
+    """Configure a parameter which stores a range of dates.
+
+    May be specified in params.json as:
+      "new" - set to [next_day, yesterday]
+      "all" - set to [export_start_date, yesterday]
+      yyyymmdd-yyyymmdd - set to exact range
+    """
+    if range_param not in params['indicator'] or params['indicator'][range_param] == 'new':
         # only create combined file for the newest update
         # (usually for yesterday, but check just in case)
-        params['indicator']['date_range'] = [
+        params['indicator'][range_param] = [
             min(
                 yesterday,
-                next_missing_day(
-                    params['indicator']["source"],
-                    set(signal[-1] for signal in variants)
-                )
+                next_day
             ),
             yesterday
         ]
-    elif params['indicator']['date_range'] == 'all':
+    elif params['indicator'][range_param] == 'all':
         # create combined files for all of the historical reports
-        params['indicator']['date_range'] = [params['indicator']['export_start_date'], yesterday]
+        if range_param == 'date_range':
+            params['indicator'][range_param] = [params['indicator']['export_start_date'], yesterday]
+        elif range_param == 'issue_range':
+            # for issue_range=all we want the latest issue for all requested
+            # dates, aka the default when issue is unspecified
+            params['indicator'][range_param] = None
+        else:
+            raise ValueError(
+                f"Bad Programmer: Invalid range_param '{range_param}';"
+                f"expected 'date_range' or 'issue_range'")
     else:
-        match_res = re.findall(re.compile(r'^\d{8}-\d{8}$'), params['indicator']['date_range'])
+        match_res = re.findall(re.compile(r'^\d{8}-\d{8}$'), params['indicator'][range_param])
         if len(match_res) == 0:
             raise ValueError(
-                "Invalid date_range parameter. Please choose from (new, all, yyyymmdd-yyyymmdd).")
+                f"Invalid {range_param} parameter. Try (new, all, yyyymmdd-yyyymmdd).")
         try:
-            date1 = datetime.strptime(params['indicator']['date_range'][:8], '%Y%m%d').date()
+            date1 = datetime.strptime(params['indicator'][range_param][:8], '%Y%m%d').date()
         except ValueError as error:
             raise ValueError(
-                "Invalid date_range parameter. Please check the first date.") from error
+                f"Invalid {range_param} parameter. Please check the first date.") from error
         try:
-            date2 = datetime.strptime(params['indicator']['date_range'][-8:], '%Y%m%d').date()
+            date2 = datetime.strptime(params['indicator'][range_param][-8:], '%Y%m%d').date()
         except ValueError as error:
             raise ValueError(
-                "Invalid date_range parameter. Please check the second date.") from error
+                f"Invalid {range_param} parameter. Please check the second date.") from error
 
-        #The the valid start date
+        # ensure valid start date
         if date1 < params['indicator']['export_start_date']:
             date1 = params['indicator']['export_start_date']
-        params['indicator']['date_range'] = [date1, date2]
-    return params
-
+        params['indicator'][range_param] = [date1, date2]
 
 def run_module(params):
     """
@@ -237,7 +266,8 @@ def run_module(params):
     for metric, geo_res, sensor_name, signal in variants:
         df = combine_usafacts_and_jhu(signal,
                                       geo_res,
-                                      extend_raw_date_range(params, sensor_name))
+                                      extend_raw_date_range(params, sensor_name),
+                                      params['indicator']['issue_range'])
         df["timestamp"] = pd.to_datetime(df["timestamp"])
         start_date = pd.to_datetime(params['indicator']['export_start_date'])
         export_dir = params["common"]["export_dir"]

--- a/combo_cases_and_deaths/tests/test_run.py
+++ b/combo_cases_and_deaths/tests/test_run.py
@@ -48,10 +48,10 @@ def test_unstable_sources():
     placeholder = lambda geo: pd.DataFrame(
         [(date.today(),"pr" if geo == "state" else "72000",1,1,1)],
         columns="time_value geo_value value stderr sample_size".split())
-    fetcher10 = lambda *x: placeholder(x[-1]) if x[0] == "usa-facts" else None
-    fetcher01 = lambda *x: placeholder(x[-1]) if x[0] == "jhu-csse" else None
-    fetcher11 = lambda *x: placeholder(x[-1])
-    fetcher00 = lambda *x: None
+    fetcher10 = lambda *x, **k: placeholder(x[-1]) if x[0] == "usa-facts" else None
+    fetcher01 = lambda *x, **k: placeholder(x[-1]) if x[0] == "jhu-csse" else None
+    fetcher11 = lambda *x, **k: placeholder(x[-1])
+    fetcher00 = lambda *x, **k: None
 
     date_range = [date.today(), date.today()]
 
@@ -62,7 +62,7 @@ def test_unstable_sources():
                 (fetcher10, 1),
                 (fetcher11, 1 if geo in ["msa", "nation", "hhs"] else 2)
         ]:
-            df = combine_usafacts_and_jhu("", geo, date_range, fetcher)
+            df = combine_usafacts_and_jhu("", geo, date_range, fetcher=fetcher)
             assert df.size == expected_size * len(COLUMN_MAPPING), f"""
 Wrong number of rows in combined data frame for the number of available signals.
 


### PR DESCRIPTION
### Description
Type of change (bug fix, new feature, etc), brief description, and motivation for these changes.

We're currently generating random 502 Bad Gateway errors on combo cases runs. One hypothesis is that at this point, combo cases pulls so many rows (~1M or more) that some of the replicas are getting overtaxed and the load balancer gives up on them.

This PR will generate the same number of _queries_, but the vast majority of them should return zero results. It also adds an optional config param if you for some reason want to manually specify the range of issues, or switch back to fetching the most recent issue for each date pulled no matter how old it is.

The default behavior will only fetch issues from the last week or so.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- generalize date range calculations (new|all|yyyymmdd-yyyymmdd) in their own function
- specify `issues` in calls to `covidcast.signal`
- drop now-superfluous "Fetching jhu-csse|usa-facts..." printcruft

### Fixes 
- Fixes #903 
