### PR TITLE
Allow "today" as an option for lag in validator

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/README.md
+++ b/_delphi_utils_python/delphi_utils/validator/README.md
@@ -53,7 +53,7 @@ Please update the follow settings:
 
 * `common`: global validation settings
    * `data_source`: should match the [formatting](https://cmu-delphi.github.io/delphi-epidata/api/covidcast_signals.html) as used in COVIDcast API calls
-   * `end_date`: specifies the last date to be checked; this can be specified as `YYYY-MM-DD` or as `today-{num}`.  The latter is interpretted as `num` days before the current date (with `today-0` being today).
+   * `end_date`: specifies the last date to be checked; this can be specified as `YYYY-MM-DD`, `today`, or `today-{num}`.  The latter is interpretted as `num` days before the current date.
    * `span_length`: specifies the number of days before the `end_date` to check. `span_length` should be long enough to contain all recent source data that is still in the process of being updated (i.e. in the backfill period), for example, if the data source of interest has a 2-week lag before all reports are in for a given date, `span_length` should be 14 days
    * `suppressed_errors`: list of objects specifying errors that have been manually verified as false positives or acceptable deviations from expected.  These errors can be specified with the following variables, where omitted values are interpreted as a wildcard, i.e., not specifying a date applies to all dates:
        * `check_name` (required):  name of the check, as specified in the validation output

--- a/_delphi_utils_python/delphi_utils/validator/utils.py
+++ b/_delphi_utils_python/delphi_utils/validator/utils.py
@@ -35,9 +35,13 @@ class TimeWindow:
     def from_params(cls, end_date_str: str, span_length_int: int):
         """Create a TimeWindow from param representations of its members."""
         span_length = timedelta(days=span_length_int)
-        if end_date_str.startswith("today-"):
-            days_back = timedelta(days=int(end_date_str[6:]))
-            end_date = date.today() - days_back
+        if end_date_str.startswith("today"):
+            if end_date_str == "today":
+                days_back = 0
+            else:
+                assert end_date_str.startswith("today-")
+                days_back = int(end_date_str[6:])
+            end_date = date.today() - timedelta(days=days_back)
         else:
             end_date = datetime.strptime(end_date_str, '%Y-%m-%d').date()
         return cls(end_date, span_length)

--- a/_delphi_utils_python/tests/validator/test_utils.py
+++ b/_delphi_utils_python/tests/validator/test_utils.py
@@ -45,8 +45,12 @@ class TestTimeWindow:
         """Test that TimeWindows can be derived from strings."""
         window = TimeWindow.from_params("2020-08-23", 366)
         assert window.start_date == date(2019, 8, 23)
+
+        today_window = TimeWindow.from_params("today", 14)
+        assert today_window.start_date == date(2020, 1, 31) 
+
         latest_window = TimeWindow.from_params("today-0", 1897)
         assert latest_window.start_date == date(2014, 12, 5)
-        latest_window = TimeWindow.from_params("today-10", 3)
-        assert latest_window.end_date == date(2020, 2, 4)
-        assert latest_window.start_date == date(2020, 2, 1)
+        latest_window2 = TimeWindow.from_params("today-10", 3)
+        assert latest_window2.end_date == date(2020, 2, 4)
+        assert latest_window2.start_date == date(2020, 2, 1)


### PR DESCRIPTION
### Description
#915 introduced the ability to lag days the validator checks the recently produced data, but inexplicably required the user to specify using today's data as "today-0".  This PR allows "today" as a valid option.

