### PR TITLE
Add C17a to microdata output list

### DIFF
--- a/facebook/delphiFacebook/R/responses.R
+++ b/facebook/delphiFacebook/R/responses.R
@@ -455,7 +455,7 @@ create_complete_responses <- function(input_data, county_crosswalk)
     "C16", "C17", "E1_1", "E1_2", "E1_3", "E1_4", "E2_1", "E2_2", "E3", # added in Wave 5
     "V1", "V2", "V3", "V4_1", "V4_2", "V4_3", "V4_4", "V4_5", # added in Wave 6
     "V9", # added in Wave 7,
-    "C14a", "V2a", "V5a", "V5b", "V5c", "V5d", "V6", "D11", # added in Wave 8
+    "C14a", "C17a", "V2a", "V5a", "V5b", "V5c", "V5d", "V6", "D11", # added in Wave 8
     "C6a", "C8a_1", "C8a_2", "C8a_3", "C13b", "C13c", "V11", "V12", "V13", "V14_1", "V14_2", # added in Wave 10
 
     "token", "wave", "UserLanguage",


### PR DESCRIPTION
### Description
C17a, a revision of C17, was introduced in Wave 8 but not added to the microdata output list.

### Fixes
Closes #987.

@krivard We'll need to reissue the microdata going back to Feb 8 so we can include this item.
