### PR TITLE
Add preliminary validation parameters to google_symptoms

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -18,5 +18,27 @@
       "auth_provider_x509_cert_url": "{{ google_symptoms_auth_provider_x509_cert_url }}",
       "client_x509_cert_url": "{{ google_symptoms_client_x509_cert_url }}"
     }
+  },
+  "validation": {
+    "common": {
+      "data_source": "google-symptoms",
+      "span_length": 14,
+      "end_date": "today-8",
+      "suppressed_errors": [
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 0,
+      "missing_se_allowed": true,
+      "missing_sample_size_allowed": true
+    },
+    "dynamic": {
+      "ref_window_size": 7,
+      "smoothed_signals": [
+        "ageusia_smoothed_search",
+        "sum_anosmia_ageusia_smoothed_search",
+        "anosmia_smoothed_search"
+      ]
+    }
   }
 }

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -7,5 +7,27 @@
     "export_start_date": "2020-02-20",
     "num_export_days": 14,
     "bigquery_credentials": {}
+  },
+  "validation": {
+    "common": {
+      "data_source": "google-symptoms",
+      "span_length": 14,
+      "end_date": "today-8",
+      "suppressed_errors": [
+      ]
+    },
+    "static": {
+      "minimum_sample_size": 0,
+      "missing_se_allowed": true,
+      "missing_sample_size_allowed": true
+    },
+    "dynamic": {
+      "ref_window_size": 7,
+      "smoothed_signals": [
+        "ageusia_smoothed_search",
+        "sum_anosmia_ageusia_smoothed_search",
+        "anosmia_smoothed_search"
+      ]
+    }
   }
 }


### PR DESCRIPTION
### Description
Adds preliminary validation parameters for `google_symptoms` indicator.  Lag time is derived from the minimum lag reported by the API metadata.

### Fixes 
- Partially addresses #725 