### PR TITLE
Add export_day_range into params.json

### DIFF
--- a/quidel_covidtest/delphi_quidel_covidtest/constants.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/constants.py
@@ -3,7 +3,6 @@
 MIN_OBS = 50  # minimum number of observations in order to compute a proportion.
 POOL_DAYS = 7  # number of days in the past (including today) to pool over
 END_FROM_TODAY_MINUS = 5 # report data until - X days
-EXPORT_DAY_RANGE = 40 # Number of dates to report
 # Signal names
 SMOOTHED_POSITIVE = "covid_ag_smoothed_pct_positive"
 RAW_POSITIVE = "covid_ag_raw_pct_positive"

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -14,7 +14,7 @@ from delphi_utils import (
     get_structured_logger
 )
 
-from .constants import (END_FROM_TODAY_MINUS, EXPORT_DAY_RANGE,
+from .constants import (END_FROM_TODAY_MINUS,
                         SMOOTHED_POSITIVE, RAW_POSITIVE,
                         SMOOTHED_TEST_PER_DEVICE, RAW_TEST_PER_DEVICE,
                         GEO_RESOLUTIONS, SENSORS, SMOOTHERS)
@@ -64,6 +64,7 @@ def run_module(params: Dict[str, Any]):
     export_dir = params["common"]["export_dir"]
     export_start_date = params["indicator"]["export_start_date"]
     export_end_date = params["indicator"]["export_end_date"]
+    export_day_range = params["indicator"]["export_day_range"]
 
     # Pull data and update export date
     df, _end_date = pull_quidel_covidtest(params["indicator"])
@@ -73,7 +74,7 @@ def run_module(params: Dict[str, Any]):
     export_end_date = check_export_end_date(export_end_date, _end_date,
                                             END_FROM_TODAY_MINUS)
     export_start_date = check_export_start_date(export_start_date,
-                                                export_end_date, EXPORT_DAY_RANGE)
+                                                export_end_date, export_day_range)
 
     first_date, last_date = df["timestamp"].min(), df["timestamp"].max()
 

--- a/quidel_covidtest/params.json.template
+++ b/quidel_covidtest/params.json.template
@@ -10,6 +10,7 @@
     "export_end_date": "",
     "pull_start_date": "2020-05-26",
     "pull_end_date":"",
+    "export_day_range":40,
     "aws_credentials": {
       "aws_access_key_id": "",
       "aws_secret_access_key": ""

--- a/quidel_covidtest/tests/test_run.py
+++ b/quidel_covidtest/tests/test_run.py
@@ -23,6 +23,7 @@ class TestRun:
             "export_end_date": "",
             "pull_start_date": "2020-07-09",
             "pull_end_date":"",
+            "export_day_range":40,
             "aws_credentials": {
                 "aws_access_key_id": "",
                 "aws_secret_access_key": ""


### PR DESCRIPTION
### Description
EXPORT DAY RANGE is a variable stored in `constants.py` previously to control the number of dates for the updates everyday. We used to let it equal to 40 to have daily reports from today-45days to today-5days. 

Since we need to backfill data for dates ranging from 11-15-2020 to 12-09-2020, it's more convenient to have EXPORT DAY RANGE to be a variable that can be easily changed via `params.json`.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- remove `EXPORT_DAY_RANGE` from `constants.py` 
- read `export_day_range` from `params.json` in `run.py`
- minor updates in `tests/test_run.py`

