### PR TITLE
Cast value column to float in HHS before downstream operations

### DIFF
--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -159,7 +159,7 @@ def make_signal(all_columns, sig):
     assert sig in SIGNALS, f"Unexpected signal name '{sig}';" + \
         " familiar names are '{', '.join(SIGNALS)}'"
     if sig == CONFIRMED:
-        return pd.DataFrame({
+        df = pd.DataFrame({
             "state": all_columns.state.apply(str.lower),
             "timestamp":int_date_to_previous_day_datetime(all_columns.date),
             "val": \
@@ -167,7 +167,7 @@ def make_signal(all_columns, sig):
             all_columns.previous_day_admission_pediatric_covid_confirmed
         })
     if sig == SUM_CONF_SUSP:
-        return pd.DataFrame({
+        df = pd.DataFrame({
             "state": all_columns.state.apply(str.lower),
             "timestamp":int_date_to_previous_day_datetime(all_columns.date),
             "val": \
@@ -176,6 +176,8 @@ def make_signal(all_columns, sig):
             all_columns.previous_day_admission_pediatric_covid_confirmed + \
             all_columns.previous_day_admission_pediatric_covid_suspected,
         })
+    df["val"] = df.val.astype(float)
+    return df
     raise Exception(
         "Bad programmer: signal '{sig}' in SIGNALS but not handled in make_signal"
     )

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -166,7 +166,7 @@ def make_signal(all_columns, sig):
             all_columns.previous_day_admission_adult_covid_confirmed + \
             all_columns.previous_day_admission_pediatric_covid_confirmed
         })
-    if sig == SUM_CONF_SUSP:
+    elif sig == SUM_CONF_SUSP:
         df = pd.DataFrame({
             "state": all_columns.state.apply(str.lower),
             "timestamp":int_date_to_previous_day_datetime(all_columns.date),
@@ -176,8 +176,9 @@ def make_signal(all_columns, sig):
             all_columns.previous_day_admission_pediatric_covid_confirmed + \
             all_columns.previous_day_admission_pediatric_covid_suspected,
         })
+    else:
+        raise Exception(
+            "Bad programmer: signal '{sig}' in SIGNALS but not handled in make_signal"
+        )
     df["val"] = df.val.astype(float)
     return df
-    raise Exception(
-        "Bad programmer: signal '{sig}' in SIGNALS but not handled in make_signal"
-    )

--- a/hhs_hosp/tests/test_run.py
+++ b/hhs_hosp/tests/test_run.py
@@ -63,14 +63,14 @@ def test_make_signal():
     expected_confirmed = pd.DataFrame({
         'state': ['na'],
         'timestamp': [datetime(year=2020, month=1, day=1)],
-        'val': [5],
+        'val': [5.],
     })
     pd.testing.assert_frame_equal(expected_confirmed, make_signal(data, CONFIRMED))
 
     expected_sum = pd.DataFrame({
         'state': ['na'],
         'timestamp': [datetime(year=2020, month=1, day=1)],
-        'val': [15],
+        'val': [15.],
     })
     pd.testing.assert_frame_equal(expected_sum, make_signal(data, SUM_CONF_SUSP))
 
@@ -87,7 +87,7 @@ def test_make_geo():
         'state': ['PA', 'WV', 'OH'],
         'state_code': [42, 54, 39],
         'timestamp': [test_timestamp] * 3,
-        'val': [1, 2, 4],
+        'val': [1., 2., 4.],
     })
 
     template = {
@@ -104,12 +104,12 @@ def test_make_geo():
             dict(template,
                  geo_id=['3', '5'],
                  timestamp=[test_timestamp] * 2,
-                 val=[3, 4])),
+                 val=[3., 4.])),
         "nation": pd.DataFrame(
             dict(template,
                  geo_id=['us'],
                  timestamp=[test_timestamp],
-                 val=[7]))
+                 val=[7.]))
     }
     for geo, expected in expecteds.items():
         result = make_geo(data, geo, geo_mapper)


### PR DESCRIPTION
### Description
The value column was getting dropped by the geomapper during a groupby, which seems to be due to a new pandas release (downgrading fixes the issue). Casting to a float prevents this from happening.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Cast value column in dataframe to a float right after it's generated

### Fixes 
- Fixes #(issue)
