### PR TITLE
[fb-survey] permit fetching qualtrics files for past days

### DIFF
--- a/facebook/Makefile
+++ b/facebook/Makefile
@@ -81,6 +81,7 @@ $(TODAY):
 	done; \
 	$(SFTP_POST); \
 	echo "SUCCESS: $(DRY_MESSAGE)Posted `echo -e $${BATCH} | wc -l` raw files" >> $(MESSAGES)
+	touch -d $(YESTERDAY) params.json
 	mv tmp $@
 
 params.json: $(TODAY)

--- a/facebook/Makefile
+++ b/facebook/Makefile
@@ -72,6 +72,7 @@ $(TODAY):
 	[ -f $(QUALTRICS) ] || mkdir -p $(QUALTRICS)
 	rm -rf tmp
 	touch -d "$(TODAY) 01:00" tmp
+	$(PYTHON) -m delphi_utils set end_date $(YESTERDAY)
 	source env/bin/activate && \
 	python -m delphi_facebook
 	BATCH=""; \

--- a/facebook/delphiFacebook/python/delphi_facebook/qualtrics.py
+++ b/facebook/delphiFacebook/python/delphi_facebook/qualtrics.py
@@ -62,10 +62,10 @@ def get(fetch,post,params):
         #start = datetime.combine(date(2020,4,19),time(00,00,00),tzinfo=TZ)
 
         # Fully incremental: 7 days to capture backfill
-        start = datetime.combine(date.today()-timedelta(days=7),time(00,00,00),tzinfo=TZ)
+        start = datetime.combine(params['date']-timedelta(days=7),time(00,00,00),tzinfo=TZ)
 
         # Account for StartDate->RecordedDate lag:
-        end   = datetime.combine(date.today(),time(4,00,00),tzinfo=TZ)
+        end   = datetime.combine(params['date'],time(4,00,00),tzinfo=TZ)
         r = post(base,{
             "format":"csv",
             "timeZone":TIMEZONE,

--- a/facebook/delphiFacebook/python/delphi_facebook/run.py
+++ b/facebook/delphiFacebook/python/delphi_facebook/run.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Functions to call when running the module.
 """
+from datetime import datetime, timedelta
 import numpy as np
 import os
 import pandas as pd
@@ -12,6 +13,10 @@ def run_module():
     params = read_params()
     qparams = params['qualtrics']
     qparams['qualtrics_dir'] = params['input_dir']
+    qparams['date'] = datetime.strptime(
+        params['end_date'],
+        "%Y-%m-%d"
+    ).date() + timedelta(days=1)
 
     if not os.path.exists(qparams['qualtrics_dir']):
         os.makedirs(qparams['qualtrics_dir'])


### PR DESCRIPTION
### Description
Currently the delphi_facebook python package fetches the most recent 7 days of data regardless of the date set in the params file. This PR makes it look at the `end_date` parameter and compute which 7 days to fetch from qualtrics.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Makefile -- set `end_date` before fetching qualtrics data
- run.py -- set `qualtrics.date` from `end_date`
- qualtrics.py -- configure POST parameters using `qualtrics.date`

