### PR TITLE
[fb-survey] Support new wording of V4a "local health" item

### DIFF
--- a/facebook/delphiFacebook/R/binary.R
+++ b/facebook/delphiFacebook/R/binary.R
@@ -115,7 +115,9 @@ get_binary_indicators <- function() {
     "smoothed_wvaccine_likely_govt_health", "weight", "v_vaccine_likely_govt_health", 6, compute_binary_response, jeffreys_binary,
     "smoothed_vaccine_likely_politicians", "weight_unif", "v_vaccine_likely_politicians", 6, compute_binary_response, jeffreys_binary,
     "smoothed_wvaccine_likely_politicians", "weight", "v_vaccine_likely_politicians", 6, compute_binary_response, jeffreys_binary,
-
+    "smoothed_vaccine_likely_doctors", "weight_unif", "v_vaccine_likely_doctors", 6, compute_binary_response, jeffreys_binary,
+    "smoothed_wvaccine_likely_doctors", "weight", "v_vaccine_likely_doctors", 6, compute_binary_response, jeffreys_binary,
+    
     # vaccine hesitancy reasons
     "smoothed_hesitancy_reason_sideeffects", "weight_unif", "v_hesitancy_reason_sideeffects", 6, compute_binary_response, jeffreys_binary,
     "smoothed_whesitancy_reason_sideeffects", "weight", "v_hesitancy_reason_sideeffects", 6, compute_binary_response, jeffreys_binary,

--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -342,16 +342,25 @@ code_vaccines <- function(input_data) {
 
   if ("V4_1" %in% names(input_data)) {
     input_data$v_vaccine_likely_friends <- input_data$V4_1 == 1
-    input_data$v_vaccine_likely_local_health <- input_data$V4_2 == 1
     input_data$v_vaccine_likely_who <- input_data$V4_3 == 1
     input_data$v_vaccine_likely_govt_health <- input_data$V4_4 == 1
     input_data$v_vaccine_likely_politicians <- input_data$V4_5 == 1
+    
+    if (wave < 8) {
+      input_data$v_vaccine_likely_local_health <- input_data$V4_2 == 1
+      input_data$v_vaccine_likely_doctors <- NA_real_
+    } else {
+      input_data$v_vaccine_likely_local_health <- NA_real_
+      input_data$v_vaccine_likely_doctors <- input_data$V4_2 == 1
+    }
+    
   } else {
     input_data$v_vaccine_likely_friends <- NA_real_
     input_data$v_vaccine_likely_local_health <- NA_real_
     input_data$v_vaccine_likely_who <- NA_real_
     input_data$v_vaccine_likely_govt_health <- NA_real_
     input_data$v_vaccine_likely_politicians <- NA_real_
+    input_data$v_vaccine_likely_doctors <- NA_real_
   }
 
   if ("V5a" %in% names(input_data) && "V5b" %in% names(input_data) && "V5c" %in% names(input_data)) {


### PR DESCRIPTION
### Description
Create new indicator for changed wording of V4a subitem 2.

### Fixes
In Wave 8, the subitem was switched from asking about "Local health workers" to "Doctors and other health professionals you go to for medical care". This resulted in a sharp increase in reported trust that is misleading when the new and old versions are reported under the same signal name.

### Impact
@krivard We will need to reissue survey data going back to Feb 8, the Wave 8 release date, to incorporate this change.