### PR TITLE
Add preliminary validation parameters for changehc

### DIFF
--- a/ansible/templates/changehc-params-prod.json.j2
+++ b/ansible/templates/changehc-params-prod.json.j2
@@ -30,5 +30,28 @@
       "pass": "{{ changehc_sftp_password }}",
       "port": "{{ changehc_sftp_port }}"
     }
+  },
+  "validation": {
+    "common": {
+      "data_source": "chng",
+      "span_length": 14,
+      "end_date": "today-4",
+      "suppressed_errors": [
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 0,
+      "missing_se_allowed": false,
+      "missing_sample_size_allowed": true
+    },
+    "dynamic": {
+      "ref_window_size": 7,
+      "smoothed_signals": [
+        "smoothed_adj_outpatient_cli",
+        "smoothed_adj_outpatient_covid",
+        "smoothed_outpatient_cli",
+        "smoothed_outpatient_covid"
+      ]
+    }
   }
 }

--- a/changehc/params.json.template
+++ b/changehc/params.json.template
@@ -30,5 +30,28 @@
       "pass": "",
       "port": 0
     }
+  },
+  "validation": {
+    "common": {
+      "data_source": "chng",
+      "span_length": 14,
+      "end_date": "today-4",
+      "suppressed_errors": [
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 0,
+      "missing_se_allowed": false,
+      "missing_sample_size_allowed": true
+    },
+    "dynamic": {
+      "ref_window_size": 7,
+      "smoothed_signals": [
+        "smoothed_adj_outpatient_cli",
+        "smoothed_adj_outpatient_covid",
+        "smoothed_outpatient_cli",
+        "smoothed_outpatient_covid"
+      ]
+    }
   }
 }


### PR DESCRIPTION
### Description
Adds preliminary validation parameters for `changehc` indicator.  Lag time is derived from the minimum lag reported by the API metadata.

### Fixes 
- Partially addresses #725 
