### PR TITLE
Add a GitHub Actions workflow to build individual indicators as container images

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -42,9 +42,3 @@ jobs:
           echo "using tag: --${imageTag}--"
           docker build -t ghcr.io/${{ github.repository }}-${{ matrix.packages }}:$imageTag --file ${INDICATOR_DOCKER_FILE} .
           docker push ghcr.io/${{ github.repository }}-${{ matrix.packages }}:$imageTag
-
-         # ## trigger a webhook update
-         # #curl -H "Authorization: Bearer ${{ secrets.DELPHI_DEPLOY_WEBHOOK_TOKEN }}" \
-         # #     -X POST ${{ secrets.DELPHI_DEPLOY_WEBHOOK_URL }} \
-         # #     -H "Content-Type: application/x-www-form-urlencoded" \
-         # #     -d "repository=ghcr.io/${{ github.repository }}&tag=$imageTag"

--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -1,0 +1,50 @@
+name: Build indicator container images and upload to registry
+
+on:
+  push:
+    branches: [ main, prod ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        packages: [""]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: cmu-delphi-deploy-machine
+          password: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_PAT }}
+
+      - name: Build, tag, and push image to Github
+        env:
+          INDICATOR_DOCKER_FILE: ${{ github.workspace }}/${{ matrix.packages }}/Dockerfile
+        run: |
+          baseRef="${GITHUB_REF#*/}"
+          baseRef="${baseRef#*/}"
+          case "${baseRef}" in
+          main)
+            imageTag="dev"
+            ;;
+          prod)
+            imageTag="latest"
+            ;;
+          *)
+            imageTag="${baseRef//\//_}" # replace `/` with `_` in branch name
+            ;;
+          esac
+          cd ${{ matrix.packages }}
+          echo "using tag: --${imageTag}--"
+          docker build -t ghcr.io/${{ github.repository }}-${{ matrix.packages }}:$imageTag --file ${INDICATOR_DOCKER_FILE} .
+          docker push ghcr.io/${{ github.repository }}-${{ matrix.packages }}:$imageTag
+
+         # ## trigger a webhook update
+         # #curl -H "Authorization: Bearer ${{ secrets.DELPHI_DEPLOY_WEBHOOK_TOKEN }}" \
+         # #     -X POST ${{ secrets.DELPHI_DEPLOY_WEBHOOK_URL }} \
+         # #     -H "Content-Type: application/x-www-form-urlencoded" \
+         # #     -d "repository=ghcr.io/${{ github.repository }}&tag=$imageTag"


### PR DESCRIPTION
### Description

This adds a GitHub Actions workflow to build container images from individual
indicators.

There will be two necesities to invoke the action:

- Create a Dockerfile in the root of the indicator's directory.
- Add the indicator directory name to the `matrix.packages` section of the
  `.github/workflows/build-container-images.yml` like:

  ```
  ...
  jobs:
    build:
      runs-on: ubuntu-latest
      strategy:
        matrix:
          packages: [new_indicator1, new_indicator2] # indicator directory name
  ...
  ```

If the Action succeeds it will build and register a container image in our private
registry. Currently, we will build off of `main` and `prod` branches.

* `main` builds create a registered image of:

  ```text
  ghcr.io/cmu-delphi/covidcast-indicators-${indicator_name}:dev
  ```

* `prod` builds create a registered image of:

  ```text
  ghcr.io/cmu-delphi/covidcast-indicators-${indicator_name}:latest
  ```

### Changelog

Itemize code/test/documentation changes and files added/removed.
- Add a new workflow of `.github/workflows/build-container-images.yml`.
- Update `.github/CONTRIBUTING.md` with basic container image building necessities.
- BONUS! Snuck in some markdown linting changes to `.github/CONTRIBUTING.md`.