### PR TITLE
Add mock to setup.py

### DIFF
--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -6,6 +6,7 @@ required = [
     "covidcast",
     "freezegun",
     "gitpython",
+    "mock",
     "moto",
     "numpy",
     "pandas>=1.1.0",

--- a/google_symptoms/setup.py
+++ b/google_symptoms/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "mock",
     "numpy",
     "pandas",
     "pydocstyle",


### PR DESCRIPTION
### Description
Builds are failing right now since the `import mock` statements are failing with Module not found. I don't know why it's only GS and utils either, since other packages use the same import

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add `mock` to the setup.py. Decided to do this isntead of replacing `import mock` with `from unittest import mock` since the latter changes the imported package, which im not sure is desired. we can refactor later.

### Fixes 
- Fixes #(issue)
