### PR TITLE
[fb-package] Create tool to find changes in survey waves using .qsf files

### DIFF
--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -75,7 +75,13 @@ get_qsf_file <- function(path) {
     
     # These "questions" are not shown to respondents and thus don't need to be
     # accounted for in documentation or code. Skip.
-    if (question$QuestionText == "Click to write the question text") {next}
+    if (question$QuestionText == "Click to write the question text") {
+      warning(paste0("Item ", question$DataExportTag, " (", question$QuestionID,
+                     ") has question text '", question$QuestionText,
+                     "' and appears to be a remnant of the survey creation process; please remove."
+      ))
+      next
+    }
     
     # For matrix questions, "Choices" are the subquestion text and code. For all
     # other questions, "Choices" are the answer choices and corresponding

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -116,7 +116,9 @@ diff_questions <- function(old_qsf, new_qsf) {
 }
 
 ## Compare a single question field.
-diff_question <- function(names, change_type, comparator, old_qsf, new_qsf) {
+diff_question <- function(names, change_type=c("answers", "wording", "display logic", "subquestions"), comparator, old_qsf, new_qsf) {
+  change_type <- match.arg(change_type)
+  
   changed <- c()
   for (question in names) {
     if ( !identical(old_qsf[[question]][[comparator]], new_qsf[[question]][[comparator]]) ) {
@@ -129,24 +131,27 @@ diff_question <- function(names, change_type, comparator, old_qsf, new_qsf) {
 }
 
 ## Print results with custom message.
-print_questions <- function(questions, change_type=c("added", "removed", "answers", "wording", "display logic", "subquestions"), question_data) {
-  change_type <- match.arg(change_type)
-  questions <- sort(questions)
-  
-  if (change_type == "added") {
+print_questions <- function(questions, change_type=c("added", "removed", "answers", "wording", "display logic", "subquestions"), reference_qsf) {
+  if ( length(questions) > 0 ) {
+    change_type <- match.arg(change_type)
+    qids <- sort(questions)
+    item <- sapply(qids, function(question) {reference_qsf[[question]]$DataExportTag})
+    item_text <- sapply(qids, function(question) {reference_qsf[[question]]$QuestionText})
     
-  } else if (change_type == "removed") {
-    
-  } else if (change_type == "wording") {
-    
-  } else if (change_type == "display logic") {
-    
-  } else if (change_type == "answers") {
-    
-  } else if (change_type == "subquestions") {
-    
+    if (change_type == "added") {
+      cat(paste0("Added: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+    } else if (change_type == "removed") {
+      cat(paste0("Removed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+    } else if (change_type == "wording") {
+      cat(paste0("Wording changed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+    } else if (change_type == "display logic") {
+      cat(paste0("Display logic changed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+    } else if (change_type == "answers") {
+      cat(paste0("Answer choices changed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+    } else if (change_type == "subquestions") {
+      cat(paste0("Subquestions changed: matrix item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+    }
   }
-  
   return(NULL)
 }
 
@@ -161,7 +166,4 @@ if (length(args) != 2) {
 old_qsf <- args[1]
 new_qsf <- args[2]
 
-old_qsf <- "~/Downloads/Survey_of_COVID-Like_Illness_-_Wave_8_slr.qsf"
-new_qsf <- "~/Downloads/Survey_of_COVID-Like_Illness_-_Wave_10.qsf"
-
-diff_qsf_files(old_qsf, new_qsf)
+invisible(diff_qsf_files(old_qsf, new_qsf))

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -163,7 +163,7 @@ qid_to_int <- function(qid_str) {
 diff_questions <- function(old_qsf, new_qsf) {
   old_names <- names(old_qsf)
   new_names <- names(new_qsf)
-  
+  browser()
   added <- setdiff(new_names, old_names)
   print_questions(added, "added", new_qsf)
   
@@ -228,22 +228,22 @@ print_questions <- function(questions, change_type=c("added", "removed", "answer
     item_text <- sapply(item, function(question) {reference_qsf[[question]]$QuestionText})
     
     if (change_type == "added") {
-      cat("\n")
+      cat("\n ")
       cat(paste0("Added: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "removed") {
-      cat("\n")
+      cat("\n ")
       cat(paste0("Removed: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "wording") {
-      cat("\n")
+      cat("\n ")
       cat(paste0("Wording changed: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "display logic") {
-      cat("\n")
+      cat("\n ")
       cat(paste0("Display logic changed: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "answers") {
-      cat("\n")
+      cat("\n ")
       cat(paste0("Answer choices changed: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "subquestions") {
-      cat("\n")
+      cat("\n ")
       cat(paste0("Subquestions changed: matrix item ", item, " (", qids, ")", "\n"))
     }
   }
@@ -261,6 +261,8 @@ if (length(args) != 2) {
 old_qsf <- args[1]
 new_qsf <- args[2]
 
+options(nwarnings = 10000)
+
 invisible(diff_qsf_files(old_qsf, new_qsf))
-cat("\n")
-warnings()
+cat("\nWarning messages:\n ")
+cat(paste0(names(warnings()), "\n"))

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -40,7 +40,6 @@
 
 
 suppressPackageStartupMessages({
-  library(dplyr)
   library(jsonlite)
   library(stringr)
 })

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -209,29 +209,20 @@ print_questions <- function(questions, change_type=c("Added", "Removed", "Choice
   if ( length(questions) > 0 ) {
     change_type <- match.arg(change_type)
     
-    item <- sort(questions)
-    qids <- sapply(item, function(question) {reference_qsf[[question]]$QuestionID})
-    item_text <- sapply(item, function(question) {reference_qsf[[question]]$QuestionText})
+    text_options <- list(
+      Added = "Added: item %s (%s)\n",
+      Removed = "Removed: item %s (%s)\n",
+      QuestionText = "Question wording changed: item %s (%s)\n",
+      DisplayLogic = "Display logic changed: item %s (%s)\n",
+      Choices = "Answer choices changed: item %s (%s)\n",
+      Subquestions = "Matrix subquestions changed: item %s (%s)\n"
+    )
     
-    if (change_type == "Added") {
-      cat("\n ")
-      cat(paste0("Added: item ", item, " (", qids, ")", "\n"))
-    } else if (change_type == "Removed") {
-      cat("\n ")
-      cat(paste0("Removed: item ", item, " (", qids, ")", "\n"))
-    } else if (change_type == "QuestionText") {
-      cat("\n ")
-      cat(paste0("Question wording changed: item ", item, " (", qids, ")", "\n"))
-    } else if (change_type == "DisplayLogic") {
-      cat("\n ")
-      cat(paste0("Display logic changed: item ", item, " (", qids, ")", "\n"))
-    } else if (change_type == "Choices") {
-      cat("\n ")
-      cat(paste0("Answer choices changed: item ", item, " (", qids, ")", "\n"))
-    } else if (change_type == "Subquestions") {
-      cat("\n ")
-      cat(paste0("Matrix subquestions changed: item ", item, " (", qids, ")", "\n"))
-    }
+    questions <- sort(questions)
+    qids <- sapply(questions, function(question) { reference_qsf[[question]]$QuestionID })
+    
+    cat("\n ")
+    cat(sprintf(text_options[[change_type]], questions, qids))
   }
   return(NULL)
 }

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -7,26 +7,35 @@
 ## Rscript translation-differ.R path/to/old/qsf path/to/new/qsf
 ##
 ## Writes the lists of new and changed items to STDOUT, so redirect STDOUT to
-## your desired location and compress as desired.
+## your desired location.
 
 
 #### Background on .qsf files
-## Keep only useful fields (item number and question text). We are only
-## interested in "SQ" (survey questions) and "BL" (block name + contained
-## questions -- ordered?).
-# SurveyElement types are BL (block), FL (flow), SO (survey options), SCO
-# (scoring), PROJ (?), notes, STAT (statistics), QC (question count), SQ
-# (survey questions), and RS (response set). Detailed info:
-# https://gist.github.com/ctesta01/d4255959dace01431fb90618d1e8c241.
 
+## A .qsf file is a json containing two elements, SurveyEntry with survey
+## metadata (start date, ID, name, etc) and SurveyElements with a numbered list
+## of survey components. For the purpose of finding differences in survey
+## contents, we are only interested in examining the SurveyElements item.
 
-# Payload (list) elements:
+## SurveyElement types are BL (block), FL (flow), SO (survey options), SCO
+## (scoring), PROJ (?), notes, STAT (statistics), QC (question count), SQ
+## (survey questions), and RS (response set). Detailed info:
+## https://gist.github.com/ctesta01/d4255959dace01431fb90618d1e8c241
+
+## We are only interested in survey questions ("SQ"). Within each SQ item,
+## details are stored in the Payload element, which can contain the following
+## fields:
+
 # [1] "QuestionText"         "QuestionType"         "Selector"             "Configuration"        "QuestionDescription"  "Choices"              "ChoiceOrder"         
 # [8] "Validation"           "AnalyzeChoices"       "Language"             "QuestionText_Unsafe"  "DataExportTag"        "QuestionID"           "DataVisibility"      
 # [15] "NextChoiceId"         "NextAnswerId"         "DefaultChoices"       "SubSelector"          "DisplayLogic"         "GradingData"          "Answers"             
 # [22] "AnswerOrder"          "ChoiceDataExportTags" "Randomization"        "RecodeValues"         "DynamicChoices"       "DynamicChoicesData"   "SearchSource"        
 # [29] "QuestionJS"  
 
+## The meaning of "Answers" and "Choices" differs for matrix vs non-matrix
+## items. "Choices" list the vertical components -- subquestions for matrix
+## items and answer choices for non-matrix items. "Answers" list the answer
+## choices for matrix items and are missing for non-matrix items.
 
 
 suppressPackageStartupMessages({
@@ -38,8 +47,6 @@ suppressPackageStartupMessages({
 #'
 #' @param old_qsf_path path to older Qualtrics translation file in .qsf format
 #' @param new_qsf_path path to newer Qualtrics translation file in .qsf format
-#'
-#' @return A named list containing new and changed item names
 diff_qsf_files <- function(old_qsf_path, new_qsf_path) {
   old_qsf <- get_qsf_file(old_qsf_path)
   new_qsf <- get_qsf_file(new_qsf_path)
@@ -49,26 +56,37 @@ diff_qsf_files <- function(old_qsf_path, new_qsf_path) {
   return(NULL)
 }
 
-## Fetch and format a single translation file.
+#' Fetch and format a single .qsf translation file.
+#'
+#' @param path path to Qualtrics translation file in .qsf format
+#'
+#' @return A named list
 get_qsf_file <- function(path) {
   # Read file as json.
   qsf <- read_json(path, simplifyVector = TRUE)
   
   questions <- filter(qsf$SurveyElements, Element == "SQ")
-  keep_items <- c("QuestionID", "DataExportTag", "QuestionText", "QuestionType", "Choices", "Answers", "DisplayLogic")
+  keep_items <- c("QuestionID", "DataExportTag", "QuestionText",
+                  "QuestionType", "Choices", "Answers", "DisplayLogic")
   
   questions_out <- list()
   for (question in questions$Payload) {
     question <- question[names(question) %in% keep_items]
     
+    # For matrix questions, "Choices" are the subquestion text and code. For all
+    # other questions, "Choices" are the answer choices and corresponding
+    # response code.
     subquestion <- names(question$Choices)
     question$Choices <- unlist(question$Choices)
     names(question$Choices) <- subquestion
     
+    # For matrix questions, "Answers" are the answer choices and corresponding
+    # response code. For all other questions, this is not provided.
     response_codes <- names(question$Answers)
     question$Answers <- unlist(question$Answers)
     names(question$Answers) <- response_codes
     
+    # Rearrange items to be consistent between matrix and other items.
     if (question$QuestionType == "Matrix") {
       question$Subquestions <- question$Choices
       question$Choices <- question$Answers
@@ -77,7 +95,14 @@ get_qsf_file <- function(path) {
       question$Subquestions <- "NULL"
     }
     
-    question$DisplayLogic <- ifelse(is.null(question$DisplayLogic$`0`$`0`$Description), "NULL", question$DisplayLogic$`0`$`0`$Description)
+    # DisplayLogic "Description" summarizes display logic (e.g. if item is shown
+    # conditional on another question), including the conditioning question
+    # text, comparator, and comparison value.
+    question$DisplayLogic <- ifelse(
+      is.null(question$DisplayLogic$`0`$`0`$Description),
+      "NULL",
+      question$DisplayLogic$`0`$`0`$Description
+      )
     
     questions_out[[question$QuestionID]] <- question
   }
@@ -85,7 +110,10 @@ get_qsf_file <- function(path) {
   return(questions_out)
 }
 
-## Compare old vs new questions.
+#' Compare old vs new questions in the two surveys.
+#'
+#' @param old_qsf trimmed output from `get_qsf_file` for older survey
+#' @param new_qsf trimmed output from `get_qsf_file` for newer survey
 diff_questions <- function(old_qsf, new_qsf) {
   old_names <- names(old_qsf)
   new_names <- names(new_qsf)
@@ -115,7 +143,14 @@ diff_questions <- function(old_qsf, new_qsf) {
   return(NULL)
 }
 
-## Compare a single question field.
+#' Compare a single question field in the two surveys.
+#'
+#' @param names character vector of Qualtrics question IDs
+#' @param change_type character; type of change to look for
+#' @param comparator character; name of question element to compare between
+#'   survey versions
+#' @param old_qsf trimmed output from `get_qsf_file` for older survey
+#' @param new_qsf trimmed output from `get_qsf_file` for newer survey
 diff_question <- function(names, change_type=c("answers", "wording", "display logic", "subquestions"), comparator, old_qsf, new_qsf) {
   change_type <- match.arg(change_type)
   
@@ -130,7 +165,14 @@ diff_question <- function(names, change_type=c("answers", "wording", "display lo
   return(NULL)
 }
 
-## Print results with custom message.
+#' Print results with custom message for each possible change type.
+#'
+#' @param questions character vector of Qualtrics question IDs for items that
+#'   changed between survey versions
+#' @param change_type character; type of change to look for
+#' @param reference_qsf trimmed output from `get_qsf_file` for survey that
+#'   contains descriptive info about a particular type of change. For "removed"
+#'   questions, should be older survey, else newer survey.
 print_questions <- function(questions, change_type=c("added", "removed", "answers", "wording", "display logic", "subquestions"), reference_qsf) {
   if ( length(questions) > 0 ) {
     change_type <- match.arg(change_type)

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -76,13 +76,10 @@ get_qsf_file <- function(path) {
   for (question in questions$Payload) {
     question <- question[names(question) %in% keep_items]
     
-    # These "questions" are not shown to respondents and thus don't need to be
-    # accounted for in documentation or code. Skip.
+    # These items are remnants of the survey creation process and are not shown
+    # to respondents. Thus, they don't need to be accounted for in documentation
+    # or code. Skip.
     if (question$QuestionText == "Click to write the question text") {
-      warning(paste0("Item ", question$DataExportTag, " (", question$QuestionID,
-                     ") has question text '", question$QuestionText,
-                     "' and appears to be a remnant of the survey creation process; please remove."
-      ))
       next
     }
     

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -134,9 +134,18 @@ diff_question <- function(names, change_type=c("answers", "wording", "display lo
 print_questions <- function(questions, change_type=c("added", "removed", "answers", "wording", "display logic", "subquestions"), reference_qsf) {
   if ( length(questions) > 0 ) {
     change_type <- match.arg(change_type)
+    
     qids <- sort(questions)
     item <- sapply(qids, function(question) {reference_qsf[[question]]$DataExportTag})
     item_text <- sapply(qids, function(question) {reference_qsf[[question]]$QuestionText})
+    
+    # These "questions" are not shown to respondents and thus don't need to be
+    # accounted for in documentation or code. Drop.
+    drop_mask <- item_text == "Click to write the question text"
+    
+    qids <- qids[!drop_mask]
+    item <- item[!drop_mask]
+    item_text <- item_text[!drop_mask]
     
     if (change_type == "added") {
       cat(paste0("Added: item ", item, " (", qids, ") asking '", item_text, "'.\n"))

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -222,16 +222,22 @@ print_questions <- function(questions, change_type=c("added", "removed", "answer
     item_text <- sapply(item, function(question) {reference_qsf[[question]]$QuestionText})
     
     if (change_type == "added") {
+      cat("\n")
       cat(paste0("Added: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
     } else if (change_type == "removed") {
+      cat("\n")
       cat(paste0("Removed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
     } else if (change_type == "wording") {
+      cat("\n")
       cat(paste0("Wording changed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
     } else if (change_type == "display logic") {
+      cat("\n")
       cat(paste0("Display logic changed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
     } else if (change_type == "answers") {
+      cat("\n")
       cat(paste0("Answer choices changed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
     } else if (change_type == "subquestions") {
+      cat("\n")
       cat(paste0("Subquestions changed: matrix item ", item, " (", qids, ") asking '", item_text, "'.\n"))
     }
   }
@@ -250,3 +256,5 @@ old_qsf <- args[1]
 new_qsf <- args[2]
 
 invisible(diff_qsf_files(old_qsf, new_qsf))
+cat("\n")
+warnings()

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -1,0 +1,167 @@
+#!/usr/bin/env Rscript
+
+## Diff two .qsf translation files to find new and changed survey items
+##
+## Usage:
+##
+## Rscript translation-differ.R path/to/old/qsf path/to/new/qsf
+##
+## Writes the lists of new and changed items to STDOUT, so redirect STDOUT to
+## your desired location and compress as desired.
+
+
+#### Background on .qsf files
+## Keep only useful fields (item number and question text). We are only
+## interested in "SQ" (survey questions) and "BL" (block name + contained
+## questions -- ordered?).
+# SurveyElement types are BL (block), FL (flow), SO (survey options), SCO
+# (scoring), PROJ (?), notes, STAT (statistics), QC (question count), SQ
+# (survey questions), and RS (response set). Detailed info:
+# https://gist.github.com/ctesta01/d4255959dace01431fb90618d1e8c241.
+
+
+# Payload (list) elements:
+# [1] "QuestionText"         "QuestionType"         "Selector"             "Configuration"        "QuestionDescription"  "Choices"              "ChoiceOrder"         
+# [8] "Validation"           "AnalyzeChoices"       "Language"             "QuestionText_Unsafe"  "DataExportTag"        "QuestionID"           "DataVisibility"      
+# [15] "NextChoiceId"         "NextAnswerId"         "DefaultChoices"       "SubSelector"          "DisplayLogic"         "GradingData"          "Answers"             
+# [22] "AnswerOrder"          "ChoiceDataExportTags" "Randomization"        "RecodeValues"         "DynamicChoices"       "DynamicChoicesData"   "SearchSource"        
+# [29] "QuestionJS"  
+
+
+
+suppressPackageStartupMessages({
+  library(dplyr)
+  library(jsonlite)
+})
+
+#' Diff chosen translation files.
+#'
+#' @param old_qsf_path path to older Qualtrics translation file in .qsf format
+#' @param new_qsf_path path to newer Qualtrics translation file in .qsf format
+#'
+#' @return A named list containing new and changed item names
+diff_qsf_files <- function(old_qsf_path, new_qsf_path) {
+  old_qsf <- get_qsf_file(old_qsf_path)
+  new_qsf <- get_qsf_file(new_qsf_path)
+  
+  diff_questions(old_qsf, new_qsf)
+  
+  return(NULL)
+}
+
+## Fetch and format a single translation file.
+get_qsf_file <- function(path) {
+  # Read file as json.
+  qsf <- read_json(path, simplifyVector = TRUE)
+  
+  questions <- filter(qsf$SurveyElements, Element == "SQ")
+  keep_items <- c("QuestionID", "DataExportTag", "QuestionText", "QuestionType", "Choices", "Answers", "DisplayLogic")
+  
+  questions_out <- list()
+  for (question in questions$Payload) {
+    question <- question[names(question) %in% keep_items]
+    
+    subquestion <- names(question$Choices)
+    question$Choices <- unlist(question$Choices)
+    names(question$Choices) <- subquestion
+    
+    response_codes <- names(question$Answers)
+    question$Answers <- unlist(question$Answers)
+    names(question$Answers) <- response_codes
+    
+    if (question$QuestionType == "Matrix") {
+      question$Subquestions <- question$Choices
+      question$Choices <- question$Answers
+      question$Answers <- NULL
+    } else {
+      question$Subquestions <- "NULL"
+    }
+    
+    question$DisplayLogic <- ifelse(is.null(question$DisplayLogic$`0`$`0`$Description), "NULL", question$DisplayLogic$`0`$`0`$Description)
+    
+    questions_out[[question$QuestionID]] <- question
+  }
+  
+  return(questions_out)
+}
+
+## Compare old vs new questions.
+diff_questions <- function(old_qsf, new_qsf) {
+  old_names <- names(old_qsf)
+  new_names <- names(new_qsf)
+  
+  added <- setdiff(new_names, old_names)
+  print_questions(added, "added", new_qsf)
+  
+  removed <- setdiff(old_names, new_names)
+  print_questions(removed, "removed", old_qsf)
+  
+  ## For questions that appear in both surveys, check for changes in wording,
+  ## display logic, and answer options.
+  shared <- intersect(old_names, new_names)
+  
+  # Wording
+  diff_question(shared, "wording", "QuestionText", old_qsf, new_qsf)
+  
+  # Display logic
+  diff_question(shared, "display logic", "DisplayLogic", old_qsf, new_qsf)
+  
+  # Answer choices
+  diff_question(shared, "answers", "Choices", old_qsf, new_qsf)
+  
+  # Matrix sub-questions
+  diff_question(shared, "subquestions", "Subquestions", old_qsf, new_qsf)
+  
+  return(NULL)
+}
+
+## Compare a single question field.
+diff_question <- function(names, change_type, comparator, old_qsf, new_qsf) {
+  changed <- c()
+  for (question in names) {
+    if ( !identical(old_qsf[[question]][[comparator]], new_qsf[[question]][[comparator]]) ) {
+      changed <- append(changed, question)
+    }
+  }
+  print_questions(changed, change_type, new_qsf)
+  
+  return(NULL)
+}
+
+## Print results with custom message.
+print_questions <- function(questions, change_type=c("added", "removed", "answers", "wording", "display logic", "subquestions"), question_data) {
+  change_type <- match.arg(change_type)
+  questions <- sort(questions)
+  
+  if (change_type == "added") {
+    
+  } else if (change_type == "removed") {
+    
+  } else if (change_type == "wording") {
+    
+  } else if (change_type == "display logic") {
+    
+  } else if (change_type == "answers") {
+    
+  } else if (change_type == "subquestions") {
+    
+  }
+  
+  return(NULL)
+}
+
+
+
+args <- commandArgs(TRUE)
+
+if (length(args) != 2) {
+  stop("Usage: Rscript translation-differ.R path/to/old/qsf path/to/new/qsf")
+}
+
+old_qsf <- args[1]
+new_qsf <- args[2]
+
+old_qsf <- "~/Downloads/Survey_of_COVID-Like_Illness_-_Wave_8_slr.qsf"
+new_qsf <- "~/Downloads/Survey_of_COVID-Like_Illness_-_Wave_10.qsf"
+
+diff_qsf_files(old_qsf, new_qsf)

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -223,22 +223,22 @@ print_questions <- function(questions, change_type=c("added", "removed", "answer
     
     if (change_type == "added") {
       cat("\n")
-      cat(paste0("Added: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+      cat(paste0("Added: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "removed") {
       cat("\n")
-      cat(paste0("Removed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+      cat(paste0("Removed: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "wording") {
       cat("\n")
-      cat(paste0("Wording changed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+      cat(paste0("Wording changed: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "display logic") {
       cat("\n")
-      cat(paste0("Display logic changed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+      cat(paste0("Display logic changed: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "answers") {
       cat("\n")
-      cat(paste0("Answer choices changed: item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+      cat(paste0("Answer choices changed: item ", item, " (", qids, ")", "\n"))
     } else if (change_type == "subquestions") {
       cat("\n")
-      cat(paste0("Subquestions changed: matrix item ", item, " (", qids, ") asking '", item_text, "'.\n"))
+      cat(paste0("Subquestions changed: matrix item ", item, " (", qids, ")", "\n"))
     }
   }
   return(NULL)

--- a/facebook/translation-differ.R
+++ b/facebook/translation-differ.R
@@ -67,8 +67,7 @@ get_qsf_file <- function(path) {
   qsf <- read_json(path)
   
   ## Block
-  block_filter <- sapply(qsf$SurveyElements, function(elem) { elem[["Element"]] == "BL" })
-  block_out <- qsf$SurveyElements[block_filter][[1]]$Payload
+  block_out <- Filter(function(elem) { elem[["Element"]] == "BL" }, qsf$SurveyElements)[[1]]$Payload
   
   shown_items <- list()
   for (block in block_out) {
@@ -86,8 +85,7 @@ get_qsf_file <- function(path) {
   ## Questions
   keep_items <- c("QuestionID", "DataExportTag", "QuestionText",
                   "QuestionType", "Choices", "Answers", "DisplayLogic")
-  question_filter <- sapply(qsf$SurveyElements, function(elem) { elem[["Element"]] == "SQ" })
-  questions <- qsf$SurveyElements[question_filter]
+  questions <- Filter(function(elem) { elem[["Element"]] == "SQ" }, qsf$SurveyElements)
   
   qid_item_map <- list()
   questions_out <- list()


### PR DESCRIPTION
### Description
This makes a command-line tool to diff two .qsf files, printing out questions that differ between the two with respect to item wording in answer choices and subquestions (for matrix items), and display logic, and questions that have been added to/removed from the survey.

Example output comparing Wave 8 and Wave 10:
```
 Added: item C13b (QID158)
 Added: item C13c (QID207)
 Added: item V11 (QID195)
 Added: item V12 (QID217)
 Added: item V13 (QID210)
 Added: item V14 (QID212)

 Removed: item A3b (QID8)
 Removed: item B2b (QID11)
 Removed: item C11 (QID18)
 Removed: item C12 (QID19)
 Removed: item C13 (QID57)
 Removed: item C13a (QID58)
 Removed: item Q93 (QID145)

 Question wording changed: item B10a (QID154)
 Question wording changed: item B10b (QID156)
 Question wording changed: item B2 (QID151)
 Question wording changed: item C6 (QID163)
 Question wording changed: item C8 (QID165)
 Question wording changed: item D7 (QID171)
 Question wording changed: item V2a (QID179)
 Question wording changed: item V5a (QID184)
 Question wording changed: item V5b (QID186)
 Question wording changed: item V5c (QID188)
 Question wording changed: item V5d (QID190)

 Display logic changed: item B11 (QID54)
 Display logic changed: item B2c (QID215)
 Display logic changed: item B7 (QID49)
 Display logic changed: item E1 (QID86)
 Display logic changed: item V5d (QID190)
 Display logic changed: item V6 (QID193)
 Display logic changed: item V9 (QID104)

 Answer choices changed: item A5 (QID148)
 Answer choices changed: item B10b (QID156)
 Answer choices changed: item B12a (QID56)
 Answer choices changed: item B7 (QID49)
 Answer choices changed: item Q67 (QID173)
 Answer choices changed: item Q78 (QID175)
 Answer choices changed: item V2a (QID179)

 Matrix subquestions changed: item A1 (QID146)
```

This provides the change type, item name, and QID for all changed questions.

The display logic change detection may be oversensitive. I've set it up to ignore changes in conditional question wording, but in some cases (e.g. for E1 above) it appears that wording stays the same despite the QID of the conditioning question changing, which triggers a "change" notice anyway. Any changes in comparison operator (<, >, =), value, comparison type, etc will also trigger a change notice.