### PR TITLE
Add backfill util

### DIFF
--- a/_delphi_utils_python/delphi_utils/backfill_profiler.py
+++ b/_delphi_utils_python/delphi_utils/backfill_profiler.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Created on Sun Feb 23 22:39:07 2021
-
-@author: jingjingtang
+"""Functions for the backfill profiler.
 
 Derive a detailed definition of "backfill profile", create a "Backfill
 Profiler" tool for calculating it for any source which can Plot the full
@@ -184,9 +181,10 @@ def create_heatmap_by_refdate(save_dir:str, backfill_df:pd.DataFrame,
                                 source:str, start_date:datetime,
                                 end_date:datetime, geo_values=None,
                                 max_lag=90):
-    """Create heatmaps of the backfill estimates by lags and reference date for
-    each location specified in the geo_values.
+    """Create heatmaps of the backfill estimates.
 
+    The heatmaps show backfill estimates by lags and reference date for
+    each location specified in the geo_values.
     The reference date will show as the y-axis while the lag will be the
     x-axis. The color filled represents the value of the backfill estimates.
     The created heatmaps will be stored in the save_dir as multiple png files.
@@ -288,14 +286,14 @@ def create_lineplot_by_loations(save_dir:str, backfill_df:pd.DataFrame,
                                   source:str, fig_name:str,
                                   start_date:datetime, end_date:datetime,
                                   geo_values=None, max_lag=90):
-    """Create a lineplot of the backfill estimates by lag and location for
-    across a certain range of reference dates.
+    """Create a lineplot of the backfill estimates.
 
-    The backfill estimates will show as the y-axis while the lag will be the
-    x-axis. Each line represents the mean across reference dates for a specific
-    location with 95% confidence interval shown as the band. The created
-    lineplot will be stored in the save_dir with specified figure name as a
-    png files.
+    The lineplot show the backfill estimates by lag and location for
+    across a certain range of reference dates. The backfill estimates will
+    show as the y-axis while the lag will be the x-axis. Each line represents
+    the mean across reference dates for a specific location with 95% confidence
+    interval shown as the band. The created lineplot will be stored in the
+    save_dir with specified figure name as a png files.
 
     Parameters
     ----------
@@ -381,9 +379,10 @@ def create_violinplot_by_lag(save_dir: str, backfill_df:pd.DataFrame,
                                source:str, start_date:datetime,
                                end_date:datetime, geo_values=None,
                                max_lag=90):
-    """Create violinplots of the backfill estimates by lags and location across
-    a certain rane of reference date for each location specified in geo_values.
+    """Create violinplots of the backfill estimates.
 
+    The violinplots show the backfill estimates by lags and location across
+    a certain rane of reference date for each location specified in geo_values.
     Each violin shows the distribution of quantitative backfill estimates
     across reference dates for a specific location and lag. The created
     violinplots will be stored in the save_dir as multiple png files.
@@ -585,13 +584,14 @@ def create_summary_plots(save_dir, backfill_df,
 def backfill_mean_check(backfill_df:pd.DataFrame, lag:int, geo_value,
                         test_start_date:datetime, test_end_date:datetime,
                         train_start_date:datetime, train_end_date:datetime):
-    """Conduct a two-sided t-test for the null hypothesis that 2 independent
-    samples have identical average (expected) values.
+    """Conduct a two-sided t-test for the means of the backfill estimates.
 
-    This test assumes that the populations have unknown variance.
-    Calculate the T-test for the means of the backfill estimates of two time
-    period. Use historical data for training, should include at least 28 days.
-    Use the dates of interest for testing, should include at least 7 days.
+    Two-sided t-test for null hypothesis that 2 independent samples have
+    identical average (expected) values. This test assumes that the
+    populations have unknown variance. Calculate the T-test for the means of
+    the backfill estimates of two time period. Use historical data for
+    training, should include at least 28 days. Use the dates of interest for
+    testing, should include at least 7 days.
 
     Parameters
     ----------
@@ -659,8 +659,7 @@ def create_mean_check_df(save_dir:str, backfill_df:pd.DataFrame,
                       test_start_date:datetime, test_end_date:datetime,
                       train_start_date:datetime, train_end_date:datetime,
                       lags=None, geo_values=None):
-    """Create a csv file for the results of the two-sided t-tests as described
-    in backfill_mean_check function.
+    """Create a csv file for the results of the two-sided t-tests.
 
     The t-tests will be conducted for each lag and each location.
 

--- a/_delphi_utils_python/delphi_utils/backfill_profiler.py
+++ b/_delphi_utils_python/delphi_utils/backfill_profiler.py
@@ -26,8 +26,7 @@ import seaborn as sns
 from scipy import stats
 
 def check_create_dir(save_dir:str):
-    """
-    Create the directory for saving figures if it is not existed
+    """Create the directory for saving figures if it is not existed
 
     Parameters
     ----------
@@ -45,8 +44,7 @@ def check_create_dir(save_dir:str):
 
 def to_covidcast_df(df:pd.DataFrame, lag_col:str, time_value_col:str,
                     geo_value_col:str, sample_size_col:str, value_col:str):
-    """
-    Conform the input dataframe into COVIDcast format. The  lag_column,
+    """Conform the input dataframe into COVIDcast format. The  lag_column,
     time_value_column, geo_value_column, sample_size_column, value_column are
     necesssary. More detailed description of the values in these columns can
     ben found in `help(covidcast.signal)`
@@ -91,8 +89,7 @@ def to_covidcast_df(df:pd.DataFrame, lag_col:str, time_value_col:str,
 
 def to_backfill_df(df, data_type = "completeness",
                    value_type="total_count", ref_lag=60):
-    """
-    Conform the dataset in COVIDcast API format into a backfill dataset.
+    """Conform the dataset in COVIDcast API format into a backfill dataset.
 
     The output dataset has:
     - time_value: Reference date of the estimate which is the date the estiamte
@@ -186,8 +183,7 @@ def create_heatmap_by_refdate(save_dir:str, backfill_df:pd.DataFrame,
                                 source:str, start_date:datetime,
                                 end_date:datetime, geo_values=None,
                                 max_lag=90):
-    """
-    Create heatmaps of the backfill estimates by lags and reference date for
+    """Create heatmaps of the backfill estimates by lags and reference date for
     each location specified in the geo_values.
     The reference date will show as the y-axis while the lag will be the
     x-axis. The color filled represents the value of the backfill estimates.
@@ -222,7 +218,6 @@ def create_heatmap_by_refdate(save_dir:str, backfill_df:pd.DataFrame,
     None.
 
     """
-
     check_create_dir(save_dir)
 
     filtered_backfill_df = backfill_df[backfill_df["lag"]<=max_lag]
@@ -291,8 +286,7 @@ def create_lineplot_by_loations(save_dir:str, backfill_df:pd.DataFrame,
                                   source:str, fig_name:str,
                                   start_date:datetime, end_date:datetime,
                                   geo_values=None, max_lag=90):
-    """
-    Create a lineplot of the backfill estimates by lag and location for
+    """Create a lineplot of the backfill estimates by lag and location for
     across a certain range of reference dates.
     The backfill estimates will show as the y-axis while the lag will be the
     x-axis. Each line represents the mean across reference dates for a specific
@@ -329,7 +323,6 @@ def create_lineplot_by_loations(save_dir:str, backfill_df:pd.DataFrame,
     None.
 
     """
-
     check_create_dir(save_dir)
 
     if not geo_values:
@@ -385,8 +378,7 @@ def create_violinplot_by_lag(save_dir: str, backfill_df:pd.DataFrame,
                                source:str, start_date:datetime,
                                end_date:datetime, geo_values=None,
                                max_lag=90):
-    """
-    Create violinplots of the backfill estimates by lags and location across
+    """Create violinplots of the backfill estimates by lags and location across
     a certain rane of reference date for each location specified in geo_values.
     Each violin shows the distribution of quantitative backfill estimates
     across reference dates for a specific location and lag. The created
@@ -419,8 +411,6 @@ def create_violinplot_by_lag(save_dir: str, backfill_df:pd.DataFrame,
     None.
 
     """
-
-
     check_create_dir(save_dir)
 
     if not geo_values:
@@ -472,8 +462,7 @@ def create_violinplot_by_lag(save_dir: str, backfill_df:pd.DataFrame,
 def create_summary_plots(save_dir, backfill_df,
                          source, start_date, end_date,
                          geo_values=None, max_lag=90):
-    """
-    Create two summary plots for the backfill dateframe.
+    """Create two summary plots for the backfill dateframe.
     - A lineplot shows the mean and 95% confidence interval of backfill
     estimates by lag across a certain range of reference dates and all
     locations in geo_values.
@@ -509,7 +498,6 @@ def create_summary_plots(save_dir, backfill_df,
     None.
 
     """
-
     check_create_dir(save_dir)
 
     if not geo_values:
@@ -594,8 +582,7 @@ def create_summary_plots(save_dir, backfill_df,
 def backfill_mean_check(backfill_df:pd.DataFrame, lag:int, geo_value,
                         test_start_date:datetime, test_end_date:datetime,
                         train_start_date:datetime, train_end_date:datetime):
-    """
-    Conduct a two-sided t-test for the null hypothesis that 2 independent
+    """Conduct a two-sided t-test for the null hypothesis that 2 independent
     samples have identical average (expected) values. This test assumes that
     the populations have unknown variance.
     Calculate the T-test for the means of the backfill estimates of two time
@@ -668,8 +655,7 @@ def create_mean_check_df(save_dir:str, backfill_df:pd.DataFrame,
                       test_start_date:datetime, test_end_date:datetime,
                       train_start_date:datetime, train_end_date:datetime,
                       lags=None, geo_values=None):
-    """
-    Create a csv file for the results of the two-sided t-tests as described
+    """Create a csv file for the results of the two-sided t-tests as described
     in backfill_mean_check function. The t-tests will be conducted for each
     lag and each location.
 

--- a/_delphi_utils_python/delphi_utils/backfill_profiler.py
+++ b/_delphi_utils_python/delphi_utils/backfill_profiler.py
@@ -26,7 +26,7 @@ import seaborn as sns
 from scipy import stats
 
 def check_create_dir(save_dir:str):
-    """Create the directory for saving figures if it is not existed
+    """Create the directory for saving figures if it is not existed.
 
     Parameters
     ----------
@@ -44,10 +44,11 @@ def check_create_dir(save_dir:str):
 
 def to_covidcast_df(df:pd.DataFrame, lag_col:str, time_value_col:str,
                     geo_value_col:str, sample_size_col:str, value_col:str):
-    """Conform the input dataframe into COVIDcast format. The  lag_column,
-    time_value_column, geo_value_column, sample_size_column, value_column are
-    necesssary. More detailed description of the values in these columns can
-    ben found in `help(covidcast.signal)`
+    """Conform the input dataframe into COVIDcast format.
+
+    The lag_column, time_value_column, geo_value_column, sample_size_column,
+    value_column are necesssary. More detailed description of the values in
+    these columns can ben found in `help(covidcast.signal)`.
 
     Parameters
     ----------
@@ -185,6 +186,7 @@ def create_heatmap_by_refdate(save_dir:str, backfill_df:pd.DataFrame,
                                 max_lag=90):
     """Create heatmaps of the backfill estimates by lags and reference date for
     each location specified in the geo_values.
+
     The reference date will show as the y-axis while the lag will be the
     x-axis. The color filled represents the value of the backfill estimates.
     The created heatmaps will be stored in the save_dir as multiple png files.
@@ -288,6 +290,7 @@ def create_lineplot_by_loations(save_dir:str, backfill_df:pd.DataFrame,
                                   geo_values=None, max_lag=90):
     """Create a lineplot of the backfill estimates by lag and location for
     across a certain range of reference dates.
+
     The backfill estimates will show as the y-axis while the lag will be the
     x-axis. Each line represents the mean across reference dates for a specific
     location with 95% confidence interval shown as the band. The created
@@ -380,6 +383,7 @@ def create_violinplot_by_lag(save_dir: str, backfill_df:pd.DataFrame,
                                max_lag=90):
     """Create violinplots of the backfill estimates by lags and location across
     a certain rane of reference date for each location specified in geo_values.
+
     Each violin shows the distribution of quantitative backfill estimates
     across reference dates for a specific location and lag. The created
     violinplots will be stored in the save_dir as multiple png files.
@@ -463,6 +467,7 @@ def create_summary_plots(save_dir, backfill_df,
                          source, start_date, end_date,
                          geo_values=None, max_lag=90):
     """Create two summary plots for the backfill dateframe.
+
     - A lineplot shows the mean and 95% confidence interval of backfill
     estimates by lag across a certain range of reference dates and all
     locations in geo_values.
@@ -583,8 +588,9 @@ def backfill_mean_check(backfill_df:pd.DataFrame, lag:int, geo_value,
                         test_start_date:datetime, test_end_date:datetime,
                         train_start_date:datetime, train_end_date:datetime):
     """Conduct a two-sided t-test for the null hypothesis that 2 independent
-    samples have identical average (expected) values. This test assumes that
-    the populations have unknown variance.
+    samples have identical average (expected) values. 
+
+    This test assumes that the populations have unknown variance.
     Calculate the T-test for the means of the backfill estimates of two time
     period. Use historical data for training, should include at least 28 days.
     Use the dates of interest for testing, should include at least 7 days.
@@ -656,8 +662,9 @@ def create_mean_check_df(save_dir:str, backfill_df:pd.DataFrame,
                       train_start_date:datetime, train_end_date:datetime,
                       lags=None, geo_values=None):
     """Create a csv file for the results of the two-sided t-tests as described
-    in backfill_mean_check function. The t-tests will be conducted for each
-    lag and each location.
+    in backfill_mean_check function. 
+
+    The t-tests will be conducted for each lag and each location.
 
     Parameters
     ----------

--- a/_delphi_utils_python/delphi_utils/backfill_profiler.py
+++ b/_delphi_utils_python/delphi_utils/backfill_profiler.py
@@ -582,13 +582,11 @@ def create_summary_plots(save_dir, backfill_df,
     plt.xticks(fontsize=15, rotation=45)
     plt.savefig(save_dir+"/lineplot_by_date.png", bbox_inches='tight')
 
-
-
 def backfill_mean_check(backfill_df:pd.DataFrame, lag:int, geo_value,
                         test_start_date:datetime, test_end_date:datetime,
                         train_start_date:datetime, train_end_date:datetime):
     """Conduct a two-sided t-test for the null hypothesis that 2 independent
-    samples have identical average (expected) values. 
+    samples have identical average (expected) values.
 
     This test assumes that the populations have unknown variance.
     Calculate the T-test for the means of the backfill estimates of two time
@@ -662,7 +660,7 @@ def create_mean_check_df(save_dir:str, backfill_df:pd.DataFrame,
                       train_start_date:datetime, train_end_date:datetime,
                       lags=None, geo_values=None):
     """Create a csv file for the results of the two-sided t-tests as described
-    in backfill_mean_check function. 
+    in backfill_mean_check function.
 
     The t-tests will be conducted for each lag and each location.
 

--- a/_delphi_utils_python/delphi_utils/backfill_profiler.py
+++ b/_delphi_utils_python/delphi_utils/backfill_profiler.py
@@ -1,0 +1,724 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Sun Feb 23 22:39:07 2021
+
+@author: jingjingtang
+
+Derive a detailed definition of "backfill profile", create a "Backfill 
+Profiler" tool for calculating it for any source which can Plot the full 
+backfill value distribution (+mean (bias) and stderr) for each lag till 
+"Finalized" date:
+- Aggregated over reference date & locations, but also separately over 
+  ref date and over locations.
+- These "backfill curves" are proportions indexed by: lag, reference date, 
+  location
+    
+"""
+import os
+from math import log10, ceil, floor
+from datetime import datetime, timedelta
+import matplotlib.pyplot as plt
+
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from scipy import stats
+
+def check_create_dir(save_dir:str):
+    """
+    Create the directory for saving figures if it is not existed
+
+    Parameters
+    ----------
+    save_dir : str
+        Directory for saving analysis figures.
+
+    Returns
+    -------
+    None.
+
+    """
+    if not os.path.exists(save_dir):
+        os.makedirs(save_dir)
+    return
+
+def to_covidcast_df(df:pd.DataFrame, lag_col:str, time_value_col:str, 
+                    geo_value_col:str, sample_size_col:str, value_col:str):
+    """
+    Conform the input dataframe into COVIDcast format. The  lag_column, 
+    time_value_column, geo_value_column, sample_size_column, value_column are 
+    necesssary. More detailed description of the values in these columns can
+    ben found in `help(covidcast.signal)`
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Dataframe need to be conformed.
+    lag_col : str
+        Column name for lag
+    time_value: str
+        Column name for time_value
+    geo_value: str
+        Column name for geo_value
+    sample_size_col: str
+        Column name for sample_size
+    value_col: str
+        Column name for value
+
+    Returns
+    -------
+    df: pd.DataFrame
+
+    """
+    for col in [lag_col,  sample_size_col, value_col]:
+        try:
+            df[col] = df[col.astype(float)]
+        except ValueError:
+            raise ValueError("Values in %s are invalid."%col)
+            
+    try:
+        assert df[time_value_col] == 'datetime64[ns]'
+    except AssertionError:
+        raise ValueError("The values in the time_value_col should be in \
+                         datetime64[ns] format.")
+        
+    df.rename({lag_col: "lag", time_value_col: "time_value",
+               geo_value_col: "geo_value", sample_size_col: "sample_size",
+               value_col: "value"}, inplace=True)
+    return df
+
+
+def to_backfill_df(df, signal, data_type = "completeness",
+                   value_type="total_count", ref_lag=60):
+    """
+    Conform the dataset in COVIDcast API format into a backfill dataset.
+    
+    The output dataset has:
+    - time_value: Reference date of the estimate which is the date the estiamte
+      is for
+    - geo_value: Identifies the location, such as a county FIPS code
+    - lag: Integer difference between issue date and time_value, in days.
+    - value: The quantity requested
+    - value_type: Either "Total counts" (the denominator, usually the total
+      number of counts) or "COVID counts" (the numerator, the number of 
+      quantity interested, such as the number of positive COVID antigen tests)
+    - data_type: Either "completeness" (the percentage of currently reported 
+      counts against the number of reported counts ref_lag days later) 
+      or "log_dailychange" (log10 of the daily change rate)
+    - ref_lag: The fixed lag between the reference date of the estimates and 
+      the issue date used to be compared when considering "completeness"
+        
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Dataset in COVIDcast API format
+    signal : str
+        String identifying the signal from that source to query, such as 
+        "smoothed_cli"
+    data_type : str, optional
+        Either "completeness" or "log_dailychange". 
+        The default is "completeness".
+    value_type : str, optional
+        Either "total_count" or "value_count". 
+        The default is "total_count".
+    ref_lag : int, optional
+        The fixed lag between the reference date of the estimates and 
+      the issue date used to be compared when considering "completeness". 
+      The default is 60.
+
+    Returns
+    -------
+    backfill_df : pd.DataFrame
+        Dataframe as described above.
+
+    """
+    df["count"] = df["sample_size"] * df["value"] / 100
+    
+    if value_type == "total_count":
+        val_col = "sample_size"
+        val_name = "Total counts"
+    else:
+        val_col = "count"
+        val_name = "COVID counts"
+    
+    pivot_df = pd.pivot_table(df, values=val_col, 
+                              index=["geo_value", "time_value"],
+                              columns="lag").reset_index()
+
+    if data_type == "completeness":
+        if ref_lag >= df["lag"].max():
+            print("Not enough days available. ref_lag larger than the \
+                  maxmimum lag included in the provided dataset.")
+            return None
+
+        for i in range(df["lag"].min(), df["lag"].max() + 1):
+            if i == ref_lag:
+                continue
+            pivot_df[i] = pivot_df[i] / pivot_df[60] * 100
+        pivot_df[ref_lag] = pivot_df[ref_lag] / pivot_df[ref_lag] * 100
+    
+    else:
+        for i in range(df["lag"].max(), df["lag"].min(), -1):
+            pivot_df[i] = (pivot_df[i] - pivot_df[i-1]) / pivot_df[i-1]
+        pivot_df.drop(df["lag"].min(), axis=1, inplace=True)
+        
+        
+    backfill_df = pd.melt(pivot_df, id_vars=["geo_value", "time_value"], 
+                          var_name="lag", value_name="value")
+    
+    if data_type == "completeness":
+        backfill_df["value_type"] = val_name
+        backfill_df["data_type"] = "completeness"
+        backfill_df["ref_lag"] = ref_lag
+    else:
+        backfill_df.loc[backfill_df["value"] == 0, "value"] = np.nan
+        backfill_df["value_type"] = val_name
+        backfill_df["data_type"] = "log_dailychange"
+        backfill_df["ref_lag"] = -1
+        backfill_df["value"] = backfill_df["value"].apply(lambda x:log10(x))
+    
+    return backfill_df
+
+
+
+def create_heatmap_over_refdate(save_dir:str, backfill_df:pd.DataFrame, 
+                                source:str, signal:str, 
+                                start_date:datetime, end_date:datetime, 
+                                geo_values=None, max_lag=90):
+    """
+    Create heatmaps of the backfill estimates by lags and reference date for
+    each location specified in the geo_values.
+    The reference date will show as the y-axis while the lag will be the 
+    x-axis. The color filled represents the value of the backfill estimates.
+    The created heatmaps will be stored in the save_dir as multiple png files.
+
+    Parameters
+    ----------
+    save_dir : str
+        Directory for saving the generated figures.
+    backfill_df : pd.DataFrame
+        The dataframe that contains information on either completeness 
+        or daily change rate.
+    source : str
+        String identifying the data source to query, such as "fb-survey".
+    signal : str
+        String identifying the signal from that source to query, such as 
+        "smoothed_cli".
+    start_date : datetime
+        Display data beginning on this date.
+    end_date : datetime
+        Display data up to this date, inclusive.
+    geo_values : list of str, optional
+        The list of locations for which the heatmaps will be created. 
+        The default is None, which means all the locations included in the 
+        backfill_df will be considered. Otherwise, only the locations in the
+        geo_values list will be considered.
+    max_lag : int, optional
+        The maximum lag that will be displayed in the heatmaps. 
+        The default is 90.
+
+    Returns
+    -------
+    None.
+
+    """
+
+    check_create_dir(save_dir)
+    
+    filtered_backfill_df = backfill_df[backfill_df["lag"]<=max_lag]
+    
+    pivot_df = pd.pivot_table(filtered_backfill_df, 
+                              values="value", 
+                              index=["geo_value", "time_value"],
+                              columns="lag").reset_index()
+    MIN_LAG = filtered_backfill_df["lag"].min()
+    value_type = filtered_backfill_df["value_type"].values[0]
+    data_type = filtered_backfill_df["data_type"].values[0]
+    
+    if not geo_values:
+        geo_values = pivot_df["geo_value"].unique()  
+    max_lag =min(backfill_df["lag"].min(), max_lag)
+    
+    if data_type == "completeness":
+        vmax = int((filtered_backfill_df["value"].max()//20 + 1) * 20)
+        vmin = int((filtered_backfill_df["value"].min()//20) * 20)
+        cbar_freq = int((vmax-vmin)/20)
+        cmap = "tab20c_r"
+        cbar_label = "Percentage"
+        ref_lag = backfill_df["ref_lag"].values[0]
+        fig_title = 'Percentage of Completion \
+                \nAgainst values reported %d days later\
+                \n%s %s, %s'%(ref_lag, source, value_type, "%s")
+    else:
+        vmax = ceil(filtered_backfill_df["value"].max())
+        vmin = floor(filtered_backfill_df["value"].min())
+        cbar_freq = int(vmax/20)
+        cmap = "YlGnBu"
+        cbar_label = "log10(Daily Change Rate)"
+        ref_lag = 0
+        fig_title = 'Daily Change Rate\n%s, %s, %s'%(source, value_type, "%s")
+        
+    n_days = (end_date - start_date).days + 1 - ref_lag
+    time_index = np.array([(start_date + timedelta(i)).date() for i in range(n_days)])
+    
+    for geo in geo_values:    
+        sns.set(font_scale=1.2)
+        heatmap_df = pivot_df.loc[(pivot_df["geo_value"] == geo) 
+                                  & (pivot_df["time_value"].isin(time_index)),
+                                  ["time_value"] + list(range(MIN_LAG, max_lag+1))]
+        heatmap_df.set_index("time_value", inplace=True)
+        plt.figure(figsize = (18, 15))
+        plt.style.context("ggplot")
+        heatmap_df = heatmap_df.reindex(time_index)
+        selected_ytix = [x.weekday() == 6 for x in time_index] # Show Sundays on y_axis
+        ax = sns.heatmap(heatmap_df, annot=False, cmap=cmap, cbar=True,
+                         vmax=vmax, vmin=vmin, center=0,
+                         cbar_kws=dict(label=cbar_label,
+                                       ticks=list(range(0, vmax+1, cbar_freq)))) 
+        xtix = ax.get_xticks()
+        plt.xlabel("Lag", fontsize = 25)
+        plt.ylabel("Reference Date", fontsize = 25)
+        plt.title(fig_title%geo, fontsize = 30, loc="left")
+        plt.xticks(fontsize=20)
+        plt.yticks(fontsize=15)
+        ax.set_yticks(np.arange(0.5, n_days + 0.5)[selected_ytix])
+        ax.set_yticklabels(time_index[selected_ytix])
+        ax.set_xticks(xtix[::5])
+        plt.savefig(save_dir+"/"+str(geo)+".png")
+    return 
+
+def create_lineplot_over_loations(save_dir:str, backfill_df:pd.DataFrame, 
+                                  source:str, signal:str, fig_name:str, 
+                                  start_date:datetime, end_date:datetime, 
+                                  geo_values=None, max_lag=90):
+    """
+    Create a lineplot of the backfill estimates by lag and location for
+    across a certain range of reference dates.
+    The backfill estimates will show as the y-axis while the lag will be the 
+    x-axis. Each line represents the mean across reference dates for a specific 
+    location with 95% confidence interval shown as the band. The created 
+    lineplot will be stored in the save_dir with specified figure name as a 
+    png files.
+    
+    Parameters
+    ----------
+    save_dir : str
+        Directory for saving the generated figures.
+    backfill_df : pd.DataFrame
+        The dataframe that contains information on either completeness 
+        or daily change rate.
+    source : str
+        String identifying the data source to query, such as "fb-survey".
+    fig_name : str
+        The file name of the figure, no suffix needed.
+    start_date : datetime
+        Display data beginning on this date.
+    end_date : datetime
+        Display data up to this date, inclusive.
+    geo_values : list of str, optional
+        The list of locations for which the heatmaps will be created. 
+        The default is None, which means all the locations included in the 
+        backfill_df will be considered. Otherwise, only the locations in the
+        geo_values list will be considered.
+    max_lag : int, optional
+        The maximum lag that will be displayed in the heatmaps. 
+        The default is 90.
+
+    Returns
+    -------
+    None.
+
+    """
+
+    check_create_dir(save_dir)
+    
+    if not geo_values:
+        geo_values = backfill_df["geo_value"].unique() 
+    max_lag =min(backfill_df["lag"].min(), max_lag)
+    
+    line_df = backfill_df.loc[(backfill_df["lag"] <=max_lag)
+                              & (backfill_df["time_value"]<=end_date)
+                              & (backfill_df["time_value"]>=start_date)]
+    data_type = line_df["data_type"].values[0]
+    
+    if data_type == "completeness":
+        vmax = int((line_df["value"].max() //20 + 1) * 20)
+        vmin = int((line_df["value"].min() //20) * 20)
+        ref_lag = line_df["ref_lag"].values[0]
+        value_type = line_df["value_type"].values[0]
+        fig_title = 'Percentage of Completion\
+                \nAgainst values reported %d days later\
+                \n%s %s, Mean with 95%% CI \
+                \nReference Date: From %s to %s'%(ref_lag, source, value_type,  
+                                          start_date.date(), end_date.date())
+        ylabel = "%Reported"
+    else:
+        vmax = ceil(line_df["value"].max())
+        vmin = floor(line_df["value"].min())
+        ref_lag = line_df["ref_lag"].values[0]
+        value_type = line_df["value_type"].values[0]
+        fig_title = 'Daily Change Rate\
+                \n%s %s, Mean with 95%% CI \
+                \nReference Date: From %s to %s'%(source, value_type, 
+                                          start_date.date(), end_date.date())
+        ylabel = "log10(Daily Change Rate)"
+            
+    line_df = line_df[line_df["geo_value"].isin(geo_values)].dropna()
+    
+    plt.figure(figsize = (10, 10))
+    sns.lineplot(data=line_df, x="lag", y="value", hue="geo_value", 
+                 ci=95, err_style="band")
+    plt.xlabel("Lag", fontsize=20)
+    plt.ylabel(ylabel, fontsize=20)
+    plt.title(fig_title, fontsize=25, loc="left")
+    plt.legend(loc="upper left")
+    if data_type == "completeness":
+        plt.axhline(90, linestyle = "--")
+        plt.axhline(100, linestyle = "--")
+    plt.yticks(np.arange(0, vmax, 10), fontsize=15)
+    plt.xticks(fontsize=15)
+    plt.ylim(vmin, vmax)
+    plt.savefig(save_dir+"/"+fig_name+".png", bbox_inches='tight')
+    return 
+
+def create_violinplot_over_lag(save_dir: str, backfill_df:pd.DataFrame, 
+                               source:str, signal:str, 
+                               start_date:datetime, end_date:datetime, 
+                               geo_values=None, max_lag=90):
+    """
+    Create violinplots of the backfill estimates by lags and location across
+    a certain rane of reference date for each location specified in geo_values.
+    Each violin shows the distribution of quantitative backfill estimates 
+    across reference dates for a specific location and lag. The created 
+    violinplots will be stored in the save_dir as multiple png files.
+
+    Parameters
+    ----------
+    save_dir : str
+        Directory for saving the generated figures.
+    backfill_df : pd.DataFrame
+        The dataframe that contains information on either completeness 
+        or daily change rate.
+    source : str
+        String identifying the data source to query, such as "fb-survey".
+    signal : str
+        String identifying the signal from that source to query, such as 
+        "smoothed_cli".
+    start_date : datetime
+        Display data beginning on this date.
+    end_date : datetime
+        Display data up to this date, inclusive.
+    geo_values : list of str, optional
+        The list of locations for which the heatmaps will be created. 
+        The default is None, which means all the locations included in the 
+        backfill_df will be considered. Otherwise, only the locations in the
+        geo_values list will be considered.
+    max_lag : int, optional
+        The maximum lag that will be displayed in the heatmaps. 
+        The default is 90.
+
+    Returns
+    -------
+    None.
+
+    """
+    
+
+    check_create_dir(save_dir)
+    
+    if not geo_values:
+        geo_values = backfill_df["geo_value"].unique()  
+    max_lag =min(backfill_df["lag"].max(), max_lag)
+    selected_lags = list(range(0, max_lag + 10, 10))
+    
+    line_df = backfill_df.loc[(backfill_df["lag"].isin(selected_lags))
+                              & (backfill_df["time_value"]<=end_date)
+                              & (backfill_df["time_value"]>=start_date)]
+    data_type = line_df["data_type"].values[0]
+    
+    if data_type == "completeness":
+        vmax = int((line_df["value"].max() //20 + 1) * 20)
+        vmin = int((line_df["value"].min() //20) * 20)
+        ref_lag = line_df["ref_lag"].values[0]
+        value_type = line_df["value_type"].values[0]
+        fig_title = 'Percentage of Completion\
+                \nAgainst values reported %d days later\
+                \n%s %s, Mean with 95%%%% CI \
+                \n%s, Reference Date: From %s to %s'%(ref_lag, source, 
+                value_type, "%s", start_date.date(), end_date.date())
+        ylabel = "%Reported"
+    else:
+        vmax = ceil(line_df["value"].max())
+        vmin = floor(line_df["value"].min())
+        ref_lag = line_df["ref_lag"].values[0]
+        value_type = line_df["value_type"].values[0]
+        fig_title = 'Daily Change Rate\
+                \n%s %s, Mean with 95%%%% CI \
+                \n%s, Reference Date: From %s to %s'%(source, value_type, "%s",
+                                          start_date.date(), end_date.date())
+        ylabel = "log10(Daily Change Rate)"
+            
+    line_df = line_df[line_df["geo_value"].isin(geo_values)]
+    
+    for geo in line_df["geo_value"].unique():
+        plt.figure(figsize = (10, 10))
+        plt.style.context("ggplot")
+        sublinedf = line_df[line_df["geo_value"] == geo]
+        sns.violinplot(data=sublinedf, x="lag", y="value", cut=0)
+        plt.xlabel("Lag", fontsize=20)
+        plt.ylabel(ylabel, fontsize=20)
+        plt.ylim(vmin, vmax)
+        plt.title(fig_title%geo, fontsize=25, loc="left")
+        plt.savefig(save_dir+"/"+geo+".png", bbox_inches='tight')
+    return 
+
+def create_summary_plots(save_dir, backfill_df, 
+                         source, signal, 
+                         start_date, end_date, 
+                         geo_values=None, max_lag=90):
+    """
+    Create two summary plots for the backfill dateframe. 
+    - A lineplot shows the mean and 95% confidence interval of backfill 
+    estimates by lag across a certain range of reference dates and all 
+    locations in geo_values.
+    - A lineplot shows the mean and 95% confidence interval of backk fill 
+    estimates by reference date across all locations in geo_values and all 
+    lags
+    
+
+    Parameters
+    ----------
+    save_dir : str
+        Directory for saving the generated figures.
+    backfill_df : pd.DataFrame
+        The dataframe that contains information on either completeness 
+        or daily change rate.
+    source : str
+        String identifying the data source to query, such as "fb-survey".
+    signal : str
+        String identifying the signal from that source to query, such as 
+        "smoothed_cli".
+    start_date : datetime
+        Display data beginning on this date.
+    end_date : datetime
+        Display data up to this date, inclusive.
+    geo_values : list of str, optional
+        The list of locations for which the heatmaps will be created. 
+        The default is None, which means all the locations included in the 
+        backfill_df will be considered. Otherwise, only the locations in the
+        geo_values list will be considered.
+    max_lag : int, optional
+        The maximum lag that will be displayed in the heatmaps. 
+        The default is 90.
+
+    Returns
+    -------
+    None.
+
+    """
+    
+    check_create_dir(save_dir)
+    
+    if not geo_values:
+        geo_values = backfill_df["geo_value"].unique()      
+    max_lag =min(backfill_df["lag"].max(), max_lag)
+    end_date = end_date-timedelta(days=max_lag)
+    
+    line_df = backfill_df.loc[(backfill_df["lag"] <=max_lag)
+                              & (backfill_df["time_value"]<=end_date)
+                              & (backfill_df["time_value"]>=start_date)
+                              ]
+    data_type = line_df["data_type"].values[0]
+    value_type = line_df["value_type"].values[0]
+    
+    n_days = (end_date - start_date).days + 1
+    time_index = np.array([(start_date + timedelta(i)).date() for i in range(n_days)])
+    
+    if data_type == "completeness":
+        ref_lag = line_df["ref_lag"].values[0]
+        fig_title_over_lag = 'Percentage of Completion\
+            \nAgainst values reported %d days later\
+            \n%s %s, Mean with 95%% CI \
+            \nAll locations \
+            \nReference Date: From %s to %s'%(ref_lag, source, value_type, 
+            start_date.date(), end_date.date())
+        fig_title_over_date = 'Percentage of Completion\
+            \nAgainst values reported %d days later\
+            \n%s %s, Mean with 95%% CI\
+            \nAll locations, lag <= %d'%(ref_lag, source, value_type, max_lag)
+        ylabel = "%Reported"
+    else:
+        ref_lag = line_df["ref_lag"].values[0]
+        fig_title_over_lag = 'Daily Change Rate\
+            \n%s %s, Mean with 95%% CI \
+            \nAll locations \
+            \nReference Date: From %s to %s'%(source, value_type, 
+            start_date.date(), end_date.date())
+        fig_title_over_date = 'Daily Change Rate\
+            \n %s %s, Mean with 95%% CI \
+            \nAll locations, lag <= %d'%(source, value_type, max_lag)
+        ylabel = "log10(Daily Change Rate)"
+
+    line_df = line_df[line_df["geo_value"].isin(geo_values)].dropna()
+    
+    # Lineplot over lags
+    plt.figure(figsize = (10, 10))
+    plt.style.context("ggplot")
+    sns.lineplot(data=line_df, x="lag", y="value", ci=95, err_style="band")
+    plt.xlabel("Lag", fontsize=20)
+    plt.ylabel(ylabel, fontsize=20)
+    plt.title(fig_title_over_lag, fontsize=25, loc="left")
+    plt.legend(loc="upper left")
+    plt.yticks(fontsize=15)
+    plt.xticks(fontsize=15)
+    plt.savefig(save_dir+"/lineplot_over_lag.png", bbox_inches='tight')
+    
+    
+    
+    # Lineplot over dates
+    plt.figure(figsize = (10, 10))
+    plt.style.context("ggplot")
+    sns.lineplot(data=line_df, x="time_value", y="value", ci=95, err_style="band")
+    # selected_xtix = [x.day == 1 for x in time_index]  #First day of each month
+    for x in time_index:
+        if x.day==1:
+            plt.axvline(x, linestyle="--")
+    plt.xlabel("Date", fontsize=20)
+    plt.ylabel(ylabel, fontsize=20)
+    plt.title(fig_title_over_date, fontsize=25, loc="left")
+    plt.legend(loc="upper left")
+    plt.yticks(fontsize=15)
+    plt.xticks(fontsize=15, rotation=45)
+    plt.savefig(save_dir+"/lineplot_over_date.png", bbox_inches='tight')
+    return 
+    
+
+def backfill_mean_check(backfill_df:pd.DataFrame, lag:int, geo_value, 
+                        test_start_date:datetime, test_end_date:datetime, 
+                        train_start_date:datetime, train_end_date:datetime):
+    """
+    Conduct a two-sided t-test for the null hypothesis that 2 independent 
+    samples have identical average (expected) values. This test assumes that 
+    the populations have unknown variance.
+    Calculate the T-test for the means of the backfill estimates of two time 
+    period. Use historical data for training, should include at least 28 days.
+    Use the dates of interest for testing, should include at least 7 days.
+
+    Parameters
+    ----------
+    backfill_df : pd.DataFrame
+        The dataframe that contains information on either completeness 
+        or daily change rate.
+    lag : int
+        DESCRIPTION.
+    geo_value : TYPE
+        The location that is considered.
+    test_start_date : datetime
+        Testing period beginning on this date.
+    test_end_date : datetime
+        Testing period up to this date, inclusive.
+    train_start_date : datetime
+        Training period beginning on this date.
+    train_end_date : datetime
+        Training period up to this date, inclusive.
+
+    Returns
+    -------
+    t : float
+        The calculated t-statistic..
+    p : float
+        The two-tailed p-value.
+
+    """
+    if geo_value not in backfill_df["geo_value"]:
+        print("Invalid geo_value.")
+        return
+    test_data = backfill_df.loc[(backfill_df["geo_value"] == geo_value)
+                                & (backfill_df["time_value"]<=test_end_date)
+                                & (backfill_df["time_value"]>=test_start_date)
+                                & (backfill_df["lag"] == lag)].dropna()
+    train_data = backfill_df.loc[(backfill_df["geo_value"] == geo_value)
+                                & (backfill_df["time_value"]<=train_end_date)
+                                & (backfill_df["time_value"]>=train_start_date)
+                                & (backfill_df["lag"] == lag)].dropna()
+    if train_data.shape[0] <= 28:
+        print("The training period is not long enough, should be longer than \
+              28 days")
+        return
+    if test_data.shape[0] <= 7:
+        print("The testing period is not long enough, should be longer than \
+              7 days")
+        return
+
+    t, p = stats.ttest_ind(train_data["value"].values, 
+                     test_data["value"].values, 
+                     equal_var=False)
+    return t, p
+    
+
+def create_mean_check_df(save_dir:str, backfill_df:pd.DataFrame, 
+                      test_start_date:datetime, test_end_date:datetime, 
+                      train_start_date:datetime, train_end_date:datetime,
+                      lags=None, geo_values=None):
+    """
+    Create a csv file for the results of the two-sided t-tests as described
+    in backfill_mean_check function. The t-tests will be conducted for each
+    lag and each location.
+
+    Parameters
+    ----------
+    save_dir : str
+        Directory for saving the analysis result.
+    backfill_df : pd.DataFrame
+        The dataframe that contains information on either completeness 
+        or daily change rate.
+    test_start_date : datetime
+        Testing period beginning on this date.
+    test_end_date : datetime
+        Testing period up to this date, inclusive.
+    train_start_date : datetime
+        Training period beginning on this date.
+    train_end_date : datetime
+        Training period up to this date, inclusive.
+    lags : list of int, optional
+        The list of lags for which the statistical analysis will consider. 
+        The default is None, which means all the lags included in the backfill
+        dataframe will be considered. Otherwise, only the lags specified in 
+        lags list will be considered.
+    geo_values : TYPE, optional
+        The list of locations for which the statistical analysis will consider. 
+        The default is None, which means all the locations included in the 
+        backfill dataframe will be considered. Otherwise, only the locations 
+        in the geo_values list will be considered.
+
+    Returns
+    -------
+    summary_df: pd.DataFrame
+
+    """
+    summary_df = pd.DataFrame(columns=["geo_value", "lag", 
+                                       "p", "t_statistics"])
+    i = 0
+    if not geo_values:
+        geo_values = backfill_df["geo_value"].unique() 
+    if not lags:
+        lags = backfill_df.loc[(backfill_df["time_value"]<=test_end_date)
+                               & (backfill_df["time_value"]>=test_start_date),
+                               "lag"].unique() 
+
+    for geo in geo_values:
+        for lag in lags:
+            t, p = backfill_mean_check(backfill_df, lag, geo, 
+                                       test_start_date, test_end_date, 
+                                       train_start_date, train_end_date)
+            summary_df.loc[i] = [geo, lag, t, p]
+            i += 1
+    summary_df.to_csv(save_dir+"/mean_check_results.csv", index=False)
+    return summary_df
+    
+
+
+
+    

--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -15,7 +15,8 @@ required = [
     "pytest-cov",
     "slackclient",
     "structlog",
-    "xlrd"
+    "xlrd",
+    "seaborn"
 ]
 
 setup(

--- a/_delphi_utils_python/tests/test_backfill_profiler.py
+++ b/_delphi_utils_python/tests/test_backfill_profiler.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Mar 18 11:19:17 2021
+
+@author: jingjingtang
+"""
+
+import pytest
+
+from datetime import datetime, timedelta
+from os import listdir, remove, system
+from os.path import join, exists
+
+import numpy as np
+import pandas as pd
+from delphi_utils.backfill_profiler import (check_create_dir,
+                                            to_covidcast_df,
+                                            to_backfill_df,
+                                            create_heatmap_by_refdate,
+                                            create_lineplot_by_loations,
+                                            create_violinplot_by_lag,
+                                            create_summary_plots,
+                                            backfill_mean_check,
+                                            create_mean_check_df)
+
+def _clean_directory(directory):
+    """Clean files out of a directory."""
+    for fname in listdir(directory):
+        if fname.startswith("."):
+            continue
+        remove(join(directory, fname))
+
+
+def _non_ignored_files_set(directory):
+    """List all files in a directory not preceded by a '.' and store them in a set."""
+    out = set()
+    for fname in listdir(directory):
+        if fname.startswith("."):
+            continue
+        out.add(fname)
+    return out
+
+
+class TestExport:
+    
+    timestamps = [datetime(2020, 3, 20) + timedelta(days=i) for i in range(56)]
+    geo_values = ["ny", "pa", "ma"]
+    lags = list(range(91))
+    index = pd.MultiIndex.from_product([timestamps, geo_values, lags], 
+                                       names = ["time_value", "geo_value", "lag"])
+        
+    backfill_df = pd.DataFrame(index=index).reset_index()
+    backfill_df["value"] = np.random.random_sample(backfill_df.shape[0]) * 1e3
+    backfill_df["value_type"] = "Total counts"
+    backfill_df["data_type"] = "completeness"
+    backfill_df["ref_lag"] = 60
+    
+    source = "chng"
+    start_date = timestamps[0]
+    end_date = timestamps[-1]
+    
+    def test_check_create_dir(self):
+        save_dir = "./test_output"
+        check_create_dir(save_dir)
+        
+        assert exists(save_dir)
+        system("rm -r %s"%save_dir)
+    
+    def test_to_covidcast_df(self):
+        
+        # Valid case
+        test_df = pd.DataFrame({"timestamp": [datetime(2021, 1, 1)],
+                                "geos": ["pa"],
+                                "totalcounts": [100],
+                                "gap": [2],
+                                "covidcounts": [2]})
+        df = to_covidcast_df(test_df, lag_col="gap", 
+                             time_value_col="timestamp", 
+                             geo_value_col="geos", 
+                             sample_size_col="totalcounts", 
+                             value_col="covidcounts")
+        assert set(["time_value", "geo_value", "sample_size", "lag", "value"]).isin(df.columns)
+        
+        # Invalid case 1
+        test_df = pd.DataFrame({"timestamp": ["2021-1-1"],
+                                "geos": ["pa"],
+                                "totalcounts": [100],
+                                "gap": [2],
+                                "covidcounts": [2]})
+        with pytest.raises(ValueError):
+            to_covidcast_df(test_df, lag_col="gap", 
+                            time_value_col="timestamp", 
+                            geo_value_col="geos", 
+                            sample_size_col="totalcounts", 
+                            value_col="covidcounts")
+        
+        # Invalid case 2
+        test_df = pd.DataFrame({"timestamp": [datetime(2021, 1, 1)],
+                                "geos": ["pa"],
+                                "totalcounts": [100],
+                                "gap": ["c"],
+                                "covidcounts": [2]})
+        with pytest.raises(ValueError):
+            to_covidcast_df(test_df, lag_col="gap", 
+                            time_value_col="timestamp", 
+                            geo_value_col="geos", 
+                            sample_size_col="totalcounts", 
+                            value_col="covidcounts")
+    
+    def test_to_backfill_df(self):
+        
+        timestamps = [datetime(2020, 3, 20) + timedelta(days=i) for i in range(56)]
+        geo_values = ["ny", "pa", "ma"]
+        lags = list(range(91))
+        index = pd.MultiIndex.from_product([timestamps, geo_values, lags], 
+                                           names = ["time_value", "geo_value", "lag"])
+        
+        df = pd.DataFrame(index=index).reset_index()
+        df["sample_size"] = np.random.random_sample(df.shape[0]) * 1e5
+        df["sample_size"] = df["sample_size"].astype(int)
+        df["value"] = np.random.random_sample(df.shape[0])
+        
+        # Too large ref_lag
+        with pytest.raises(ValueError):
+            to_backfill_df(df, data_type = "completeness",
+                       value_type="total_count", ref_lag=100)
+         
+        # Normal case for completeness
+        backfill_df = to_backfill_df(df, data_type = "completeness",
+                       value_type="total_count", ref_lag=60)
+        
+        assert (backfill_df.loc[backfill_df["lag"] == 60, "value"] == 100).all()
+    
+    def test_create_heatmap_by_refdate(self, backfill_df, source, 
+                                       start_date, end_date):
+        save_dir = "./test_dir"
+        create_heatmap_by_refdate(save_dir, backfill_df, source, 
+                                    start_date, end_date, 
+                                    geo_values=None, max_lag=90)
+        
+        figs = _non_ignored_files_set(save_dir)
+        assert len(figs) == backfill_df["geo_value"].nunique()
+        
+        _clean_directory(save_dir)
+    
+    def test_create_lineplot_by_loations(self, backfill_df, source, 
+                                       start_date, end_date):
+        save_dir = "./test_dir"
+        create_lineplot_by_loations(save_dir, backfill_df, 
+                                    source, fig_name="test", 
+                                    start_date=start_date, 
+                                    end_date=end_date, 
+                                    geo_values=None, max_lag=90)
+        
+        figs = _non_ignored_files_set(save_dir)
+        assert "test.png" in figs
+        
+        _clean_directory(save_dir)
+    
+        
+    def test_create_violinplot_by_lag(self, backfill_df, source, 
+                                       start_date, end_date):
+        save_dir = "./test_dir"
+        create_violinplot_by_lag(save_dir, backfill_df, source, start_date, 
+                                 end_date, geo_values=None, max_lag=90)
+        
+        figs = _non_ignored_files_set(save_dir)
+        assert len(figs) == backfill_df["geo_value"].nunique()
+        
+        _clean_directory(save_dir)
+    
+    def test_create_summary_plots(self, backfill_df, source, 
+                                       start_date, end_date):
+        save_dir = "./test_dir"
+        with pytest.raises(ValueError):
+            create_summary_plots(save_dir, backfill_df, 
+                                 source, start_date, end_date, 
+                                 geo_values=None, max_lag=90)
+        
+        create_summary_plots(save_dir, backfill_df, 
+                                 source, start_date, end_date, 
+                                 geo_values=None, max_lag=10)
+        
+        figs = _non_ignored_files_set(save_dir)
+        
+        assert "lineplot_by_date.png" in figs
+        assert "lineplot_by_lag.png" in figs
+        
+        _clean_directory(save_dir)
+    
+    def test_backfill_mean_check(self, backfill_df):
+        
+        # Invalid lag
+        with pytest.raises(ValueError): 
+            backfill_mean_check(backfill_df, lag=100, geo_value="ny", 
+                                test_start_date=datetime(2020, 5, 7), 
+                                test_end_date=datetime(2020, 5, 14), 
+                                train_start_date=datetime(2020, 3, 20),
+                                train_end_date=datetime(2020, 5, 7))
+        
+        # Invalid geo_value
+        with pytest.raises(ValueError): 
+            backfill_mean_check(backfill_df, lag=10, geo_value="ca", 
+                                test_start_date=datetime(2020, 5, 7), 
+                                test_end_date=datetime(2020, 5, 14), 
+                                train_start_date=datetime(2020, 3, 20),
+                                train_end_date=datetime(2020, 5, 7))
+        # Valid case
+        t, p = backfill_mean_check(backfill_df, lag=10, geo_value="pa", 
+                                test_start_date=datetime(2020, 5, 7), 
+                                test_end_date=datetime(2020, 5, 14), 
+                                train_start_date=datetime(2020, 3, 20),
+                                train_end_date=datetime(2020, 5, 7)) 
+        assert (p > 0) and (p <= 1)
+        
+    def test_create_mean_check_df(self, backfill_df):
+        save_dir = "./test_dir"
+        output = create_mean_check_df(save_dir, backfill_df, 
+                                      test_start_date=datetime(2020, 5, 7), 
+                                      test_end_date=datetime(2020, 5, 14), 
+                                      train_start_date=datetime(2020, 3, 20),
+                                      train_end_date=datetime(2020, 5, 7),
+                                      lags=None, geo_values=None)
+        
+        files = _non_ignored_files_set(save_dir)
+        
+        assert "mean_check_results.csv" in files
+        assert (output["p"] <= 1).all()
+        assert (output["p"] >= 0).all()
+        
+        _clean_directory(save_dir)
+        
+    
+    
+        
+        
+        
+        
+        
+        
+            
+        
+        

--- a/_delphi_utils_python/tests/test_backfill_profiler.py
+++ b/_delphi_utils_python/tests/test_backfill_profiler.py
@@ -20,10 +20,8 @@ from delphi_utils.backfill_profiler import (check_create_dir,
                                             to_backfill_df,
                                             create_heatmap_by_refdate,
                                             create_lineplot_by_loations,
-                                            create_violinplot_by_lag,
-                                            create_summary_plots,
-                                            backfill_mean_check,
-                                            create_mean_check_df)
+                                            create_lineplot_by_issuedate,
+                                            create_violinplot_by_lag)
 
 warnings.filterwarnings("ignore")
 
@@ -141,7 +139,19 @@ class TestExport:
         _clean_directory(save_dir)
         create_heatmap_by_refdate(save_dir, backfill_df, source, 
                                     start_date, end_date, 
-                                    geo_values=None, max_lag=90)
+                                    geo_values=[], max_lag=90)
+        
+        figs = _non_ignored_files_set(save_dir)
+        assert len(figs) == backfill_df["geo_value"].nunique()
+        
+        _clean_directory(save_dir)
+        
+    def create_lineplot_by_issuedate(self):
+        save_dir = "./test_dir"
+        _clean_directory(save_dir)
+        create_lineplot_by_issuedate(save_dir, backfill_df, source, 
+                                    start_date, end_date, 
+                                    geo_values=[], max_lag=90)
         
         figs = _non_ignored_files_set(save_dir)
         assert len(figs) == backfill_df["geo_value"].nunique()
@@ -155,7 +165,7 @@ class TestExport:
                                     source, fig_name="test", 
                                     start_date=start_date, 
                                     end_date=end_date, 
-                                    geo_values=None, max_lag=90)
+                                    geo_values=[], max_lag=90)
         
         figs = _non_ignored_files_set(save_dir)
         assert "test.png" in figs
@@ -167,82 +177,9 @@ class TestExport:
         save_dir = "./test_dir"
         _clean_directory(save_dir)
         create_violinplot_by_lag(save_dir, backfill_df, source, start_date, 
-                                 end_date, geo_values=None, max_lag=90)
+                                 end_date, geo_values=[], max_lag=90)
         
         figs = _non_ignored_files_set(save_dir)
         assert len(figs) == backfill_df["geo_value"].nunique()
         
         _clean_directory(save_dir)
-    
-    def test_create_summary_plots(self):
-        save_dir = "./test_dir"
-        _clean_directory(save_dir)
-        with pytest.raises(ValueError):
-            create_summary_plots(save_dir, backfill_df, 
-                                 source, start_date, end_date, 
-                                 geo_values=None, max_lag=90)
-        
-        create_summary_plots(save_dir, backfill_df, 
-                                 source, start_date, end_date, 
-                                 geo_values=None, max_lag=10)
-        
-        figs = _non_ignored_files_set(save_dir)
-        
-        assert "lineplot_by_date.png" in figs
-        assert "lineplot_by_lag.png" in figs
-        
-        _clean_directory(save_dir)
-    
-    def test_backfill_mean_check(self):
-        
-        # Invalid lag
-        with pytest.raises(ValueError): 
-            backfill_mean_check(backfill_df, lag=100, geo_value="ny", 
-                                test_start_date=datetime(2020, 5, 7), 
-                                test_end_date=datetime(2020, 5, 14), 
-                                train_start_date=datetime(2020, 3, 20),
-                                train_end_date=datetime(2020, 5, 7))
-        
-        # Invalid geo_value
-        with pytest.raises(ValueError): 
-            backfill_mean_check(backfill_df, lag=10, geo_value="ca", 
-                                test_start_date=datetime(2020, 5, 7), 
-                                test_end_date=datetime(2020, 5, 14), 
-                                train_start_date=datetime(2020, 3, 20),
-                                train_end_date=datetime(2020, 5, 7))
-        # Valid case
-        t, p = backfill_mean_check(backfill_df, lag=10, geo_value="pa", 
-                                test_start_date=datetime(2020, 5, 7), 
-                                test_end_date=datetime(2020, 5, 14), 
-                                train_start_date=datetime(2020, 3, 20),
-                                train_end_date=datetime(2020, 5, 7)) 
-        assert (p > 0) and (p <= 1)
-        
-    def test_create_mean_check_df(self):
-        save_dir = "./test_dir"
-        output = create_mean_check_df(save_dir, backfill_df, 
-                                      test_start_date=datetime(2020, 5, 7), 
-                                      test_end_date=datetime(2020, 5, 14), 
-                                      train_start_date=datetime(2020, 3, 20),
-                                      train_end_date=datetime(2020, 5, 7),
-                                      lags=None, geo_values=None)
-        
-        files = _non_ignored_files_set(save_dir)
-        
-        assert "mean_check_results.csv" in files
-        assert (output["p"] <= 1).all()
-        assert (output["p"] >= 0).all()
-        
-        _clean_directory(save_dir)
-        
-    
-    
-        
-        
-        
-        
-        
-        
-            
-        
-        

--- a/_delphi_utils_python/tests/test_backfill_profiler.py
+++ b/_delphi_utils_python/tests/test_backfill_profiler.py
@@ -139,7 +139,7 @@ class TestExport:
         _clean_directory(save_dir)
         create_heatmap_by_refdate(save_dir, backfill_df, source, 
                                     start_date, end_date, 
-                                    geo_values=[], max_lag=90)
+                                    geo_values=None, max_lag=90)
         
         figs = _non_ignored_files_set(save_dir)
         assert len(figs) == backfill_df["geo_value"].nunique()
@@ -151,7 +151,7 @@ class TestExport:
         _clean_directory(save_dir)
         create_lineplot_by_issuedate(save_dir, backfill_df, source, 
                                     start_date, end_date, 
-                                    geo_values=[], max_lag=90)
+                                    geo_values=None, max_lag=90)
         
         figs = _non_ignored_files_set(save_dir)
         assert len(figs) == backfill_df["geo_value"].nunique()
@@ -165,7 +165,7 @@ class TestExport:
                                     source, fig_name="test", 
                                     start_date=start_date, 
                                     end_date=end_date, 
-                                    geo_values=[], max_lag=90)
+                                    geo_values=None, max_lag=90)
         
         figs = _non_ignored_files_set(save_dir)
         assert "test.png" in figs
@@ -177,7 +177,7 @@ class TestExport:
         save_dir = "./test_dir"
         _clean_directory(save_dir)
         create_violinplot_by_lag(save_dir, backfill_df, source, start_date, 
-                                 end_date, geo_values=[], max_lag=90)
+                                 end_date, geo_values=None, max_lag=90)
         
         figs = _non_ignored_files_set(save_dir)
         assert len(figs) == backfill_df["geo_value"].nunique()


### PR DESCRIPTION
### Description
Add the "backfill profile", which has functions for calculating backfill
estimates for any source and generating distribution visualization
- currently only support backfill estimates for counts not ratios
- heatmap, lineplot, violinplot are supported
- two-side t-test for the means of two independent period of backfill estimates
  is used for alerting

TODOs:
- Make the visualization tools support for ratios
- Daily check metric using the alerting function

### Changelog
Itemize code/test/documentation changes and files added/removed.
- `backfill_profiler.py` added in `delphi_utils`
- `test_backfill_profiler.py` added in `tests`

