### PR TITLE
Preliminary validation params for safegraph

### DIFF
--- a/ansible/templates/safegraph-params-prod.json.j2
+++ b/ansible/templates/safegraph-params-prod.json.j2
@@ -14,7 +14,31 @@
     "sync": true,
     "wip_signal" : []
   },
-  "archive": {
-    "cache_dir": "./cache"
+  "validation": {
+    "common": {
+      "data_source": "safegraph",
+      "span_length": 14,
+      "end_date": "today",
+      "suppressed_errors": [
+        {"signal": "bars_visit_num"},
+        {"signal": "bars_visit_prop"},
+        {"signal": "restaurants_visit_num"},
+        {"signal": "restaurants_visit_prop"}
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 100,
+      "missing_se_allowed": false,
+      "missing_sample_size_allowed": false
+    },
+    "dynamic": {
+      "ref_window_size": 7,
+      "smoothed_signals": [
+        "completely_home_prop_7dav",
+        "full_time_work_prop_7dav",
+        "part_time_work_prop_7dav",
+        "median_home_dwell_time_7dav"
+      ]
+    }
   }
 }

--- a/safegraph/params.json.template
+++ b/safegraph/params.json.template
@@ -17,7 +17,31 @@
                     "part_time_work_prop_7dav",
                     "full_time_work_prop_7dav"]
   },
-  "archive": {
-    "cache_dir": "./cache"
+  "validation": {
+    "common": {
+      "data_source": "safegraph",
+      "span_length": 14,
+      "end_date": "today",
+      "suppressed_errors": [
+        {"signal": "bars_visit_num"},
+        {"signal": "bars_visit_prop"},
+        {"signal": "restaurants_visit_num"},
+        {"signal": "restaurants_visit_prop"}
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 100,
+      "missing_se_allowed": false,
+      "missing_sample_size_allowed": false
+    },
+    "dynamic": {
+      "ref_window_size": 7,
+      "smoothed_signals": [
+        "completely_home_prop_7dav",
+        "full_time_work_prop_7dav",
+        "part_time_work_prop_7dav",
+        "median_home_dwell_time_7dav"
+      ]
+    }
   }
 }

--- a/safegraph/run-safegraph.sh
+++ b/safegraph/run-safegraph.sh
@@ -12,6 +12,7 @@ rm -f ./receiving/*
 # Run the indicator code.
 echo "Running the indicator..."
 env/bin/python -m delphi_safegraph
+env/bin/python -m delphi_utils.validator
 
 # Copy the files to the ingestion directory.
 echo "Copying files to the ingestion directory..."


### PR DESCRIPTION
### Description
Create a preliminary set of validation params for `safegraph` and turn on running the validation in production.

### Changelog
Validation file turns off validation for all signals in `safegraph_patterns` since they share a common `data_source` in the API. 

### Fixes 
- Partially addresses #725 
