### PR TITLE
Create preliminary validation params for safegraph_patterns

### DIFF
--- a/ansible/templates/safegraph_patterns-params-prod.json.j2
+++ b/ansible/templates/safegraph_patterns-params-prod.json.j2
@@ -18,7 +18,7 @@
     "common": {
       "data_source": "safegraph",
       "span_length": 14,
-      "end_date": "today",
+      "end_date": "today-4",
       "suppressed_errors": [
         {"signal": "completely_home_prop"},
         {"signal": "completely_home_prop_7dav"},

--- a/ansible/templates/safegraph_patterns-params-prod.json.j2
+++ b/ansible/templates/safegraph_patterns-params-prod.json.j2
@@ -14,7 +14,30 @@
     "sync": true,
     "wip_signal" : []
   },
-  "archive": {
-    "cache_dir": "./cache"
+  "validation": {
+    "common": {
+      "data_source": "safegraph",
+      "span_length": 14,
+      "end_date": "today",
+      "suppressed_errors": [
+        {"signal": "completely_home_prop"},
+        {"signal": "completely_home_prop_7dav"},
+        {"signal": "full_time_work_prop"},
+        {"signal": "full_time_work_prop_7dav"},
+        {"signal": "part_time_work_prop"},
+        {"signal": "part_time_work_prop_7dav"},
+        {"signal": "median_home_dwell_time"},
+        {"signal": "median_home_dwell_time_7dav"}
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 100,
+      "missing_se_allowed": false,
+      "missing_sample_size_allowed": false
+    },
+    "dynamic": {
+      "ref_window_size": 7,
+      "smoothed_signals": []
+    }
   }
 }

--- a/safegraph_patterns/params.json.template
+++ b/safegraph_patterns/params.json.template
@@ -13,7 +13,30 @@
     "aws_endpoint": "",
     "sync": true
   },
-  "archive": {
-    "cache_dir": "./cache"
+  "validation": {
+    "common": {
+      "data_source": "safegraph",
+      "span_length": 14,
+      "end_date": "today",
+      "suppressed_errors": [
+        {"signal": "completely_home_prop"},
+        {"signal": "completely_home_prop_7dav"},
+        {"signal": "full_time_work_prop"},
+        {"signal": "full_time_work_prop_7dav"},
+        {"signal": "part_time_work_prop"},
+        {"signal": "part_time_work_prop_7dav"},
+        {"signal": "median_home_dwell_time"},
+        {"signal": "median_home_dwell_time_7dav"}
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 100,
+      "missing_se_allowed": false,
+      "missing_sample_size_allowed": false
+    },
+    "dynamic": {
+      "ref_window_size": 7,
+      "smoothed_signals": []
+    }
   }
 }

--- a/safegraph_patterns/params.json.template
+++ b/safegraph_patterns/params.json.template
@@ -17,7 +17,7 @@
     "common": {
       "data_source": "safegraph",
       "span_length": 14,
-      "end_date": "today",
+      "end_date": "today-4",
       "suppressed_errors": [
         {"signal": "completely_home_prop"},
         {"signal": "completely_home_prop_7dav"},

--- a/safegraph_patterns/run-safegraph_patterns.sh
+++ b/safegraph_patterns/run-safegraph_patterns.sh
@@ -17,6 +17,7 @@ rm -f ./receiving/*
 # Run the indicator code.
 echo "Running the indicator..."
 env/bin/python -m delphi_safegraph_patterns
+env/bin/python -m delphi_utils.validator
 
 # Copy the files to the ingestion directory.
 # The unwieldy one-liner does the following:


### PR DESCRIPTION
### Description
Create a preliminary set of validation params for `safegraph_patterns` and turn on running the validation in production.

### Changelog
Validation file turns off validation for all signals in `safegraph` since they share a common `data_source` in the API. 

### Fixes 
- Partially addresses #725 
