### PR TITLE
Google Symptoms uses metadata to determine how many days of data to fetch

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -5,7 +5,6 @@
   },
   "indicator": {
     "export_start_date": "2020-02-20",
-    "num_export_days": 14,
     "bigquery_credentials": {
       "type": "{{ google_symptoms_account_type }}",
       "project_id": "{{ google_symptoms_project_id }}",

--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -5,6 +5,7 @@
   },
   "indicator": {
     "export_start_date": "2020-02-20",
+    "num_export_days": null,
     "bigquery_credentials": {
       "type": "{{ google_symptoms_account_type }}",
       "project_id": "{{ google_symptoms_project_id }}",

--- a/google_symptoms/delphi_google_symptoms/run.py
+++ b/google_symptoms/delphi_google_symptoms/run.py
@@ -7,6 +7,7 @@ when the module is run with `python -m delphi_google_symptoms`.
 import time
 from datetime import datetime
 from itertools import product
+import covidcast
 
 import numpy as np
 from delphi_utils import (
@@ -46,7 +47,14 @@ def run_module(params):
     export_start_date = datetime.strptime(
         params["indicator"]["export_start_date"], "%Y-%m-%d")
     export_dir = params["common"]["export_dir"]
-    num_export_days = params["indicator"].get("num_export_days", "all")
+
+    if "num_export_days" in params["indicator"]:
+        num_export_days = params["indicator"]["num_export_days"]
+    else:
+        # Get number of days based on what's missing from the API.
+        metadata = covidcast.metadata()
+        gs_metadata = metadata[(metadata.data_source == "google-symptoms")]
+        num_export_days = max(gs_metadata.min_lag)
 
     logger = get_structured_logger(
         __name__, filename=params["common"].get("log_filename"),

--- a/google_symptoms/delphi_google_symptoms/run.py
+++ b/google_symptoms/delphi_google_symptoms/run.py
@@ -47,10 +47,9 @@ def run_module(params):
     export_start_date = datetime.strptime(
         params["indicator"]["export_start_date"], "%Y-%m-%d")
     export_dir = params["common"]["export_dir"]
+    num_export_days = params["indicator"]["num_export_days"]
 
-    if "num_export_days" in params["indicator"]:
-        num_export_days = params["indicator"]["num_export_days"]
-    else:
+    if num_export_days is None:
         # Get number of days based on what's missing from the API.
         metadata = covidcast.metadata()
         gs_metadata = metadata[(metadata.data_source == "google-symptoms")]

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -5,6 +5,7 @@
   },
   "indicator": {
     "export_start_date": "2020-02-20",
+    "num_export_days": null,
     "bigquery_credentials": {}
   },
   "validation": {

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -5,7 +5,6 @@
   },
   "indicator": {
     "export_start_date": "2020-02-20",
-    "num_export_days": 14,
     "bigquery_credentials": {}
   },
   "validation": {


### PR DESCRIPTION
### Description
Instead of pulling a fixed 14 days of data, determine number of days to pull based on metadata `min_lag` value. Pre-existing functionality (`num_export_days` can be set in params to an integer or to "all") still works.

### Changelog
- Pull GS-specific `min_lag` from metadata if `num_export_days` is not set in params.
- Remove 14-day `num_export_day` setting from template and Ansible params files.

### Fixes 
Makes GS pipeline more robust to BigQuery outages. Minimize data pulled in anticipation of change to daily updates.