### PR TITLE
Add preliminary validation parameters to hhs_hosp

### DIFF
--- a/ansible/templates/hhs_hosp-params-prod.json.j2
+++ b/ansible/templates/hhs_hosp-params-prod.json.j2
@@ -3,6 +3,21 @@
     "export_dir": "/common/covidcast/receiving/hhs",
     "log_filename": "/var/log/indicators/hhs_hosp.log"
   },
+  "validation": {
+    "common": {
+      "data_source": "hhs",
+      "span_length": 14,
+      "end_date": "today-2",
+      "suppressed_errors: [
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 0,
+      "missing_se_allowed": true,
+      "missing_sample_size_allowed": true
+    },
+    "dynamic": {}
+  },
   "archive": {
     "aws_credentials": {
       "aws_access_key_id": "{{ delphi_aws_access_key_id }}",

--- a/ansible/templates/hhs_hosp-params-prod.json.j2
+++ b/ansible/templates/hhs_hosp-params-prod.json.j2
@@ -8,8 +8,7 @@
       "data_source": "hhs",
       "span_length": 14,
       "end_date": "today-2",
-      "suppressed_errors: [
-      ]
+      "suppressed_errors": []
     },
     "static": {
       "minimum_sample_size": 0,

--- a/hhs_hosp/Makefile
+++ b/hhs_hosp/Makefile
@@ -25,4 +25,5 @@ clean:
 
 run:
 	env/bin/python -m $(dir)
+	env/bin/python -m delphi_utils.validator
 	env/bin/python -m delphi_utils.archive

--- a/hhs_hosp/params.json.template
+++ b/hhs_hosp/params.json.template
@@ -2,5 +2,20 @@
   "common": {
     "export_dir": "./receiving",
     "log_filename": "hhs_hosp.log"
+  },
+  "validation": {
+    "common": {
+      "data_source": "hhs",
+      "span_length": 14,
+      "end_date": "today-2",
+      "suppressed_errors: [
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 0,
+      "missing_se_allowed": true,
+      "missing_sample_size_allowed": true
+    },
+    "dynamic": {}
   }
 }

--- a/hhs_hosp/params.json.template
+++ b/hhs_hosp/params.json.template
@@ -8,8 +8,7 @@
       "data_source": "hhs",
       "span_length": 14,
       "end_date": "today-2",
-      "suppressed_errors: [
-      ]
+      "suppressed_errors": []
     },
     "static": {
       "minimum_sample_size": 0,


### PR DESCRIPTION
### Description
Create a preliminary set of validation params for `hhs_hosp` and turn on running the validation in production.

### Changelog
Sets the lag on the `common.end_date` parameter to be 2 days since it is the minimum lag time for `hhs` in `covidcast.metadata()`.

### Fixes 
- Partially fixes #725 