### PR TITLE
fix: sync version for bumpversion

### DIFF
--- a/_delphi_utils_python/.bumpversion.cfg
+++ b/_delphi_utils_python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 commit = False
 tag = False
 tag_name = delphi-utils/v{new_version}


### PR DESCRIPTION
### Description
sync the bumpversion with current version

### Changelog

fixes the underlying error:

![image](https://user-images.githubusercontent.com/4129778/124624226-ff91fa80-de7c-11eb-8a4c-c04e68ac09a2.png)

of a not in-sync bumpversion with code version

### Fixes 
- Fixes #1095 
