### PR TITLE
combo cases: drop all but the most recent issue

### DIFF
--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -134,6 +134,14 @@ def combine_usafacts_and_jhu(signal, geo, date_range, issue_range=None, fetcher=
             # se and sample size are required later so we add them back.
             combined_df["se"] = combined_df["sample_size"] = None
         combined_df.rename({geo: "geo_id"}, axis=1, inplace=True)
+
+    # default sort from API is ORDER BY signal, time_value, geo_value, issue
+    # we want to drop all but the most recent (last) issue
+    combined_df.drop_duplicates(
+        subset=["geo_id", "timestamp"],
+        keep="last",
+        inplace=True
+    )
     return combined_df
 
 def extend_raw_date_range(params, sensor_name):

--- a/combo_cases_and_deaths/tests/test_run.py
+++ b/combo_cases_and_deaths/tests/test_run.py
@@ -39,36 +39,56 @@ All variants: {variants}
 Date-extended variants: {variants_changed}
 """
 
-
-def test_unstable_sources():
+@patch("covidcast.covidcast.signal")
+def test_unstable_sources(mock_covidcast_signal):
     """Verify that combine_usafacts_and_jhu assembles the combined data
     frame correctly for all cases where 0, 1, or both signals are
     available.
     """
-    placeholder = lambda geo: pd.DataFrame(
-        [(date.today(),"pr" if geo == "state" else "72000",1,1,1)],
-        columns="time_value geo_value value stderr sample_size".split())
-    fetcher10 = lambda *x, **k: placeholder(x[-1]) if x[0] == "usa-facts" else None
-    fetcher01 = lambda *x, **k: placeholder(x[-1]) if x[0] == "jhu-csse" else None
-    fetcher11 = lambda *x, **k: placeholder(x[-1])
-    fetcher00 = lambda *x, **k: None
+    def jhu(geo, c=[0]):
+        c[0] += 1
+        return pd.DataFrame(
+            [(date.fromordinal(c[0]),"pr" if geo == "state" else "72000",1,1,1)],
+            columns="time_value geo_value value stderr sample_size".split())
+    def uf(geo, c=[0]):
+        c[0] += 1
+        return pd.DataFrame(
+            [(date.fromordinal(c[0]),"ny" if geo == "state" else "36000",1,1,1)],
+            columns="time_value geo_value value stderr sample_size".split())
+    def make_mock(geo):
+        return [
+            # 1 0
+            uf(geo), None,
+            # 0 1
+            None, jhu(geo),
+            # 1 1
+            uf(geo), jhu(geo),
+            # 0 0
+            None, None
+        ]
 
+    geos = ["state", "county", "msa", "nation", "hhs"]
+    outputs = [df for g in geos for df in make_mock(g)]
+    mock_covidcast_signal.side_effect = outputs[:]
+    
     date_range = [date.today(), date.today()]
 
-    for geo in ["state", "county", "msa", "nation", "hhs"]:
-        for (fetcher, expected_size) in [
-                (fetcher00, 0),
-                (fetcher01, 0 if geo == "msa" else 1),
-                (fetcher10, 1),
-                (fetcher11, 1 if geo in ["msa", "nation", "hhs"] else 2)
+    calls = -1
+    for geo in geos:
+        for config, expected_size in [
+                ("1 0", 1),
+                ("0 1", 0 if geo == "msa" else 1),
+                ("1 1", 1 if geo in ["msa", "nation", "hhs"] else 2),
+                ("0 0", 0)
         ]:
-            df = combine_usafacts_and_jhu("", geo, date_range, fetcher=fetcher)
+            calls += 1
+            df = combine_usafacts_and_jhu("", geo, date_range, fetcher=mock_covidcast_signal)
             assert df.size == expected_size * len(COLUMN_MAPPING), f"""
 Wrong number of rows in combined data frame for the number of available signals.
 
-input for {geo}:
-{fetcher('usa-facts',geo)}
-{fetcher('jhu-csse',geo)}
+input for {geo} {config}:
+{outputs[2*calls]}
+{outputs[2*calls + 1]}
 
 output:
 {df}
@@ -76,6 +96,30 @@ output:
 expected rows: {expected_size}
 """
 
+
+@patch("covidcast.covidcast.signal")
+def test_multiple_issues(mock_covidcast_signal):
+    """Verify that only the most recent issue is retained."""
+    mock_covidcast_signal.side_effect = [
+        pd.DataFrame({
+            "geo_value": ["01000", "01000"],
+            "value": [1, 10],
+            "timestamp": [20200101, 20200101],
+            "issue": [20200102, 20200104]
+        }),
+        None
+    ]
+    result = combine_usafacts_and_jhu("confirmed_incidence_num", "county", date_range=(0, 1), fetcher=mock_covidcast_signal)
+    pd.testing.assert_frame_equal(
+        result,
+        pd.DataFrame({
+            "geo_id": ["01000"],
+            "val": [10],
+            "timestamp": [20200101],
+            "issue": [20200104]
+        },
+                     index=[1])
+    )
 
 def test_compute_special_geo_dfs():
     test_df = pd.DataFrame({"geo_id": ["01000", "01001"],

--- a/combo_cases_and_deaths/tests/test_run.py
+++ b/combo_cases_and_deaths/tests/test_run.py
@@ -112,13 +112,15 @@ def test_multiple_issues(mock_covidcast_signal):
     result = combine_usafacts_and_jhu("confirmed_incidence_num", "county", date_range=(0, 1), fetcher=mock_covidcast_signal)
     pd.testing.assert_frame_equal(
         result,
-        pd.DataFrame({
-            "geo_id": ["01000"],
-            "val": [10],
-            "timestamp": [20200101],
-            "issue": [20200104]
-        },
-                     index=[1])
+        pd.DataFrame(
+            {
+                "geo_id": ["01000"],
+                "val": [10],
+                "timestamp": [20200101],
+                "issue": [20200104]
+            },
+            index=[1]
+        )
     )
 
 def test_compute_special_geo_dfs():


### PR DESCRIPTION
### Description
If any region+date was updated more than once in the last week, then #906 accidentally included all retrieved issues. Luckily, this caused problems with the archiver, otherwise we wouldn't have known about the problem.

This PR drops duplicates based on `geo_id` and `timestamp`. It also refactors the unstable_sources test, since it used to rely on a blissful ignorance of duplicates

### Changelog
Itemize code/test/documentation changes and files added/removed.
- run.py:combine_usafacts_and_jhu() - drop duplicates, keeping the most recent issue
- test_run.py: add test for multiple issues, & refactor unstable_sources test to use mock instead of hacky lambdas

### Fixes 
- Fixes #910 
