### PR TITLE
Move 7dav to back of hhs signal name

### DIFF
--- a/hhs_hosp/delphi_hhs/constants.py
+++ b/hhs_hosp/delphi_hhs/constants.py
@@ -18,5 +18,5 @@ GEOS = [
 
 SMOOTHERS = [
     (Smoother("identity", impute_method=None), ""),
-    (Smoother("moving_average", window_length=7), "7dav_"),
+    (Smoother("moving_average", window_length=7), "_7dav"),
 ]

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -107,7 +107,7 @@ def run_module(params):
         df = smooth_values(df, smoother[0])
         if df.empty:
             continue
-        sensor_name = smoother[1] + sensor
+        sensor_name = sensor + smoother[1]
         # don't export first 6 days for smoothed signals since they'll be nan.
         start_date = min(df.timestamp) + timedelta(6) if smoother[1] else min(df.timestamp)
         create_export_csv(df,


### PR DESCRIPTION
### Description
Changes the 7dav from the start of the signal name to the back.

Example files
```
20210625_state_confirmed_admissions_covid_1d_7dav.csv
20210625_state_confirmed_admissions_covid_1d.csv
20210625_state_sum_confirmed_suspected_admissions_covid_1d_7dav.csv
20210625_state_sum_confirmed_suspected_admissions_covid_1d.csv
```
### Changelog
Itemize code/test/documentation changes and files added/removed.
- Flip 7dav order

### Fixes 
- Fixes #(issue)
