### PR TITLE
Add nancodes enum util

### DIFF
--- a/_delphi_utils_python/delphi_utils/__init__.py
+++ b/_delphi_utils_python/delphi_utils/__init__.py
@@ -12,5 +12,6 @@ from .logger import get_structured_logger
 from .geomap import GeoMapper
 from .smooth import Smoother
 from .signal import add_prefix
+from .nancodes import Nans
 
 __version__ = "0.1.0"

--- a/_delphi_utils_python/delphi_utils/nancodes.py
+++ b/_delphi_utils_python/delphi_utils/nancodes.py
@@ -1,0 +1,13 @@
+"""Unified not-a-number codes for CMU Delphi codebase."""
+
+from enum import IntEnum
+
+class Nans(IntEnum):
+    """An enum of not-a-number codes for the indicators."""
+
+    NOT_MISSING = 0
+    NOT_APPLICABLE = 1
+    REGION_EXCEPTION = 2
+    PRIVACY = 3
+    DELETED = 4
+    UNKNOWN = 5


### PR DESCRIPTION
### Description
This is part of #838. Adds the nancode constants used throughout the indicators.

### Changelog
Add the nancodes.py of constants.

### Fixes 
- Fixes #838 
