### PR TITLE
Switch Google Symptoms to expect `datetime` format for export end date

### DIFF
--- a/google_symptoms/delphi_google_symptoms/pull.py
+++ b/google_symptoms/delphi_google_symptoms/pull.py
@@ -120,12 +120,10 @@ def get_date_range(export_start_date, export_end_date, num_export_days):
         # Get all dates since export_start_date.
         start_date = export_start_date
     else:
-        # Don't fetch data before the user-set start date. Convert both
-        # dates/datetimes to date to avoid error from trying to compare
-        # different types.
+        # Don't fetch data before the user-set start date.
         start_date = max(
             export_end_date - timedelta(days=num_export_days),
-            export_start_date.date()
+            export_start_date
         )
 
     retrieve_dates = [

--- a/google_symptoms/tests/conftest.py
+++ b/google_symptoms/tests/conftest.py
@@ -57,7 +57,7 @@ dates = [
     "20200811"
 ]
 
-date_list = [datetime.strptime(date, "%Y%m%d").date() for date in dates]
+date_list = [datetime.strptime(date, "%Y%m%d") for date in dates]
 
 
 @pytest.fixture(scope="session")

--- a/google_symptoms/tests/conftest.py
+++ b/google_symptoms/tests/conftest.py
@@ -51,15 +51,6 @@ county_data = pd.read_csv(
     good_input["county"], parse_dates=["date"])[keep_cols]
 
 
-# Set up fake list of dates to fetch.
-dates = [
-    "20200726",
-    "20200811"
-]
-
-date_list = [datetime.strptime(date, "%Y%m%d") for date in dates]
-
-
 @pytest.fixture(scope="session")
 def run_as_module():
     params = {
@@ -81,10 +72,8 @@ def run_as_module():
     else:
         makedirs("receiving")
 
-    with mock.patch("delphi_google_symptoms.pull.get_date_range",
-                    return_value=date_list) as mock_all_dates:
-        with mock.patch("delphi_google_symptoms.pull.initialize_credentials",
-                        return_value=None) as mock_credentials:
-            with mock.patch("pandas_gbq.read_gbq", side_effect=[
-                    state_data, county_data]) as mock_read_gbq:
-                delphi_google_symptoms.run.run_module(params)
+    with mock.patch("delphi_google_symptoms.pull.initialize_credentials",
+                    return_value=None) as mock_credentials:
+        with mock.patch("pandas_gbq.read_gbq", side_effect=[
+                state_data, county_data]) as mock_read_gbq:
+            delphi_google_symptoms.run.run_module(params)

--- a/google_symptoms/tests/test_pull.py
+++ b/google_symptoms/tests/test_pull.py
@@ -24,14 +24,6 @@ keep_cols = ["open_covid_region_code", "date"] + symptom_names
 new_keep_cols = ["geo_id", "timestamp"] + METRICS + [COMBINED_METRIC]
 
 
-# Set up fake list of dates to fetch.
-dates = [
-    "20200726",
-    "20200811"
-]
-date_list = [datetime.strptime(date, "%Y%m%d").date() for date in dates]
-
-
 class TestPullGoogleSymptoms:
     @freeze_time("2021-01-05")
     @mock.patch("pandas_gbq.read_gbq")
@@ -47,8 +39,8 @@ class TestPullGoogleSymptoms:
         mock_read_gbq.side_effect = [state_data, county_data]
         mock_credentials.return_value = None
 
-        dfs = pull_gs_data(
-            "", datetime.strptime("20201230", "%Y%m%d"), date.today(), 0)
+        dfs = pull_gs_data("", datetime.strptime(
+            "20201230", "%Y%m%d"), datetime.combine(date.today(), datetime.min.time()), 0)
 
         for level in ["county", "state"]:
             df = dfs[level]
@@ -85,27 +77,28 @@ class TestPullHelperFuncs:
     def test_get_date_range_recent_export_start_date(self):
         output = get_date_range(
             datetime.strptime("20201230", "%Y%m%d"),
-            date.today(),
+            datetime.combine(date.today(), datetime.min.time()),
             14
         )
 
-        expected = [date(2020, 12, 24),
-                    date(2021, 1, 5)]
+        expected = [datetime(2020, 12, 24),
+                    datetime(2021, 1, 5)]
         assert set(output) == set(expected)
 
     @freeze_time("2021-01-05")
     def test_get_date_range(self):
         output = get_date_range(
             datetime.strptime("20200201", "%Y%m%d"),
-            date.today(),
+            datetime.combine(date.today(), datetime.min.time()),
             14
         )
 
-        expected = [date(2020, 12, 16), date(2021, 1, 5)]
+        expected = [datetime(2020, 12, 16),
+                    datetime(2021, 1, 5)]
         assert set(output) == set(expected)
 
     def test_format_dates_for_query(self):
-        date_list = [date(2016, 12, 30), date(2021, 1, 5)]
+        date_list = [datetime(2016, 12, 30), datetime(2021, 1, 5)]
         output = format_dates_for_query(date_list)
         expected = ["2016-12-30", "2021-01-05"]
         assert output == expected


### PR DESCRIPTION
### Description
Previously expected `export_end_date` to be of type `date`. With #967 `export_end_date` is created as type `datetime`, but tests were updated assuming `date` format. A full-pipeline test didn't trigger the error due to the problem function being mocked out.

### Changelog
- Un-mock problem function in full-pipeline test.
- Update other tests to expect `export_end_date` in `datetime` format.
- Fix incompatible date-type comparison.

### Fixes 
GS pipeline failing with message:

```
Starting step [id=39077|step_id=75|name=<span class="tag_indicators"> </span>Google Symptoms]
   Running cmd...
{"event": "Top-level exception occurred", "logger": "delphi_google_symptoms.run", "level": "error", "timestamp": "2021-04-01T13:00:10.368505Z", "exception": "
Traceback (most recent call last):
  File "/home/indicators/.pyenv/versions/3.8.2/lib/python3.8/runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/indicators/.pyenv/versions/3.8.2/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
   File "/mnt/data2/indicators/runtime/google_symptoms/env/lib/python3.8/site-packages/delphi_utils/runner.py", line 55, in <module>
    run_indicator_pipeline(indicator_module.run.run_module,
  File "/mnt/data2/indicators/runtime/google_symptoms/env/lib/python3.8/site-packages/delphi_utils/runner.py", line 38, in run_indicator_pipeline
    indicator_fn(params)
  File "/mnt/data2/indicators/runtime/google_symptoms/delphi_google_symptoms/run.py", line 62, in run_module
    dfs = pull_gs_data(params["indicator"]["bigquery_credentials"],
  File "/mnt/data2/indicators/runtime/google_symptoms/delphi_google_symptoms/pull.py", line 281, in pull_gs_data
    retrieve_dates = get_date_range(
  File "/mnt/data2/indicators/runtime/google_symptoms/delphi_google_symptoms/pull.py", line 126, in get_date_range
    start_date = max(
TypeError: can't compare datetime.datetime to datetime.date"}
   Fail [cmd=sudo -u indicators -s bash -c "cd /home/indicators/runtime/google_symptoms && env/bin/python -m delphi_utils.runner delphi_google_symptoms"]
```