### PR TITLE
Add openpyxl to quidel dependencies

### DIFF
--- a/quidel/setup.py
+++ b/quidel/setup.py
@@ -11,7 +11,8 @@ required = [
     "delphi-utils",
     "imap-tools",
     "xlrd==1.2.0",
-    "covidcast"
+    "covidcast",
+    "openpyxl"
 ]
 
 setup(

--- a/quidel_covidtest/setup.py
+++ b/quidel_covidtest/setup.py
@@ -11,7 +11,8 @@ required = [
     "delphi-utils",
     "imap-tools",
     "xlrd==1.2.0",
-    "covidcast"
+    "covidcast",
+    "openpyxl"
 ]
 
 setup(


### PR DESCRIPTION
### Description
Quidel tests are failing on main due to these optional dependencies missing. Uncertain why this started happening, but adding them to fix the problem for now.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add openpyxl to setup.py for both quidel indicators.

### Fixes 
- Fixes #(issue)
