### PR TITLE
Use z-score to account for variance in validation check of current vs historical values

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -1,5 +1,4 @@
 """Dynamic file checks."""
-import math
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Dict, Set

--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -409,8 +409,8 @@ class DynamicValidator:
         # These variables are interpolated into the call to `api_df_or_error.query()`
         # below but pylint doesn't recognize that.
         # pylint: disable=unused-variable
-        api_frames_end = min(api_frames["time_value"].max(
-        ), source_frame_start-timedelta(days=1))
+        api_frames_end = min(api_frames["time_value"].max(),
+                             source_frame_start-timedelta(days=1))
         # pylint: enable=unused-variable
         outlier_df = all_frames.query(
             'time_value >= @api_frames_end & time_value <= @source_frame_end')
@@ -474,91 +474,84 @@ class DynamicValidator:
         Returns:
             - None
         """
-        # Average each of val, se, and sample_size over all dates for a given geo_id.
-        # Ignores NA by default.
-        df_to_test = df_to_test.groupby(['geo_id'], as_index=False)[
-            ['val', 'se', 'sample_size']].mean()
-        df_to_test["type"] = "test"
+        # Calculate reference mean and standard deviation for each geo_id.
+        reference_mean = df_to_reference.groupby(['geo_id'], as_index=False)[
+            ['val', 'se', 'sample_size']].mean().assign(type="reference mean")
+        reference_sd = df_to_reference.groupby(['geo_id'], as_index=False)[
+            ['val', 'se', 'sample_size']].std().assign(type="reference sd")
 
-        df_to_reference = df_to_reference.groupby(['geo_id'], as_index=False)[
-            ['val', 'se', 'sample_size']].mean()
-        df_to_reference["type"] = "reference"
+        # Replace standard deviations of 0 with non-zero min sd for that type. Ignores NA.
+        replacements = {"val": {0: df_to_test.val[df_to_test.val > 0].min()},
+                        "se": {0: df_to_test.se[df_to_test.se > 0].min()},
+                        "sample_size": {0: df_to_test.se[df_to_test.sample_size > 0].min()}}
+        reference_sd.replace(replacements, inplace=True)
 
-        df_all = pd.concat([df_to_test, df_to_reference])
+        # Duplicate reference_mean and reference_sd for every unique time_value seen in df_to_test
+        reference_df = pd.concat(
+            [reference_mean, reference_sd]
+        ).assign(
+            key=0
+        ).merge(
+            df_to_test.assign(key=0)[["time_value", "key"]].drop_duplicates()
+        ).drop("key", axis=1)
+
+        # Drop unused columns from test data.
+        df_to_test = df_to_test[[
+            "geo_id", "val", "se", "sample_size", "time_value"
+        ]].assign(
+            type="test"
+        )
 
         # For each variable (val, se, and sample size) where not missing, calculate the
-        # relative mean difference and mean absolute difference between the test data
-        # and the reference data across all geographic regions.
+        # mean z-score and mean absolute z-score of the test data across all geographic
+        # regions and dates.
         #
-        # Steps:
-        #   - melt: creates a long version of df, where 'variable' specifies variable
-        # name (val, se, sample size) and 'value' specifies the value of said variable;
-        # geo_id and type columns are unchanged
-        #   - pivot: each row is the test and reference values for a given geo
-        # region-variable type combo
-        #   - reset_index: index is set to auto-incrementing int; geo_id and variable
-        # names are back as normal columns
-        #   - dropna: drop all rows with at least one missing value (makes it
-        # impossible to compare reference and test)
-        #   - assign: create new temporary columns, raw and abs value of difference
-        # between test and reference columns
-        #   - groupby: group by variable name
-        #   - agg: for every variable name group (across geo regions), calculate the
-        # mean of each of the raw difference between test and reference columns, the
-        # abs value of the difference between test and reference columns, all test
-        # values, all reference values
-        #   - assign: use the new aggregate vars to calculate the relative mean
-        # difference, 2 * mean(differences) / sum(means) of two groups.
-        df_all = pd.melt(
-            df_all, id_vars=["geo_id", "type"], value_vars=["val", "se", "sample_size"]
+        # Approach:
+        #  - Use each reference df to calculate mean and sd for each geo_id (above). Merge
+        #    onto test data.
+        #  - Use to calculate z-score for each test datapoint for a given geo_id and date.
+        #  - Avg z-scores over each geo_id, across all dates.
+        #  - Avg all z-scores together.
+        df_all = pd.concat(
+            [df_to_test, reference_df]
+        ).melt(
+            id_vars=["geo_id", "type", "time_value"], value_vars=["val", "se", "sample_size"]
         ).pivot(
-            index=("geo_id", "variable"), columns="type", values="value"
+            index=("geo_id", "variable", "time_value"), columns="type", values="value"
         ).reset_index(
-            ("geo_id", "variable")
+            ("geo_id", "variable", "time_value")
         ).dropna(
         ).assign(
-            type_diff=lambda x: x["test"] - x["reference"],
-            abs_type_diff=lambda x: abs(x["type_diff"])
+            z=lambda x: (
+                x["test"] - x["reference mean"]) / x["reference sd"],
+            abs_z=lambda x: abs(x["z"])
+        ).groupby(
+            ["geo_id", "variable"], as_index=False
+        ).agg(
+            geo_z=("z", "mean"),
+            geo_abs_z=("abs_z", "mean")
         ).groupby(
             "variable", as_index=False
         ).agg(
-            mean_type_diff=("type_diff", "mean"),
-            mean_abs_type_diff=("abs_type_diff", "mean"),
-            mean_test_var=("test", "mean"),
-            mean_ref_var=("reference", "mean")
-        ).assign(
-            mean_stddiff=lambda x: 2 *
-            x["mean_type_diff"] / (x["mean_test_var"] + x["mean_ref_var"]),
-            mean_stdabsdiff=lambda x: 2 *
-            x["mean_abs_type_diff"] / (x["mean_test_var"] + x["mean_ref_var"])
-        )[["variable", "mean_stddiff", "mean_stdabsdiff"]]
+            mean_z=("geo_z", "mean"),
+            mean_abs_z=("geo_abs_z", "mean")
+        )[["variable", "mean_z", "mean_abs_z"]]
 
-        # Set thresholds for raw and smoothed variables.
-        classes = ['mean_stddiff', 'val_mean_stddiff', 'mean_stdabsdiff']
-        raw_thresholds = pd.DataFrame([[1.50, 1.30, 1.80]], columns=classes)
-        smoothed_thresholds = raw_thresholds.apply(
-            lambda x: x/(math.sqrt(7) * 1.5))
-
-        switcher = {
-            'raw': raw_thresholds,
-            'smoothed': smoothed_thresholds,
-        }
-
-        # Get the selected thresholds from switcher dictionary
-        smooth_option = "smoothed" if signal_type in self.params.smoothed_signals else "raw"
-        thres = switcher.get(smooth_option, lambda: "Invalid smoothing option")
+        # Set thresholds for comparison.
+        classes = ['mean_z', 'val_mean_z', 'mean_abs_z']
+        thres = pd.DataFrame([[4.0, 3.5, 4.25]], columns=classes)
 
         # Check if the calculated mean differences are high compared to the thresholds.
-        mean_stddiff_high = (
-            abs(df_all["mean_stddiff"]) > float(thres["mean_stddiff"])).any() or (
+        mean_z_high = (
+            abs(df_all["mean_z"]) > float(thres["mean_z"])).any() or (
                 (df_all["variable"] == "val").any() and
-                (abs(df_all[df_all["variable"] == "val"]["mean_stddiff"])
-                 > float(thres["val_mean_stddiff"])).any()
+                (abs(df_all[df_all["variable"] == "val"]["mean_z"])
+                 > float(thres["val_mean_z"])).any()
         )
-        mean_stdabsdiff_high = (df_all["mean_stdabsdiff"] > float(
-            thres["mean_stdabsdiff"])).any()
+        mean_abs_z_high = (df_all["mean_abs_z"] > float(
+            thres["mean_abs_z"])).any()
 
-        if mean_stddiff_high or mean_stdabsdiff_high:
+        if mean_z_high or mean_abs_z_high:
             report.add_raised_error(
                 ValidationFailure(
                     "check_test_vs_reference_avg_changed",

--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -480,9 +480,9 @@ class DynamicValidator:
             ['val', 'se', 'sample_size']].std().assign(type="reference sd")
 
         # Replace standard deviations of 0 with non-zero min sd for that type. Ignores NA.
-        replacements = {"val": {0: df_to_test.val[df_to_test.val > 0].min()},
-                        "se": {0: df_to_test.se[df_to_test.se > 0].min()},
-                        "sample_size": {0: df_to_test.se[df_to_test.sample_size > 0].min()}}
+        replacements = {"val": {0: reference_sd.val[reference_sd.val > 0].min()},
+                        "se": {0: reference_sd.se[reference_sd.se > 0].min()},
+                        "sample_size": {0: reference_sd.se[reference_sd.sample_size > 0].min()}}
         reference_sd.replace(replacements, inplace=True)
 
         # Duplicate reference_mean and reference_sd for every unique time_value seen in df_to_test

--- a/_delphi_utils_python/tests/validator/test_dynamic.py
+++ b/_delphi_utils_python/tests/validator/test_dynamic.py
@@ -6,6 +6,7 @@ import pandas as pd
 from delphi_utils.validator.report import ValidationReport
 from delphi_utils.validator.dynamic import DynamicValidator
 
+
 class TestCheckRapidChange:
     params = {
         "common": {
@@ -54,7 +55,8 @@ class TestCheckAvgValDiffs:
         report = ValidationReport([])
 
         data = {"val": [1, 1, 1, 2, 0, 1], "se": [np.nan] * 6,
-                "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
+                "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6,
+                "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
 
         test_df = pd.DataFrame(data)
         ref_df = pd.DataFrame(data)
@@ -69,7 +71,8 @@ class TestCheckAvgValDiffs:
         report = ValidationReport([])
 
         data = {"val": [np.nan] * 6, "se": [1, 1, 1, 2, 0, 1],
-                "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
+                "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6,
+                "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
 
         test_df = pd.DataFrame(data)
         ref_df = pd.DataFrame(data)
@@ -84,7 +87,8 @@ class TestCheckAvgValDiffs:
         report = ValidationReport([])
 
         data = {"val": [np.nan] * 6, "se": [np.nan] * 6,
-                "sample_size": [1, 1, 1, 2, 0, 1], "geo_id": ["1"] * 6}
+                "sample_size": [1, 1, 1, 2, 0, 1], "geo_id": ["1"] * 6,
+                "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
 
         test_df = pd.DataFrame(data)
         ref_df = pd.DataFrame(data)
@@ -99,7 +103,8 @@ class TestCheckAvgValDiffs:
         report = ValidationReport([])
 
         data = {"val": [1, 1, 1, 2, 0, 1], "se": [1, 1, 1, 2, 0, 1],
-                "sample_size": [1, 1, 1, 2, 0, 1], "geo_id": ["1"] * 6}
+                "sample_size": [1, 1, 1, 2, 0, 1], "geo_id": ["1"] * 6,
+                "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
 
         test_df = pd.DataFrame(data)
         ref_df = pd.DataFrame(data)
@@ -113,9 +118,11 @@ class TestCheckAvgValDiffs:
         validator = DynamicValidator(self.params)
         report = ValidationReport([])
         test_data = {"val": [1, 1, 1, 20, 0, 1], "se": [np.nan] * 6,
-                     "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
+                     "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6,
+                     "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
         ref_data = {"val": [1, 1, 1, 2, 0, 1], "se": [np.nan] * 6,
-                    "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
+                    "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6,
+                    "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
 
         test_df = pd.DataFrame(test_data)
         ref_df = pd.DataFrame(ref_data)
@@ -123,15 +130,18 @@ class TestCheckAvgValDiffs:
             test_df, ref_df,
             datetime.combine(date.today(), datetime.min.time()), "geo", "signal", report)
 
-        assert len(report.raised_errors) == 0
+        assert len(report.raised_errors) == 1
+        assert report.raised_errors[0].check_name == "check_test_vs_reference_avg_changed"
 
     def test_100x_val(self):
         validator = DynamicValidator(self.params)
         report = ValidationReport([])
         test_data = {"val": [1, 1, 1, 200, 0, 1], "se": [np.nan] * 6,
-                     "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
+                     "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6,
+                     "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
         ref_data = {"val": [1, 1, 1, 2, 0, 1], "se": [np.nan] * 6,
-                    "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
+                    "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6,
+                    "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
 
         test_df = pd.DataFrame(test_data)
         ref_df = pd.DataFrame(ref_data)
@@ -146,9 +156,11 @@ class TestCheckAvgValDiffs:
         validator = DynamicValidator(self.params)
         report = ValidationReport([])
         test_data = {"val": [1, 1, 1, 2000, 0, 1], "se": [np.nan] * 6,
-                     "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
+                     "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6,
+                     "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
         ref_data = {"val": [1, 1, 1, 2, 0, 1], "se": [np.nan] * 6,
-                    "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6}
+                    "sample_size": [np.nan] * 6, "geo_id": ["1"] * 6,
+                    "time_value": ["2021-01-01", "2021-01-02", "2021-01-03", "2021-01-04", "2021-01-05", "2021-01-06"]}
 
         test_df = pd.DataFrame(test_data)
         ref_df = pd.DataFrame(ref_data)
@@ -158,6 +170,7 @@ class TestCheckAvgValDiffs:
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_test_vs_reference_avg_changed"
+
 
 class TestDataOutlier:
     params = {
@@ -169,39 +182,39 @@ class TestDataOutlier:
     }
     pd.set_option("display.max_rows", None, "display.max_columns", None)
     # Test to determine outliers based on the row data, has lead and lag outlier
+
     def test_pos_outlier(self):
         validator = DynamicValidator(self.params)
         report = ValidationReport([])
 
         ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,
-                31.42857143, 31.71428571, 32, 32, 32.14285714,
-                32.28571429, 32.42857143, 32.57142857, 32.71428571,
-                32.85714286, 33, 33, 33, 33, 33, 33, 33, 33,
-                33, 33, 33, 33.28571429, 33.57142857, 33.85714286, 34.14285714]
+                   31.42857143, 31.71428571, 32, 32, 32.14285714,
+                   32.28571429, 32.42857143, 32.57142857, 32.71428571,
+                   32.85714286, 33, 33, 33, 33, 33, 33, 33, 33,
+                   33, 33, 33, 33.28571429, 33.57142857, 33.85714286, 34.14285714]
         test_val = [100, 100, 100]
 
+        ref_data = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                    "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
+                    "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
+        test_data = {"val": test_val, "se": [np.nan] * len(test_val),
+                     "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
+                     "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
-        ref_data = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
-                "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
-        test_data = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
-                 "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
+        ref_data2 = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                     "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
+                     "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
+        test_data2 = {"val": test_val, "se": [np.nan] * len(test_val),
+                      "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
+                      "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
-        ref_data2 = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
-                "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
-        test_data2 = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
-                "time_value": pd.date_range(start="2020-10-24",end="2020-10-26")}
-
-        ref_df = pd.concat([pd.DataFrame(ref_data), pd.DataFrame(ref_data2)]).reset_index(drop=True)
+        ref_df = pd.concat(
+            [pd.DataFrame(ref_data), pd.DataFrame(ref_data2)]).reset_index(drop=True)
         test_df = pd.concat([pd.DataFrame(test_data), pd.DataFrame(test_data2)]). \
-                            reset_index(drop=True)
+            reset_index(drop=True)
 
         validator.check_positive_negative_spikes(
             test_df, ref_df, "state", "signal", report)
-
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_positive_negative_spikes"
@@ -218,30 +231,27 @@ class TestDataOutlier:
                    100, 98, 100, 100, 100]
         test_val = [10, 10, 10]
 
+        ref_data = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                    "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
+                    "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
+        test_data = {"val": test_val, "se": [np.nan] * len(test_val),
+                     "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
+                     "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
-        ref_data = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
-                "time_value": pd.date_range(start="2020-09-24",end="2020-10-23")}
-        test_data = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
-                 "time_value": pd.date_range(start="2020-10-24",end="2020-10-26")}
-
-        ref_data2 = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
-                 "time_value": pd.date_range(start="2020-09-24",end="2020-10-23")}
-        test_data2 = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
-                 "time_value": pd.date_range(start="2020-10-24",end="2020-10-26")}
+        ref_data2 = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                     "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
+                     "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
+        test_data2 = {"val": test_val, "se": [np.nan] * len(test_val),
+                      "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
+                      "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
         ref_df = pd.concat([pd.DataFrame(ref_data), pd.DataFrame(ref_data2)]). \
-                    reset_index(drop=True)
+            reset_index(drop=True)
         test_df = pd.concat([pd.DataFrame(test_data), pd.DataFrame(test_data2)]). \
-                    reset_index(drop=True)
-
+            reset_index(drop=True)
 
         validator.check_positive_negative_spikes(
             test_df, ref_df, "state", "signal", report)
-
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_positive_negative_spikes"
@@ -251,37 +261,33 @@ class TestDataOutlier:
         report = ValidationReport([])
 
         ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,
-                31.42857143, 31.71428571, 32, 32, 32.14285714,
-                32.28571429, 32.42857143, 32.57142857, 32.71428571,
-                32.85714286, 33, 33, 33, 33, 33, 33, 33, 33,
-                33, 33, 33, 33.28571429, 33.57142857, 33.85714286, 34.14285714]
+                   31.42857143, 31.71428571, 32, 32, 32.14285714,
+                   32.28571429, 32.42857143, 32.57142857, 32.71428571,
+                   32.85714286, 33, 33, 33, 33, 33, 33, 33, 33,
+                   33, 33, 33, 33.28571429, 33.57142857, 33.85714286, 34.14285714]
         test_val = [0, 0, 0]
 
+        ref_data = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                    "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
+                    "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
+        test_data = {"val": test_val, "se": [np.nan] * len(test_val),
+                     "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
+                     "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
-        ref_data = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
-                "time_value": pd.date_range(start="2020-09-24",end="2020-10-23")}
-        test_data = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
-                 "time_value": pd.date_range(start="2020-10-24",end="2020-10-26")}
-
-        ref_data2 = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
-                 "time_value": pd.date_range(start="2020-09-24",end="2020-10-23")}
-        test_data2 = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
-                 "time_value": pd.date_range(start="2020-10-24",end="2020-10-26")}
+        ref_data2 = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                     "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
+                     "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
+        test_data2 = {"val": test_val, "se": [np.nan] * len(test_val),
+                      "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
+                      "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
         ref_df = pd.concat([pd.DataFrame(ref_data), pd.DataFrame(ref_data2)]). \
-                    reset_index(drop=True)
+            reset_index(drop=True)
         test_df = pd.concat([pd.DataFrame(test_data), pd.DataFrame(test_data2)]). \
-                    reset_index(drop=True)
-
+            reset_index(drop=True)
 
         validator.check_positive_negative_spikes(
             test_df, ref_df, "state", "signal", report)
-
-
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_positive_negative_spikes"
@@ -290,38 +296,35 @@ class TestDataOutlier:
         validator = DynamicValidator(self.params)
         report = ValidationReport([])
 
-        #Data from 51580 between 9/24 and 10/26 (10/25 query date)
+        # Data from 51580 between 9/24 and 10/26 (10/25 query date)
         ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,
-                31.42857143, 31.71428571, 32, 32, 32.14285714,
-                32.28571429, 32.42857143, 32.57142857, 32.71428571,
-                32.85714286, 33, 33, 33, 33, 33, 33, 33, 33,
-                33, 33, 33, 33, 33, 33, 33]
+                   31.42857143, 31.71428571, 32, 32, 32.14285714,
+                   32.28571429, 32.42857143, 32.57142857, 32.71428571,
+                   32.85714286, 33, 33, 33, 33, 33, 33, 33, 33,
+                   33, 33, 33, 33, 33, 33, 33]
         test_val = [33, 33, 33]
 
+        ref_data = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                    "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
+                    "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
+        test_data = {"val": test_val, "se": [np.nan] * len(test_val),
+                     "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
+                     "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
-        ref_data = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
-                "time_value": pd.date_range(start="2020-09-24",end="2020-10-23")}
-        test_data = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
-                 "time_value": pd.date_range(start="2020-10-24",end="2020-10-26")}
-
-        ref_data2 = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
-                 "time_value": pd.date_range(start="2020-09-24",end="2020-10-23")}
-        test_data2 = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
-                 "time_value": pd.date_range(start="2020-10-24",end="2020-10-26")}
+        ref_data2 = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                     "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
+                     "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")}
+        test_data2 = {"val": test_val, "se": [np.nan] * len(test_val),
+                      "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
+                      "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
         ref_df = pd.concat([pd.DataFrame(ref_data), pd.DataFrame(ref_data2)]). \
-                    reset_index(drop=True)
+            reset_index(drop=True)
         test_df = pd.concat([pd.DataFrame(test_data), pd.DataFrame(test_data2)]). \
-                    reset_index(drop=True)
-
+            reset_index(drop=True)
 
         validator.check_positive_negative_spikes(
             test_df, ref_df, "state", "signal", report)
-
 
         assert len(report.raised_errors) == 0
 
@@ -329,38 +332,35 @@ class TestDataOutlier:
         validator = DynamicValidator(self.params)
         report = ValidationReport([])
 
-        #Data from 51580 between 9/24 and 10/26 (10/25 query date)
+        # Data from 51580 between 9/24 and 10/26 (10/25 query date)
         ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,
-                31.42857143, 31.71428571, 32, 32, 32.14285714,
-                32.28571429, 32.42857143, 32.57142857, 32.71428571,
-                32.85714286, 33, 33, 33, 33, 33, 33, 33, 33, 33,
-                33, 33, 33, 33, 33, 33, 33, 33, 33]
+                   31.42857143, 31.71428571, 32, 32, 32.14285714,
+                   32.28571429, 32.42857143, 32.57142857, 32.71428571,
+                   32.85714286, 33, 33, 33, 33, 33, 33, 33, 33, 33,
+                   33, 33, 33, 33, 33, 33, 33, 33, 33]
         test_val = [100, 100, 100]
 
+        ref_data = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                    "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
+                    "time_value": pd.date_range(start="2020-09-24", end="2020-10-26")}
+        test_data = {"val": test_val, "se": [np.nan] * len(test_val),
+                     "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
+                     "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
-        ref_data = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
-                "time_value": pd.date_range(start="2020-09-24",end="2020-10-26")}
-        test_data = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
-                 "time_value": pd.date_range(start="2020-10-24",end="2020-10-26")}
-
-        ref_data2 = {"val": ref_val , "se": [np.nan] * len(ref_val),
-                "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
-                 "time_value": pd.date_range(start="2020-09-24",end="2020-10-26")}
-        test_data2 = {"val": test_val , "se": [np.nan] * len(test_val),
-                "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
-                 "time_value": pd.date_range(start="2020-10-24",end="2020-10-26")}
+        ref_data2 = {"val": ref_val, "se": [np.nan] * len(ref_val),
+                     "sample_size": [np.nan] * len(ref_val), "geo_id": ["2"] * len(ref_val),
+                     "time_value": pd.date_range(start="2020-09-24", end="2020-10-26")}
+        test_data2 = {"val": test_val, "se": [np.nan] * len(test_val),
+                      "sample_size": [np.nan] * len(test_val), "geo_id": ["2"] * len(test_val),
+                      "time_value": pd.date_range(start="2020-10-24", end="2020-10-26")}
 
         ref_df = pd.concat([pd.DataFrame(ref_data), pd.DataFrame(ref_data2)]). \
-                    reset_index(drop=True)
+            reset_index(drop=True)
         test_df = pd.concat([pd.DataFrame(test_data), pd.DataFrame(test_data2)]). \
-                    reset_index(drop=True)
-
+            reset_index(drop=True)
 
         validator.check_positive_negative_spikes(
             test_df, ref_df, "state", "signal", report)
-
 
         assert len(report.raised_errors) == 1
         assert report.raised_errors[0].check_name == "check_positive_negative_spikes"


### PR DESCRIPTION
### Description
The validation check `check_test_vs_reference_avg_changed` previously used a metric tracking average change (across all regions and dates-to-be-checked) in historical average value vs average value in test set compared to historical average + current average. Think half-way between multiplicative increase in current average value compared to historical average value and relative mean difference. This approach does not account for variance, causing errors in high-variance signals, which we tend to see at fine geo levels (county, e.g.) due to small population.

To account for variance and to allow more intuitive tuning of hard-coded thresholds, this switches `check_test_vs_reference_avg_changed` to using z-score instead.

Initial z-score thresholds were set using JHU signals only in consideration of #752.

### Changelog
- Use z-score in place of "relative mean difference". Variances of 0 are replaced with the smallest non-zero variance.
- Increase size of reference window used for smoothed signals to avoid interaction with moving average smoothing window.
- Auto-formatting.

### Fixes 
This PR makes #970 obsolete by switching to a metric that controls for historical variance. There should be no need for users to adjust metric thresholds on a per-signal basis.
