### PR TITLE
Survey codebook generator tuning on all QSFs

### DIFF
--- a/facebook/qsf-tools/generate-codebook.R
+++ b/facebook/qsf-tools/generate-codebook.R
@@ -198,7 +198,7 @@ process_qsf <- function(path_to_qsf,
     }
   })) %>%
     map(unique) %>%
-    map(~ if (length(.x) > 1) { .x[!is.na(.x)] } else {.x}) %>% 
+    map(~ if (length(.x) > 1) { .x[!is.na(.x)] } else {NA}) %>% 
     unlist()
   qdf <- qdf %>% mutate(group_of_respondents_item_was_shown_to=coalesce(group_of_respondents_item_was_shown_to, module_assignment_from_display_logic)) %>%
     replace_na(list(group_of_respondents_item_was_shown_to = "all"))  

--- a/facebook/qsf-tools/generate-codebook.R
+++ b/facebook/qsf-tools/generate-codebook.R
@@ -330,7 +330,7 @@ add_qdf_to_codebook <- function(qdf,
     add_static_fields(qdf_wave, path_to_static_fields) %>% 
     arrange(!is.na(.data$type), variable, wave)
   
-  ii_replacing_DNE <- which( !(codebook$replaces %in% codebook$variable) )
+  ii_replacing_DNE <- which( !(codebook$replaces %in% codebook$variable) & !is.na(codebook$replaces) )
   if ( length(ii_replacing_DNE) > 0 ) {
     replacing_variables <- unique( codebook$variable[ii_replacing_DNE] )
     warning(sprintf("the items that %s report replacing do not exist in the codebook",

--- a/facebook/qsf-tools/static_microdata_fields.csv
+++ b/facebook/qsf-tools/static_microdata_fields.csv
@@ -1,7 +1,0 @@
-item,replaces,description,question,matrix_subquestion,type,response_option_randomization
-StartDatetime,NA,"survey start timestamp",NA,NA,NA,NA
-EndDatetime,NA,"survey end timestamp",NA,NA,NA,NA
-wave,NA,"survey version",NA,NA,NA,NA
-UserLanguage,NA,"survey language",NA,NA,NA,NA
-fips,NA,"county FIPS code",NA,NA,NA,NA
-weight,NA,"Facebook respondent weight",NA,NA,NA,NA


### PR DESCRIPTION
### Description
Cleanup and tuning of codebook generator.

### Changelog
- Remove straggling `static_microdata_fields.csv`. New version already exists in the `static` dir.
- Explicitly set non-randomized questions to `NA` in one substep of the module assignment parsing. Prevents `NULL`s from causing problems in the `unlist()` step.
- Remove questions that aren't replacing any old items (replacement is set to `NA`) to simplify warning output.

### Fixes
Gets codebook generator to correctly ingest QSFs from all survey waves.