### PR TITLE
combo cases: 

### DIFF
--- a/combo_cases_and_deaths/tests/test_run.py
+++ b/combo_cases_and_deaths/tests/test_run.py
@@ -235,7 +235,6 @@ def test_no_nation_jhu(mock_covidcast_signal):
         20200101,
         "county"
     )
-    #assert False, result
     pd.testing.assert_frame_equal(
         result,
         pd.DataFrame({"timestamp":[20200101],


### PR DESCRIPTION
### Description
If JHU data extends farther into the future than USAFacts data, stop where USAFacts stops.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- run.py - multiple logic changes to discard scenarios when we only have JHU data
- test_run.py - fix existing tests to account for differences in fetcher call counts, add test for nation when JHU extends past USAFacts

### Fixes 
- Fixes #947 
