### PR TITLE
add vi/gu to US state count

### DIFF
--- a/claims_hosp/delphi_claims_hosp/config.py
+++ b/claims_hosp/delphi_claims_hosp/config.py
@@ -63,7 +63,7 @@ class GeoConstants:
     NUM_COUNTIES = 3141 + 52
     NUM_HRRS = 308
     NUM_MSAS = 392 + 52  # MSA + States
-    NUM_STATES = 52  # including DC and PR
+    NUM_STATES = 54  # including DC, PR, VI, GU
     NUM_HHSS = 10
     NUM_NATIONS = 1
 


### PR DESCRIPTION
### Description
Drops of hosp claims data contain observations from VI/GU. Increase the number of possible states to account for this. 

### Changelog
- One line change in `config.py`
