### PR TITLE
Pin pylint to 2.8.3

### DIFF
--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -14,7 +14,7 @@ required = [
     "numpy",
     "pandas>=1.1.0",
     "pydocstyle",
-    "pylint",
+    "pylint==2.8.3",
     "pytest",
     "pytest-cov",
     "slackclient",

--- a/_template_python/setup.py
+++ b/_template_python/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "covidcast"
 ]

--- a/cdc_covidnet/setup.py
+++ b/cdc_covidnet/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "requests",
     "covidcast"

--- a/changehc/setup.py
+++ b/changehc/setup.py
@@ -8,7 +8,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "covidcast",
     "boto3",

--- a/claims_hosp/setup.py
+++ b/claims_hosp/setup.py
@@ -8,7 +8,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "covidcast"
 ]

--- a/combo_cases_and_deaths/setup.py
+++ b/combo_cases_and_deaths/setup.py
@@ -6,7 +6,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "covidcast>=0.1.4"
 ]

--- a/covid_act_now/setup.py
+++ b/covid_act_now/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "covidcast",
     "pyarrow",

--- a/doctor_visits/setup.py
+++ b/doctor_visits/setup.py
@@ -8,7 +8,7 @@ required = [
     "cvxpy",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils"
 ]
 

--- a/facebook/delphiFacebook/python/setup.py
+++ b/facebook/delphiFacebook/python/setup.py
@@ -5,7 +5,7 @@ required = [
     "requests",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils"
 ]
 

--- a/google_symptoms/setup.py
+++ b/google_symptoms/setup.py
@@ -8,7 +8,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "freezegun",
     "pandas-gbq"

--- a/hhs_facilities/setup.py
+++ b/hhs_facilities/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "covidcast",
     "delphi-epidata"

--- a/hhs_hosp/setup.py
+++ b/hhs_hosp/setup.py
@@ -8,7 +8,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "covidcast",
     "delphi-epidata"

--- a/jhu/setup.py
+++ b/jhu/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils"
 ]
 

--- a/nchs_mortality/setup.py
+++ b/nchs_mortality/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "sodapy",
     "epiweeks",

--- a/nowcast/setup.py
+++ b/nowcast/setup.py
@@ -10,7 +10,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "scipy"
 ]
 

--- a/quidel/setup.py
+++ b/quidel/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "imap-tools",
     "xlrd==1.2.0",

--- a/quidel_covidtest/setup.py
+++ b/quidel_covidtest/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "imap-tools",
     "xlrd==1.2.0",

--- a/safegraph_patterns/setup.py
+++ b/safegraph_patterns/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils"
 ]
 

--- a/sir_complainsalot/setup.py
+++ b/sir_complainsalot/setup.py
@@ -5,7 +5,7 @@ required = [
     "pandas",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils",
     "slackclient",
     "covidcast"

--- a/usafacts/setup.py
+++ b/usafacts/setup.py
@@ -7,7 +7,7 @@ required = [
     "pydocstyle",
     "pytest",
     "pytest-cov",
-    "pylint",
+    "pylint==2.8.3",
     "delphi-utils"
 ]
 


### PR DESCRIPTION
### Description
Latest pylint releases (2.9.0 and 2.9.1)  throw a few false positives across our repo, so pinning everything to the previous version.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Pin all pylints to 2.8.3

### Fixes 
- Fixes #(issue)
