### PR TITLE
Pull `run_module` from `indicator.run` rather than `indicator` in indicator runner

### DIFF
--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     parser.add_argument("indicator_name",
                         type=str,
                         help="Name of the Python package containing the indicator.  This package "
-                             "must export a `run_module(params)` function.")
+                             "must export a `run.run_module(params)` function.")
     args = parser.parse_args()
     indicator_module = importlib.import_module(args.indicator_name)
-    run_indicator_pipeline(indicator_module.run_module, validator_from_params, archiver_from_params)
+    run_indicator_pipeline(indicator_module.run.run_module, validator_from_params, archiver_from_params)

--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -46,4 +46,6 @@ if __name__ == "__main__":
                              "must export a `run.run_module(params)` function.")
     args = parser.parse_args()
     indicator_module = importlib.import_module(args.indicator_name)
-    run_indicator_pipeline(indicator_module.run.run_module, validator_from_params, archiver_from_params)
+    run_indicator_pipeline(indicator_module.run.run_module,
+                           validator_from_params,
+                           archiver_from_params)


### PR DESCRIPTION
### Description
Indicator runner imports `run.run_module` rather than `run_module` from the indicator package.  This prevents us from having to add `from run import run_module` in every indicators `__init__.py`.

### Fixes 
- Fixes #968 