### PR TITLE
[Fix] Make Smoother "identity" smoother a true no-op by default (no impute)

### DIFF
--- a/_delphi_utils_python/delphi_utils/smooth.py
+++ b/_delphi_utils_python/delphi_utils/smooth.py
@@ -153,10 +153,9 @@ class Smoother:  # pylint: disable=too-many-instance-attributes
     def _select_imputer(self, impute_method, smoother_name):
         if impute_method is None and smoother_name != "identity":
             return "savgol"
-        elif impute_method is None and smoother_name == "identity":
+        if impute_method is None and smoother_name == "identity":
             return "identity"
-        else:
-            return impute_method
+        return impute_method
 
     def smooth(
         self, signal: Union[np.ndarray, pd.Series], impute_order=2

--- a/_delphi_utils_python/delphi_utils/smooth.py
+++ b/_delphi_utils_python/delphi_utils/smooth.py
@@ -116,7 +116,7 @@ class Smoother:  # pylint: disable=too-many-instance-attributes
         poly_fit_degree=2,
         window_length=28,
         gaussian_bandwidth=144,  # a ~2 week window
-        impute_method="savgol",
+        impute_method=None,
         minval=None,
         boundary_method="shortened_window",
     ):
@@ -125,12 +125,12 @@ class Smoother:  # pylint: disable=too-many-instance-attributes
         self.poly_fit_degree = poly_fit_degree
         self.window_length = window_length
         self.gaussian_bandwidth = gaussian_bandwidth
-        self.impute_method = impute_method
+        self.impute_method = self._select_imputer(impute_method, self.smoother_name)
         self.minval = minval
         self.boundary_method = boundary_method
 
         valid_smoothers = {"savgol", "left_gauss_linear", "moving_average", "identity"}
-        valid_impute_methods = {"savgol", "zeros", None}
+        valid_impute_methods = {"savgol", "zeros", "identity"}
         valid_boundary_methods = {"shortened_window", "identity", "nan"}
         if self.smoother_name not in valid_smoothers:
             raise ValueError("Invalid smoother_name given.")
@@ -149,6 +149,14 @@ class Smoother:  # pylint: disable=too-many-instance-attributes
             )
         else:
             self.coeffs = None
+
+    def _select_imputer(self, impute_method, smoother_name):
+        if impute_method is None and smoother_name != "identity":
+            return "savgol"
+        elif impute_method is None and smoother_name == "identity":
+            return "identity"
+        else:
+            return impute_method
 
     def smooth(
         self, signal: Union[np.ndarray, pd.Series], impute_order=2
@@ -239,7 +247,7 @@ class Smoother:  # pylint: disable=too-many-instance-attributes
             imputed_signal = self.savgol_impute(signal, impute_order)
         elif self.impute_method == "zeros":
             imputed_signal = np.nan_to_num(signal)
-        elif self.impute_method is None:
+        elif self.impute_method == "identity":
             imputed_signal = np.copy(signal)
 
         return imputed_signal

--- a/_delphi_utils_python/tests/test_smooth.py
+++ b/_delphi_utils_python/tests/test_smooth.py
@@ -30,7 +30,7 @@ class TestSmoothers:
         with pytest.raises(ValueError):
             signal = np.array([1, 1, 1])
             Smoother(smoother_name="window_average", window_length=5.5).smooth(signal)
-        
+
         # The raw and smoothed lengths should match
         signal = np.ones(30)
         smoother = Smoother(smoother_name="moving_average")
@@ -171,7 +171,7 @@ class TestSmoothers:
 
         # test the nan imputer
         signal = np.array([i if i % 3 else np.nan for i in range(1, 40)])
-        assert np.allclose(Smoother(impute_method=None).impute(signal), signal, equal_nan=True)
+        assert np.allclose(Smoother(impute_method="identity").impute(signal), signal, equal_nan=True)
 
         # test the zeros imputer
         signal = np.array([i if i % 3 else np.nan for i in range(1, 40)])

--- a/testing_utils/indicator_validation.py
+++ b/testing_utils/indicator_validation.py
@@ -1,24 +1,27 @@
-import os
-from os import listdir
+from os import listdir, getcwd
 from os.path import isfile, join, basename
-import glob
-from datetime import date
 from datetime import datetime
-import pandas as pd
-import matplotlib.pyplot as plt
+
 import covidcast
 from joblib import Memory
+import nest_asyncio
+from numpy.core.numeric import NaN
+from pandas import date_range, to_datetime, read_csv, concat
 
-ROOT_DIR = os.getcwd()
+nest_asyncio.apply()  # Jupyter Notebook async compatibility
+covidcast.covidcast._ASYNC_CALL = True  # Covidcast async mode
+
+ROOT_DIR = getcwd()
 CACHE_DIR = join(ROOT_DIR, "testing_utils", "cache")
 memory = Memory(CACHE_DIR, verbose=0)
 
 
-def read_relevant_date_filenames(
-    data_path, date_slist, geo_code="", signal_type="", return_path=False
-):
+def read_relevant_date_filenames(data_path, date_slist, geo_code="", signal_type="", return_path=False):
     """
     Return a list of tuples of every filename in the specified directory if the file is in the specified date range.
+
+    Files are assumed to have the naming format YYYYMMDD_signal_info.csv.
+
     Arguments:
         - data_path: path to the directory containing CSV data files.
         - date_slist: list of dates (formatted as strings) to check
@@ -29,17 +32,11 @@ def read_relevant_date_filenames(
         - list
     """
     all_files = [f for f in listdir(data_path) if isfile(join(data_path, f))]
-    filelist = list()
-
-    for fl in all_files:
-        for dt in date_slist:
-            if fl.find(dt) != -1 and geo_code in fl and signal_type in fl:
-                filelist.append(fl if not return_path else join(data_path, fl))
-
+    filelist = [fl if not return_path else join(data_path, fl) for fl in all_files if fl[:8] in date_slist and geo_code in fl and signal_type in fl]
     return filelist
 
 
-def generate_date_range(start, end):
+def get_date_range(start, end, format="list"):
     """
     Return a list of string-formatted dates in the format YYYYMMDD from start to end, both ends inclusive.
 
@@ -54,7 +51,16 @@ def generate_date_range(start, end):
     ---------
     List of dates.
     """
-    return [x.strftime("%Y%m%d") for x in pd.date_range(start, end)]
+    if format == "list":
+        return [x.strftime("%Y%m%d") for x in date_range(start, end)]
+    if format == "set":
+        return {x.strftime("%Y%m%d") for x in date_range(start, end)}
+    raise ValueError("format should be either 'set' or 'list'.")
+
+
+def _parse_date(d: str):
+    """Convert YYYYMMDD string to a datetime object."""
+    return datetime(int(d[:4]), int(d[4:6]), int(d[6:8]))
 
 
 def load_csvs(filename_list):
@@ -62,37 +68,28 @@ def load_csvs(filename_list):
     Returns a list of dataframes for each csv file in the list. Each dataframe is appended with a date column
     that contains the date in the first 8 characters of the filename with the format YYYYMMDD.
     """
-    all_frames = []
-    for filename in filename_list:
-        frame = pd.read_csv(
-            join("receiving", filename),
-            dtype={"geo_id": str, "val": float, "se": float, "sample_size": float},
-        )
-        frame["date"] = datetime(
-            int(basename(filename)[:4]),
-            int(basename(filename)[4:6]),
-            int(basename(filename)[6:8]),
-        )
-        all_frames.append(frame)
+    dtypes = {"geo_id": str, "val": float, "se": float, "sample_size": float}
+    all_frames = [read_csv(join("receiving", fl), dtype=dtypes).assign(time_value=_parse_date(basename(fl)[:8])) for fl in filename_list]
     return all_frames
 
+
 @memory.cache
-def load_local_signal_data(local_signal_dir, signal_type, start_day, end_day, geo_type):
+def load_local_signal_data(local_signal_dir, signal_type, start_day, end_day, geo_type, local_signal_subdir="receiving"):
     """
     This function loads a local directory's .csv files into a single timestamped dataframe for analysis.
 
     This function is cached to disk to speed up computation times. You can force clear the cache like so:
     >>> load_local_signal_data.clear()
     """
-    date_range = generate_date_range(
-        start_day.strftime("%Y%m%d"), end_day.strftime("%Y%m%d")
-    )
-    local_files = read_relevant_date_filenames(
-        join(ROOT_DIR, local_signal_dir, "receiving"), date_range, geo_type, signal_type, return_path=True
-    )
-    local_data = pd.concat(load_csvs(local_files)).set_index(["geo_id", "date"]).sort_index()
-    
+    dates = get_date_range(start_day.strftime("%Y%m%d"), end_day.strftime("%Y%m%d"), format="set")
+    _dir_path = join(ROOT_DIR, local_signal_dir, local_signal_subdir)
+    local_files = read_relevant_date_filenames(_dir_path, dates, geo_type, signal_type, return_path=True)
+    _col_names = {"geo_id": "geo_value", "val": "value", "se": "stderr"}
+    local_data = concat(load_csvs(local_files)).rename(columns=_col_names)
+    local_data["time_value"] = to_datetime(local_data["time_value"])
+    local_data = local_data.set_index(["geo_value", "time_value"]).sort_index()
     return local_data
+
 
 @memory.cache
 def load_remote_signal_data(remote_source_name, signal_type, start_day, end_day, geo_type):
@@ -100,19 +97,16 @@ def load_remote_signal_data(remote_source_name, signal_type, start_day, end_day,
     This function is a caching wrapper for the covidcast signal function. You can force clear the cache like so:
     >>> load_remote_signal_data.clear()
     """
-    remote_data = covidcast.signal(
-            remote_source_name, signal_type, start_day, end_day, geo_type
-        )
-    if not isinstance(remote_data, type(None)):
-        remote_data["time_value"] = pd.to_datetime(remote_data["time_value"])
+    remote_data = covidcast.signal(remote_source_name, signal_type, start_day, end_day, geo_type)
+    if remote_data is not None:
+        remote_data["time_value"] = to_datetime(remote_data["time_value"])
         remote_data["geo_value"] = remote_data["geo_value"].astype(str)
-        remote_data = remote_data.set_index(["geo_value", "time_value"]).sort_index()
+        remote_data = remote_data.set_index(["geo_value", "time_value"]).sort_index().replace(to_replace=[None], value=NaN)
 
     return remote_data
 
-def load_signal_data(
-    local_signal_dir, remote_source_name, signal_type, start_day, end_day, geo_type
-):
+
+def load_signal_data(local_signal_dir, remote_source_name, signal_type, start_day, end_day, geo_type):
     """
     This function loads two dataframes: local_data and remote_data. The local_data is stitched together from the .csv
     files contained in your local_signal_dir. The remote_data is pulled from covidcast remote_source_name.

--- a/usafacts/.gitignore
+++ b/usafacts/.gitignore
@@ -5,6 +5,7 @@ params.json
 
 # Do not commit output files
 receiving/*.csv
+receiving\ copy/*.csv
 
 # Do not commit test files
 tests/receiving/*.csv


### PR DESCRIPTION
### Description
Currently, the identity smoother imputes nan values using the "savgol" smoother. This was the intended behavior for other smoothers (since not imputing while smoothing would lead to nan propagation), but the intention for the identity smoother is to be a true no-op by default. This fixes that issue.

### Changelog
Change the default argument handling: the default for "identity" is no imputation, while the default for anything else is "savgol". User-supplied impute arguments are handled normally.

### Fixes 
- Probably helps #1077. 
- May change the JHU and USAFacts raw signals (difference plots incoming).
