### PR TITLE
Add raw data logging statement to USAFacts

### DIFF
--- a/usafacts/delphi_usafacts/run.py
+++ b/usafacts/delphi_usafacts/run.py
@@ -100,7 +100,7 @@ def run_module(params: Dict[str, Dict[str, Any]]):
             params["archive"]["aws_credentials"])
         arch_diff.update_cache()
 
-    dfs = {metric: pull_usafacts_data(base_url, metric) for metric in METRICS}
+    dfs = {metric: pull_usafacts_data(base_url, metric, logger) for metric in METRICS}
     for metric, geo_res, sensor, smoother in product(
             METRICS, GEO_RESOLUTIONS, SENSORS, SMOOTHERS):
         logger.info("generating signal and exporting to CSV",

--- a/usafacts/tests/test_pull.py
+++ b/usafacts/tests/test_pull.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 
 import pandas as pd
 
@@ -12,11 +13,12 @@ BASE_URL_BAD = {
     "extra_cols": "test_data/bad_{metric}_extra_cols.csv"
 }
 
+TEST_LOGGER = logging.getLogger()
 
 class TestPullUSAFacts:
     def test_good_file(self):
         metric = "deaths"
-        df = pull_usafacts_data(BASE_URL_GOOD, metric)
+        df = pull_usafacts_data(BASE_URL_GOOD, metric, TEST_LOGGER)
         expected_df = pd.DataFrame({
             "fips": ["00001", "00001", "00001", "36009", "36009", "36009"],
             "timestamp": [pd.Timestamp("2020-02-29"), pd.Timestamp("2020-03-01"),
@@ -33,7 +35,7 @@ class TestPullUSAFacts:
         metric = "confirmed"
         with pytest.raises(ValueError):
             pull_usafacts_data(
-                BASE_URL_BAD["missing_days"], metric
+                BASE_URL_BAD["missing_days"], metric, TEST_LOGGER
             )
 
     def test_missing_cols(self):
@@ -41,7 +43,7 @@ class TestPullUSAFacts:
         metric = "confirmed"
         with pytest.raises(ValueError):
             pull_usafacts_data(
-                BASE_URL_BAD["missing_cols"], metric
+                BASE_URL_BAD["missing_cols"], metric, TEST_LOGGER
             )
 
     def test_extra_cols(self):
@@ -49,5 +51,5 @@ class TestPullUSAFacts:
         metric = "confirmed"
         with pytest.raises(ValueError):
             pull_usafacts_data(
-                BASE_URL_BAD["extra_cols"], metric
+                BASE_URL_BAD["extra_cols"], metric, TEST_LOGGER
             )


### PR DESCRIPTION
### Description
USAFacts has had a few instances where it ran without error but nothing new was ingested. It's unclear if it's something in our pipeline or if it's from the source, but the latest instance shows that the max export date did not change for 3 days in a row, suggesting that raw data may not have updated. This PR adds additional logging on the raw data.

Another thing we might consider doing in the future is just storing all the raw data to s3 as an intermediate step.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add log statement with info about the raw dataframe downloaded.
    - dimensions
    - min/max dates
    - checksum

### Fixes 
- Fixes #(issue)
