### PR TITLE
Change max age of google-symptoms to 6 days

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -16,7 +16,7 @@
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "google-symptoms": {
-      "max_age": 11,
+      "max_age": 6,
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "usa-facts": {

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -17,7 +17,7 @@
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "google-symptoms": {
-      "max_age": 11,
+      "max_age": 6,
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "usa-facts": {


### PR DESCRIPTION
### Description
Google Search Trends now updates on a daily cadence, making the typical lag 5 days with occasional 6s due to late delivery. Sir CAL should start complaining at 7 days.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Ansible template & dev params for sir CAL

### Fixes 
- Fixes #1037 
