### PR TITLE
Rename nancodes before release

### DIFF
--- a/_delphi_utils_python/delphi_utils/nancodes.py
+++ b/_delphi_utils_python/delphi_utils/nancodes.py
@@ -8,6 +8,6 @@ class Nans(IntEnum):
     NOT_MISSING = 0
     NOT_APPLICABLE = 1
     REGION_EXCEPTION = 2
-    PRIVACY = 3
+    CENSORED = 3
     DELETED = 4
-    UNKNOWN = 5
+    OTHER = 5


### PR DESCRIPTION
### Description
After some discussion, we have decided to rename PRIVACY to CENSORED and UNKNOWN to OTHER. Since these codes have not been used in the system yet, no other changes will be necessary.
