### PR TITLE
Add --dry_run flag to validator

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/report.py
+++ b/_delphi_utils_python/delphi_utils/validator/report.py
@@ -92,7 +92,7 @@ class ValidationReport:
 
     def print_and_exit(self, die_on_failures=True):
         """Print results and exit.
-        
+
         Arguments
         ---------
         die_on_failures: bool

--- a/_delphi_utils_python/delphi_utils/validator/report.py
+++ b/_delphi_utils_python/delphi_utils/validator/report.py
@@ -90,13 +90,19 @@ class ValidationReport:
         for warning in self.raised_warnings:
             logger.warning(str(warning))
 
-    def print_and_exit(self):
-        """Print results and, if any unsuppressed exceptions were raised, exit with non-0 status."""
+    def print_and_exit(self, die_on_failures=True):
+        """Print results and exit.
+        
+        Arguments
+        ---------
+        die_on_failures: bool
+            Whether to return non-zero status if any failures were encountered.
+        """
         print(self.summary())
         self.log()
         if self.success():
             sys.exit(0)
-        else:
+        elif die_on_failures:
             sys.exit(1)
 
     def success(self):

--- a/_delphi_utils_python/delphi_utils/validator/run.py
+++ b/_delphi_utils_python/delphi_utils/validator/run.py
@@ -4,14 +4,19 @@
 This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m delphi_validator`.
 """
+import argparse as ap
 from .. import read_params
 from .validate import Validator
 
 
 def run_module():
     """Run the validator as a module."""
+    parser = ap.ArgumentParser()
+    parser.add_argument("--dry_run", action="store_true", help="When provided, return zero exit"
+                        " status irrespective of the number of failures")
+    args = parser.parse_args()
     validator = Validator(read_params())
-    validator.validate().print_and_exit()
+    validator.validate().print_and_exit(not args.dry_run)
 
 
 def validator_from_params(params):

--- a/hhs_hosp/Makefile
+++ b/hhs_hosp/Makefile
@@ -25,5 +25,5 @@ clean:
 
 run:
 	env/bin/python -m $(dir)
-	env/bin/python -m delphi_utils.validator
+	env/bin/python -m delphi_utils.validator --dry_run
 	env/bin/python -m delphi_utils.archive


### PR DESCRIPTION
### Description
Running the validator from the command line now has the option of turning off failing with non-zero exit status when failures are raised.

### Changelog
Add `--dry_run` flag to `delph_utils.validator` that, when invoked, exits with success regardless of the number of failures.

### Fixes 
- Fixes #969
