### PR TITLE
[fb-package] Modify output when debug flag is on

### DIFF
--- a/facebook/delphiFacebook/R/contingency_run.R
+++ b/facebook/delphiFacebook/R/contingency_run.R
@@ -8,6 +8,12 @@
 #'
 #' @export
 run_contingency_tables <- function(params) {
+  if (!is.null(params$debug) && params$debug) {
+    debug_msg <- "!!!debug is on and the standard privacy threshold for sample size is disabled!!!"
+    msg_plain(debug_msg)
+    warning(debug_msg)
+  }
+  
   if ( !is.null(params$aggs_in) ) {
     if ( !file.exists(params$aggs_in) ) {
       stop("requested aggregate-setting file does not exist")

--- a/facebook/delphiFacebook/R/contingency_write.R
+++ b/facebook/delphiFacebook/R/contingency_write.R
@@ -159,6 +159,9 @@ get_file_name <- function(params, geo_type, groupby_vars) {
     paste(aggregation_type, collapse = "_"),
     sep = "_"
   )
+  if (!is.null(params$debug) && params$debug) {
+    file_name <- paste0("DebugOn-DoNotShare_", file_name)
+  }
   file_name <- paste0(file_name, ".csv")
   return(file_name)
 }

--- a/facebook/delphiFacebook/unit-tests/testthat/test-contingency-write.R
+++ b/facebook/delphiFacebook/unit-tests/testthat/test-contingency-write.R
@@ -50,3 +50,18 @@ test_that("testing write_contingency_tables command", {
   df <- read_csv(file.path(tdir, "20200510_20200516_weekly_state_tested.csv"))
   expect_equivalent(df, test_data)
 })
+
+test_that("testing command to create output filenames", {
+  params <- list(
+    debug=TRUE,
+    aggregate_range="month",
+    start_date=as.Date("2021-01-01"),
+    end_date=as.Date("2021-01-02")
+  )
+  out <- get_file_name(params, "nation", c("gender"))
+  expected <- "DebugOn-DoNotShare_20210101_20210102_monthly_nation_gender.csv"
+  
+  params$debug <- FALSE
+  out <- get_file_name(params, "nation", c("gender", "race", "ethnicity"))
+  expected <- "20210101_20210102_monthly_nation_ethnicity_gender_race.csv"
+})


### PR DESCRIPTION
### Description
When `debug=true` in params, print message and raise warning, and add message to beginning of contingency table names. Add supporting tests.