### PR TITLE
Stop sending slack messages directly from Sircal

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -1,5 +1,4 @@
 {
-  "channel": "#sir-complains-a-lot",
   "log_filename": "/var/log/indicators/sircal.log",
   "slack_token": "{{ sir_complainsalot_slack_token }}",
   "sources": {


### PR DESCRIPTION
Remove the slack channel from the sircal config since we are alerting through ELK monitoring.
