### PR TITLE
[DRAFT] Refactor indicators to use delphi utils pypi install

### DIFF
--- a/_template_python/Makefile
+++ b/_template_python/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/_template_python/setup.py
+++ b/_template_python/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/cdc_covidnet/Makefile
+++ b/cdc_covidnet/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/cdc_covidnet/setup.py
+++ b/cdc_covidnet/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/changehc/Makefile
+++ b/changehc/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/changehc/setup.py
+++ b/changehc/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "cvxpy",

--- a/claims_hosp/Makefile
+++ b/claims_hosp/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/claims_hosp/setup.py
+++ b/claims_hosp/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "cvxpy",

--- a/combo_cases_and_deaths/Makefile
+++ b/combo_cases_and_deaths/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/combo_cases_and_deaths/setup.py
+++ b/combo_cases_and_deaths/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "pandas",
     "pydocstyle",
     "pytest",

--- a/covid_act_now/Makefile
+++ b/covid_act_now/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/covid_act_now/setup.py
+++ b/covid_act_now/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/doctor_visits/Makefile
+++ b/doctor_visits/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/doctor_visits/setup.py
+++ b/doctor_visits/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "sklearn",

--- a/google_health/Makefile
+++ b/google_health/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/google_health/setup.py
+++ b/google_health/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "google-api-python-client",

--- a/google_symptoms/Makefile
+++ b/google_symptoms/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/google_symptoms/setup.py
+++ b/google_symptoms/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "mock",
     "numpy",
     "pandas",

--- a/hhs_facilities/Makefile
+++ b/hhs_facilities/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/hhs_facilities/setup.py
+++ b/hhs_facilities/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/hhs_hosp/Makefile
+++ b/hhs_hosp/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/hhs_hosp/setup.py
+++ b/hhs_hosp/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "freezegun",
     "numpy",
     "pandas",

--- a/jhu/Makefile
+++ b/jhu/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/jhu/setup.py
+++ b/jhu/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/nchs_mortality/Makefile
+++ b/nchs_mortality/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/nchs_mortality/setup.py
+++ b/nchs_mortality/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/nowcast/Makefile
+++ b/nowcast/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/nowcast/setup.py
+++ b/nowcast/setup.py
@@ -3,6 +3,7 @@ from setuptools import find_packages
 
 required = [
     "aiohttp",
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/quidel/Makefile
+++ b/quidel/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/quidel/setup.py
+++ b/quidel/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/quidel_covidtest/Makefile
+++ b/quidel_covidtest/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/quidel_covidtest/setup.py
+++ b/quidel_covidtest/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/safegraph/Makefile
+++ b/safegraph/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/safegraph/setup.py
+++ b/safegraph/setup.py
@@ -3,6 +3,7 @@ from setuptools import find_packages
 
 required = [
     "covidcast",
+    "delphi_utils",
     "numpy",
     "pydocstyle",
     "pandas",

--- a/safegraph_patterns/Makefile
+++ b/safegraph_patterns/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/safegraph_patterns/setup.py
+++ b/safegraph_patterns/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",

--- a/sir_complainsalot/Makefile
+++ b/sir_complainsalot/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/sir_complainsalot/setup.py
+++ b/sir_complainsalot/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "pandas",
     "pytest",
     "pytest-cov",

--- a/usafacts/Makefile
+++ b/usafacts/Makefile
@@ -8,7 +8,6 @@ venv:
 install: venv
 	. env/bin/activate; \
 	pip install wheel ; \
-	pip install -e ../_delphi_utils_python ;\
 	pip install -e .
 
 lint:

--- a/usafacts/setup.py
+++ b/usafacts/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 required = [
+    "delphi_utils",
     "numpy",
     "pandas",
     "pydocstyle",


### PR DESCRIPTION
### Description
Change indicators to use the pypi utils package instead of the local package. 

This change is still under discussion, hence the draft status.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Replace local utils install with the util in the setup requirements

### Fixes 
- Fixes #(issue)
