### PR TITLE
Simplify syntax to suppress all validation checks for a signal/geo/time

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/README.md
+++ b/_delphi_utils_python/delphi_utils/validator/README.md
@@ -56,7 +56,7 @@ Please update the follow settings:
    * `end_date`: specifies the last date to be checked; this can be specified as `YYYY-MM-DD`, `today`, or `today-{num}`.  The latter is interpretted as `num` days before the current date.
    * `span_length`: specifies the number of days before the `end_date` to check. `span_length` should be long enough to contain all recent source data that is still in the process of being updated (i.e. in the backfill period), for example, if the data source of interest has a 2-week lag before all reports are in for a given date, `span_length` should be 14 days
    * `suppressed_errors`: list of objects specifying errors that have been manually verified as false positives or acceptable deviations from expected.  These errors can be specified with the following variables, where omitted values are interpreted as a wildcard, i.e., not specifying a date applies to all dates:
-       * `check_name` (required):  name of the check, as specified in the validation output
+       * `check_name`:  name of the check, as specified in the validation output
        * `date`:  date in `YYYY-MM-DD` format
        * `geo_type`:  geo resolution of the data
        * `signal`:  name of COVIDcast API signal

--- a/_delphi_utils_python/delphi_utils/validator/errors.py
+++ b/_delphi_utils_python/delphi_utils/validator/errors.py
@@ -23,7 +23,7 @@ class ValidationFailure:
     """Structured report of single validation failure."""
 
     def __init__(self,
-                 check_name: str,
+                 check_name: Optional[str]=None,
                  date: Optional[Union[str, dt.date]]=None,
                  geo_type: Optional[str]=None,
                  signal: Optional[str]=None,
@@ -33,8 +33,9 @@ class ValidationFailure:
 
         Parameters
         ----------
-        check_name: str
-            Name of check at which the failure happened.
+        check_name: Optional[str]
+            Name of check at which the failure happened.  A value of `None` is used to express all
+            possible checks with a given `date`, `geo_type`, and/or `signal`.
         date: Optional[Union[str, dt.date]]
             Date corresponding to the data over which the failure happened.
             Strings are interpretted in ISO format ("YYYY-MM-DD").

--- a/_delphi_utils_python/tests/validator/test_errors.py
+++ b/_delphi_utils_python/tests/validator/test_errors.py
@@ -20,8 +20,8 @@ class TestValidationFailure:
         vf2 = ValidationFailure("chk", dt.date(1990, 10, 3))
         assert vf2.check_name == "chk"
         assert vf2.date == dt.date(1990, 10, 3)
-        assert vf2.geo_type == None
-        assert vf2.signal == None
+        assert vf2.geo_type is None
+        assert vf2.signal is None
         assert vf2.message == ""
 
         # Values extracted from a filename.
@@ -32,6 +32,14 @@ class TestValidationFailure:
         assert vf3.geo_type == "county"
         assert vf3.signal == "cases_7dav"
         assert vf3.message == ""
+
+        # All missing arguments
+        vf4 = ValidationFailure()
+        assert vf4.check_name is None
+        assert vf4.date is None
+        assert vf4.geo_type is None
+        assert vf4.signal is None
+        assert vf4.message == ""
 
         with pytest.raises(AssertionError,
                            match='`filename` argument expected to be in "{date}_{geo_type}_'\


### PR DESCRIPTION
### Description
#939 and #941 specified that all checks corresponding to a particular set of signals should be suppressed by adding `{"signal": "$SIGNAL"}` to the `validation.common.suppressed_errors` lists of the params files.  This syntax, however, is not valid and causes the validator to die.  Instead of "fixing" the params files by adding `"check_name": null` to each entry (see #964), this PR changes the validator params syntax to allow the aforementioned specifications to work as intended.

### Changelog
- `check_name` argument to `ValidationFailure` constructor is now optional and set to None when omitted.

