### PR TITLE
Fix misplaced parenthesis preventing dry-run mode

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/run.py
+++ b/_delphi_utils_python/delphi_utils/validator/run.py
@@ -19,8 +19,8 @@ def run_module():
     validator = Validator(params)
     validator.validate().print_and_exit(
         get_structured_logger(__name__,
-                              params["common"].get("log_filename", None),
-                              not args.dry_run))
+                              params["common"].get("log_filename", None)),
+        not args.dry_run)
 
 
 def validator_from_params(params):


### PR DESCRIPTION
### Description
HHS needs a dry-run until we can tune its validation params. We'd added this mode, but whoopsed the parenthesis placement, so it was never taking effect.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- validator/run.py: move paren to correct location

### Fixes 
- Fixes #1024 
