### PR TITLE
hhs_hosp: move indicator_prefix from command line to production params

### DIFF
--- a/ansible/templates/hhs_hosp-params-prod.json.j2
+++ b/ansible/templates/hhs_hosp-params-prod.json.j2
@@ -9,7 +9,7 @@
       "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"
     },
     "bucket_name": "delphi-covidcast-indicator-output",
-    "cache_dir": "./cache"
+    "cache_dir": "./cache",
+    "indicator_prefix": "delphi_hhs_hosp"
   }
-
 }

--- a/hhs_hosp/Makefile
+++ b/hhs_hosp/Makefile
@@ -25,4 +25,4 @@ clean:
 
 run:
 	env/bin/python -m $(dir)
-	env/bin/python -m delphi_utils.archive --archive_type s3 --indicator_prefix $(dir)
+	env/bin/python -m delphi_utils.archive


### PR DESCRIPTION
### Description
The indicator runner refactor changed the expected call and params signature of delphi_utils.archive, which confused hhs_hosp. This PR corrects the production params as well as how delphi_utils.archive is called in `make run`.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- hhs_hosp/Makefile: drop command line arguments; these are read out of params instead
- hhs_hosp production params: specify indicator_prefix

### Fixes 
- Fixes failed hhs_hosp indicator run
