### PR TITLE
Change CAN export dir to dashes instead of underscores

### DIFF
--- a/ansible/templates/covid_act_now-params-prod.json.j2
+++ b/ansible/templates/covid_act_now-params-prod.json.j2
@@ -1,6 +1,6 @@
 {
   "common": {
-    "export_dir": "/common/covidcast/receiving/covid_act_now"
+    "export_dir": "/common/covidcast/receiving/covid-act-now"
   },
   "indicator": {
     "parquet_url": "https://storage.googleapis.com/can-scrape-outputs/final/can_scrape_api_covid_us.parquet"


### PR DESCRIPTION
### Description
Dashes are consistent with the rest of the sources.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Update ansible params.json to use receiving folder with dashes.
