### PR TITLE
add try-except for non-datestring folder names

### DIFF
--- a/quidel_covidtest/delphi_quidel_covidtest/pull.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/pull.py
@@ -33,10 +33,13 @@ def get_from_s3(start_date, end_date, bucket):
     for obj in bucket.objects.all():
         if "-sars" in obj.key:
             date_string = obj.key.split("/")[1]
-            yy = int(date_string.split("_")[0])
-            mm = int(date_string.split("_")[1])
-            dd = int(date_string.split("_")[2])
-            received_date = datetime(yy, mm, dd)
+            try:
+                yy = int(date_string.split("_")[0])
+                mm = int(date_string.split("_")[1])
+                dd = int(date_string.split("_")[2])
+                received_date = datetime(yy, mm, dd)
+            except ValueError:
+                continue
             if received_date not in s3_files.keys():
                 s3_files[received_date] = [obj.key]
             else:


### PR DESCRIPTION
### Description
Bug fix. Error raised 2021-04-22, since there was a new folder added "backdate" in s3 bucket which did not follow the `YYYY-MM-DD` format.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- add `try-except` to allow such folder names in `get_from_s3` in `pull.py`

### Fixes 
- Fixes [issue](https://delphi-org.slack.com/archives/C01LZ3A2UMU/p1619030186002000)
