### PR TITLE
Remove the update step for the available signal matchlist from the Jenkins workflow

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,6 @@ pipeline {
                     }
                     parallel deploy_staging
                 }
-                sh "jenkins/deploy-staging-api-match-list.sh"
             }
         }
         stage('Deploy production') {


### PR DESCRIPTION
### Description
We are decommissioning api-staging.delphi.cmu.edu. There is a step in the
indicators Jenkinsfile that runs some Ansible to update a text file used by this
server. To keep Jenkins from failing we will remove this step.