### PR TITLE
Fix education coding bug in the delphiFacebook package

### DIFF
--- a/facebook/delphiFacebook/R/contingency_variables.R
+++ b/facebook/delphiFacebook/R/contingency_variables.R
@@ -293,9 +293,9 @@ remap_responses <- function(df) {
         "3"="Some college",
         "4"="2 year degree",
         "5"="4 year degree",
-        "6"="Master's degree",
-        "7"="Professional degree",
-        "8"="Doctorate"),
+        "8"="Master's degree",
+        "6"="Professional degree",
+        "7"="Doctorate"),
       "default"=NULL,
       "type"="mc"
     ),


### PR DESCRIPTION
### Description

* In the delphiFacebook R package, fix the coding of the education variable for master's degree, professional degree, and doctorate, which were out of order: should be 8 = master's, 6 = professional, 7 = doctorate per the [survey coding, p. 42](https://cmu-delphi.github.io/delphi-epidata/symptom-survey/waves/CMU%20Survey%20Wave%2010.pdf).

### Changelog
Itemize code/test/documentation changes and files added/removed.
- `contingency_variables.R`: Fix the coding for variable D8 to have 8 = master's, 6 = professional, 7 = doctorate.

@nmdefries This change doesn't actually affect the contingency table results because the tables use `edulevel` rather than `edulevelfull`, and `edulevel` combines all three of master's, professional, and doctorate into a single "PostGraduate" category. I've compared it on one week of data and got identical results.