### PR TITLE
Standardization of Completed logging

### DIFF
--- a/changehc/delphi_changehc/run.py
+++ b/changehc/delphi_changehc/run.py
@@ -190,7 +190,7 @@ def run_module(params: Dict[str, Dict[str, Any]]):
             logger.info("finished processing", geo = geo)
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
-    min_max_date = stats and max(s[0] for s in stats)
+    min_max_date = stats and min(s[0] for s in stats)
     csv_export_count = sum(s[-1] for s in stats)
     max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
     formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")

--- a/changehc/delphi_changehc/update_sensor.py
+++ b/changehc/delphi_changehc/update_sensor.py
@@ -59,7 +59,7 @@ def write_to_csv(df, geo_level, write_se, day_shift, out_name, output_path=".", 
                 geo, out_name
             ))
 
-    create_export_csv(
+    dates = create_export_csv(
         df,
         export_dir=output_path,
         geo_res=geo_level,
@@ -72,6 +72,7 @@ def write_to_csv(df, geo_level, write_se, day_shift, out_name, output_path=".", 
         df.size, df["geo_id"].unique().size, geo_level
     ))
     logging.debug("wrote files to {0}".format(output_path))
+    return dates
 
 
 class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
@@ -233,8 +234,9 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
         df = df[df['incl']]
 
         # write out results
+        all_dates = []
         for signal in self.updated_signal_names:
-            write_to_csv(
+            dates = write_to_csv(
                 df,
                 geo_level=self.geo,
                 start_date=min(self.sensor_dates),
@@ -244,3 +246,5 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
                 out_name=signal,
                 output_path=output_path
             )
+            all_dates.append(dates)
+        return all_dates

--- a/changehc/delphi_changehc/update_sensor.py
+++ b/changehc/delphi_changehc/update_sensor.py
@@ -234,7 +234,7 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
         df = df[df['incl']]
 
         # write out results
-        all_dates = []
+        stats = []
         for signal in self.updated_signal_names:
             dates = write_to_csv(
                 df,
@@ -246,5 +246,6 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
                 out_name=signal,
                 output_path=output_path
             )
-            all_dates.append(dates)
-        return all_dates
+            if len(dates) > 0:
+                stats.append((max(dates), len(dates)))
+        return stats

--- a/covid_act_now/delphi_covid_act_now/run.py
+++ b/covid_act_now/delphi_covid_act_now/run.py
@@ -4,6 +4,7 @@
 This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m delphi_covid_act_now`.
 """
+from datetime import datetime
 import time
 
 import numpy as np
@@ -113,8 +114,10 @@ def run_module(params):
             print(f"Failed to archive '{exported_file}'")
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
+    max_lag_in_days = (datetime.now() - min(max_dates_exported)).days
     logger.info("Completed indicator run",
                 elapsed_time_in_seconds=elapsed_time_in_seconds,
                 csv_export_count=num_exported_files,
+                max_lag_in_days=max_lag_in_days,
                 earliest_export_date=min(min_dates_exported).strftime("%Y-%m-%d"),
                 latest_export_date=max(max_dates_exported).strftime("%Y-%m-%d"))

--- a/hhs_facilities/delphi_hhs_facilities/run.py
+++ b/hhs_facilities/delphi_hhs_facilities/run.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Main function to run the HHS facilities module. Run with `python -m delphi_hhs_facilities`."""
-
+from datetime import datetime
 import time
 
 from itertools import product
@@ -34,11 +34,21 @@ def run_module(params) -> None:
     raw_df = pull_data()
     gmpr = GeoMapper()
     filled_fips_df = fill_missing_fips(raw_df, gmpr)
+    stats = []
     for geo, (sig_name, sig_cols, sig_func, sig_offset) in product(GEO_RESOLUTIONS, SIGNALS):
         mapped_df = convert_geo(filled_fips_df, geo, gmpr)
         output_df = generate_signal(mapped_df, sig_cols, sig_func, sig_offset)
-        create_export_csv(output_df, params["common"]["export_dir"], geo, sig_name)
+        dates = create_export_csv(output_df, params["common"]["export_dir"], geo, sig_name)
+        if len(dates) > 0:
+            stats.append((max(dates), len(dates)))
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
+    min_max_date = stats and max(s[0] for s in stats)
+    csv_export_count = sum(s[-1] for s in stats)
+    max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
+    formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")
     logger.info("Completed indicator run",
-                elapsed_time_in_seconds=elapsed_time_in_seconds)
+                elapsed_time_in_seconds = elapsed_time_in_seconds,
+                csv_export_count = csv_export_count,
+                max_lag_in_days = max_lag_in_days,
+                oldest_final_export_date = formatted_min_max_date)

--- a/hhs_facilities/delphi_hhs_facilities/run.py
+++ b/hhs_facilities/delphi_hhs_facilities/run.py
@@ -43,7 +43,7 @@ def run_module(params) -> None:
             stats.append((max(dates), len(dates)))
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
-    min_max_date = stats and max(s[0] for s in stats)
+    min_max_date = stats and min(s[0] for s in stats)
     csv_export_count = sum(s[-1] for s in stats)
     max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
     formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -120,7 +120,7 @@ def run_module(params):
             stats.append((max(dates), len(dates)))
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
-    min_max_date = stats and max(s[0] for s in stats)
+    min_max_date = stats and min(s[0] for s in stats)
     csv_export_count = sum(s[-1] for s in stats)
     max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
     formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -97,7 +97,8 @@ def run_module(params):
         dfs.append(pd.DataFrame(response['epidata']))
     all_columns = pd.concat(dfs)
     geo_mapper = GeoMapper()
-
+    stats = []
+    
     for sensor, smoother, geo in product(SIGNALS, SMOOTHERS, GEOS):
         df = geo_mapper.add_geocode(make_signal(all_columns, sensor),
                                     "state_id",
@@ -110,15 +111,23 @@ def run_module(params):
         sensor_name = sensor + smoother[1]
         # don't export first 6 days for smoothed signals since they'll be nan.
         start_date = min(df.timestamp) + timedelta(6) if smoother[1] else min(df.timestamp)
-        create_export_csv(df,
+        dates = create_export_csv(df,
                           params["common"]["export_dir"],
                           geo,
                           sensor_name,
                           start_date=start_date)
+        stats.append((max(dates), len(dates)))
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
+    min_max_date = stats and max(s[0] for s in stats)
+    csv_export_count = sum(s[-1] for s in stats)
+    max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
+    formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")
     logger.info("Completed indicator run",
-        elapsed_time_in_seconds = elapsed_time_in_seconds)
+                elapsed_time_in_seconds = elapsed_time_in_seconds,
+                csv_export_count = csv_export_count,
+                max_lag_in_days = max_lag_in_days,
+                oldest_final_export_date = formatted_min_max_date)
 
 
 def smooth_values(df, smoother):

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -98,7 +98,7 @@ def run_module(params):
     all_columns = pd.concat(dfs)
     geo_mapper = GeoMapper()
     stats = []
-    
+
     for sensor, smoother, geo in product(SIGNALS, SMOOTHERS, GEOS):
         df = geo_mapper.add_geocode(make_signal(all_columns, sensor),
                                     "state_id",
@@ -116,7 +116,8 @@ def run_module(params):
                           geo,
                           sensor_name,
                           start_date=start_date)
-        stats.append((max(dates), len(dates)))
+        if len(dates) > 0:
+            stats.append((max(dates), len(dates)))
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
     min_max_date = stats and max(s[0] for s in stats)

--- a/nchs_mortality/delphi_nchs_mortality/export.py
+++ b/nchs_mortality/delphi_nchs_mortality/export.py
@@ -4,7 +4,7 @@ import pandas as pd
 from epiweeks import Week
 
 def export_csv(df, geo_name, sensor, export_dir, start_date):
-    """Export data set in format expected for injestion by the API.
+    """Export data set in format expected for ingestion by the API.
 
     Parameters
     ----------
@@ -24,7 +24,8 @@ def export_csv(df, geo_name, sensor, export_dir, start_date):
     df = df.copy()
     df = df[df["timestamp"] >= start_date]
 
-    for date in df["timestamp"].unique():
+    dates = df["timestamp"].unique()
+    for date in dates:
         t = Week.fromdate(pd.to_datetime(str(date)))
         date_short = "weekly_" + str(t.year) + str(t.week).zfill(2)
         export_fn = f"{date_short}_{geo_name}_{sensor}.csv"
@@ -32,3 +33,5 @@ def export_csv(df, geo_name, sensor, export_dir, start_date):
         result_df.to_csv(f"{export_dir}/{export_fn}",
                          index=False,
                          float_format="%.8f")
+    print(dates)
+    return pd.to_datetime(dates)

--- a/nchs_mortality/delphi_nchs_mortality/run.py
+++ b/nchs_mortality/delphi_nchs_mortality/run.py
@@ -110,7 +110,7 @@ def run_module(params: Dict[str, Any]):
         arch_diffs(params, daily_arch_diff)
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
-    min_max_date = stats and max(s[0] for s in stats)
+    min_max_date = stats and min(s[0] for s in stats)
     csv_export_count = sum(s[-1] for s in stats)
     max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
     formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")

--- a/nchs_mortality/delphi_nchs_mortality/run.py
+++ b/nchs_mortality/delphi_nchs_mortality/run.py
@@ -58,7 +58,7 @@ def run_module(params: Dict[str, Any]):
             params["archive"]["aws_credentials"])
         daily_arch_diff.update_cache()
 
-
+    stats = []
     df_pull = pull_nchs_mortality_data(token, test_file)
     for metric in METRICS:
         if metric == 'percent_of_expected_deaths':
@@ -69,13 +69,15 @@ def run_module(params: Dict[str, Any]):
             df["sample_size"] = np.nan
             df = df[~df["val"].isnull()]
             sensor_name = "_".join([SENSOR_NAME_MAP[metric]])
-            export_csv(
+            dates = export_csv(
                 df,
                 geo_name=GEO_RES,
                 export_dir=daily_export_dir,
                 start_date=datetime.strptime(export_start_date, "%Y-%m-%d"),
                 sensor=sensor_name,
             )
+            if len(dates) > 0:
+                stats.append((max(dates), len(dates)))
         else:
             for sensor in SENSORS:
                 print(metric, sensor)
@@ -88,13 +90,15 @@ def run_module(params: Dict[str, Any]):
                 df["sample_size"] = np.nan
                 df = df[~df["val"].isnull()]
                 sensor_name = "_".join([SENSOR_NAME_MAP[metric], sensor])
-                export_csv(
+                dates = export_csv(
                     df,
                     geo_name=GEO_RES,
                     export_dir=daily_export_dir,
                     start_date=datetime.strptime(export_start_date, "%Y-%m-%d"),
                     sensor=sensor_name,
                 )
+                if len(dates) > 0:
+                    stats.append((max(dates), len(dates)))
 
 #     Weekly run of archive utility on Monday
 #     - Does not upload to S3, that is handled by daily run of archive utility
@@ -106,5 +110,12 @@ def run_module(params: Dict[str, Any]):
         arch_diffs(params, daily_arch_diff)
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
+    min_max_date = stats and max(s[0] for s in stats)
+    csv_export_count = sum(s[-1] for s in stats)
+    max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
+    formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")
     logger.info("Completed indicator run",
-        elapsed_time_in_seconds = elapsed_time_in_seconds)
+                elapsed_time_in_seconds = elapsed_time_in_seconds,
+                csv_export_count = csv_export_count,
+                max_lag_in_days = max_lag_in_days,
+                oldest_final_export_date = formatted_min_max_date)

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -30,7 +30,7 @@ from .pull import (pull_quidel_covidtest,
 def log_exit(start_time, stats, logger):
     """Log at program exit."""
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
-    min_max_date = stats and max(s[0] for s in stats)
+    min_max_date = stats and min(s[0] for s in stats)
     csv_export_count = sum(s[-1] for s in stats)
     max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
     formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -5,6 +5,7 @@ This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m MODULE_NAME`.
 """
 import atexit
+from datetime import datetime
 import time
 from typing import Dict, Any
 
@@ -26,11 +27,18 @@ from .pull import (pull_quidel_covidtest,
                    update_cache_file)
 
 
-def log_exit(start_time, logger):
+def log_exit(start_time, stats, logger):
     """Log at program exit."""
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
+    min_max_date = stats and max(s[0] for s in stats)
+    csv_export_count = sum(s[-1] for s in stats)
+    max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
+    formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")
     logger.info("Completed indicator run",
-                elapsed_time_in_seconds=elapsed_time_in_seconds)
+                elapsed_time_in_seconds = elapsed_time_in_seconds,
+                csv_export_count = csv_export_count,
+                max_lag_in_days = max_lag_in_days,
+                oldest_final_export_date = formatted_min_max_date)
 
 def run_module(params: Dict[str, Any]):
     """Run the quidel_covidtest indicator.
@@ -59,7 +67,8 @@ def run_module(params: Dict[str, Any]):
     logger = get_structured_logger(
         __name__, filename=params["common"].get("log_filename"),
         log_exceptions=params["common"].get("log_exceptions", True))
-    atexit.register(log_exit, start_time, logger)
+    stats = []
+    atexit.register(log_exit, start_time, stats, logger)
     cache_dir = params["indicator"]["input_cache_dir"]
     export_dir = params["common"]["export_dir"]
     export_start_date = params["indicator"]["export_start_date"]
@@ -102,8 +111,15 @@ def run_module(params: Dict[str, Any]):
                 geo_groups, res_key, smooth=smoothers[sensor][1],
                 device=smoothers[sensor][0], first_date=first_date,
                 last_date=last_date)
-            create_export_csv(state_df, geo_res=geo_res, sensor=sensor, export_dir=export_dir,
-                              start_date=export_start_date, end_date=export_end_date)
+            dates = create_export_csv(
+                state_df,
+                geo_res=geo_res,
+                sensor=sensor,
+                export_dir=export_dir,
+                start_date=export_start_date,
+                end_date=export_end_date)
+            if len(dates) > 0:
+                stats.append((max(dates), len(dates)))
 
     # County/HRR/MSA level
     for geo_res in PARENT_GEO_RESOLUTIONS:
@@ -114,10 +130,11 @@ def run_module(params: Dict[str, Any]):
                 geo_groups, geo_data, res_key, smooth=smoothers[sensor][1],
                 device=smoothers[sensor][0], first_date=first_date,
                 last_date=last_date)
-            create_export_csv(res_df, geo_res=geo_res, sensor=sensor, export_dir=export_dir,
+            dates = create_export_csv(res_df, geo_res=geo_res, sensor=sensor, export_dir=export_dir,
                               start_date=export_start_date, end_date=export_end_date,
                               remove_null_samples=True)
-
+            if len(dates) > 0:
+                stats.append((max(dates), len(dates)))
 
     # Export the cache file if the pipeline runs successfully.
     # Otherwise, don't update the cache file

--- a/safegraph_patterns/delphi_safegraph_patterns/process.py
+++ b/safegraph_patterns/delphi_safegraph_patterns/process.py
@@ -125,7 +125,7 @@ def aggregate(df, metric, geo_res):
     return df.rename({geo_key: "geo_id"}, axis=1)
 
 def process(fname, sensors, metrics, geo_resolutions,
-            export_dir, brand_df):
+            export_dir, brand_df, stats):
     """
     Process an input census block group-level CSV and export it.
 
@@ -143,6 +143,8 @@ def process(fname, sensors, metrics, geo_resolutions,
         List of geo resolutions to export the data.
     brand_df: pd.DataFrame
         mapping info from naics_code to safegraph_brand_id
+    stats: List[Tuple[datetime, int]]
+        List to which we will add (max export date, number of export dates)
 
     Returns
     -------
@@ -188,7 +190,7 @@ def process(fname, sensors, metrics, geo_resolutions,
 
             if wip:
                 metric = "wip_" + metric
-            create_export_csv(
+            dates = create_export_csv(
                 df_export,
                 export_dir=export_dir,
                 start_date=df_export["timestamp"].min(),
@@ -196,3 +198,5 @@ def process(fname, sensors, metrics, geo_resolutions,
                 geo_res=geo_res,
                 sensor=sensor,
             )
+            if len(dates) > 0:
+                stats.append((max(dates), len(dates)))

--- a/safegraph_patterns/delphi_safegraph_patterns/run.py
+++ b/safegraph_patterns/delphi_safegraph_patterns/run.py
@@ -110,7 +110,7 @@ def run_module(params):
             pool.map(process_file, files)
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
-    min_max_date = stats and max(s[0] for s in stats)
+    min_max_date = stats and min(s[0] for s in stats)
     csv_export_count = sum(s[-1] for s in stats)
     max_lag_in_days = min_max_date and (datetime.now() - min_max_date).days
     formatted_min_max_date = min_max_date and min_max_date.strftime("%Y-%m-%d")

--- a/safegraph_patterns/delphi_safegraph_patterns/run.py
+++ b/safegraph_patterns/delphi_safegraph_patterns/run.py
@@ -4,6 +4,7 @@
 This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m MODULE_NAME`.
 """
+from datetime import datetime
 import glob
 import multiprocessing as mp
 import subprocess


### PR DESCRIPTION
### Description
Submit max min lag, min max date, and csv export count for all indicators.

I tried to do this largely the same way for all indicators wherever possible. The general strategy is:
1. for each signal configuration saved, grab the max date and the number of files exported
2. store as a list of tuples called `stats`
3. right before the Completed log, grab the min (earliest) max date and compute max lag
4. sum the number of files exported
5. log these in Completed

This was impossible for:
* doctor-visits
* hospital-admissions
* fb-survey
& we'll have to pick those up when we productionize them.

Variations noted in changelog below.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- changehc - had to nest `stats` in groups used within `update_sensor.py`
- covid_act_now - was already computing stats using another method, just added lag
- hhs_facilities - above method
- hhs_hosp - above method
- nchs_mortality - doesn't use create_export_csvs because epiweeks, so I added a `return` to its custom `export.py` to simulate it
- quidel_covidtest - extended `log_exit` to do final stats computation, since it uses atexit registration to perform Completed logging
- safegraph_patterns - added `stats` list to the function signature used as partials for workers in `process.py` (nb Python lists are thread-safe so this should be fine)

Remaining indicators (jhu, usa-facts, google-symptoms) already log these items using various other methods; I opted not to normalize the code.

### Fixes 
- Fixes #1087 
