### PR TITLE
Switch to sendmail for stale weights notifications

### DIFF
--- a/facebook/Makefile
+++ b/facebook/Makefile
@@ -3,10 +3,11 @@ SHELL:=/bin/bash
 # dry-run mode: generate all files, but do not post them anywhere, and disable all emails to outside parties.
 DRY:=yes
 ifeq ($(DRY),yes)
-	OUTSIDE_EMAIL_FLAGS:=-d
+	EMAIL_SEND:=echo -e "Would send mail: echo -e \"Subject: $${SUBJECT}\n\n$${MSG}\" | sendmail krivard@cs.cmu.edu"
 	SFTP_POST:=echo -e "Would run: sftp -b <(echo -e \"\$${BATCH}\") -P 2222 fb-automation@ftp.delphi.cmu.edu\n$${BATCH}"
 	DRY_MESSAGE:="[DRY-RUN] "
 else
+	EMAIL_SEND:=echo -e "Subject: $${SUBJECT}\n\n$${MSG}" | sendmail krivard@cs.cmu.edu
 	SFTP_POST:=sftp -b <(echo -e "$${BATCH}") -P 2222 fb-automation@ftp.delphi.cmu.edu
 endif
 
@@ -111,8 +112,8 @@ $(WEIGHTS): $(TODAY)
 	if [[ $$EXPECTED_MAX_WEIGHTED -gt $$MAX_WEIGHTED ]]; then \
 	  MSG="Expected most recent file: $$EXPECTED_MAX_WEIGHTED\nActual most recent file: $$MAX_WEIGHTED"; \
 	  echo "WARNING: $${MSG}" | tr "\n" ";" >> $(MESSAGES); \
-	  echo -e "$(FB_CC)\n\n$${MSG}" | \
-	  s-nail $(OUTSIDE_EMAIL_FLAGS) -t -s "[fb-cmu-cvid] Weights are stale" -. krivard@cs.cmu.edu; \
+	  SUBJECT="[fb-cmu-cvid] Weights are stale"; \
+	  $(EMAIL_SEND) ;\
 	fi
 
 dev: delphiFacebook_1.0.tar.gz


### PR DESCRIPTION
### Description
Surveys is moving to a temporary home after three strikes on the server under my desk on campus crashing with no evidence as to why. The Makefile emails for help if the weights are stale, and need to be converted from `s-nail` to `sendmail`.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Makefile - more detailed dry-run handling for sending email via sendmail instead of snail

