### PR TITLE
Turn on async covidcast fetch for sirCAL

### DIFF
--- a/sir_complainsalot/delphi_sir_complainsalot/check_source.py
+++ b/sir_complainsalot/delphi_sir_complainsalot/check_source.py
@@ -7,6 +7,8 @@ from datetime import datetime, timedelta
 import numpy as np
 import pandas as pd
 
+covidcast.covidcast._ASYNC_CALL = True  # pylint: disable=protected-access
+
 @dataclass
 class Complaint:
     message: str


### PR DESCRIPTION
### Description

The nightly SirCAL run has been pushing an hour in running time, so it's probably a good idea to switch to async calls.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- check_source.py

