### PR TITLE
[fb-package] Add preg/smoke/obese versions of eligible indicators

### DIFF
--- a/facebook/delphiFacebook/R/contingency_indicators.R
+++ b/facebook/delphiFacebook/R/contingency_indicators.R
@@ -39,6 +39,7 @@ get_aggs <- function() {
     c("age", "gender", "healthcareworker"),
     c("raceethnicity", "healthcareworker"),
     c("age", "gender", "eligible"),
+    c("age", "gender", "eligiblepregsmokeobese"),
     c("age"),
     c("agefull"),
     c("age65plus"),


### PR DESCRIPTION
We want all tables grouping by "eligible" variable to also have a version using "eligiblepregsmokeobese" (expanded eligibility group). One was missing; add it.