### PR TITLE
Reduce fb package testing setup time

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,7 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ main, prod, 'release/*' ]
+    branches: [ main, prod ]
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
     branches: [ main, prod ]

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -49,9 +49,9 @@ jobs:
       - name: Install R dependencies
         run: |
           install.packages("remotes")
-          remotes::update_packages(c("rcmdcheck", "mockr"), dependencies=TRUE, upgrade="always")
+          remotes::update_packages(c("rcmdcheck", "mockr"), upgrade="always")
           dependency_list <- remotes::dev_package_deps(dependencies=TRUE)
-          remotes::update_packages(dependency_list$package, dependencies=TRUE, upgrade="always")
+          remotes::update_packages(dependency_list$package, upgrade="always")
         shell: Rscript {0}
       - name: Check
         run: |

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -1,0 +1,59 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+#
+# See https://github.com/r-lib/actions/tree/master/examples#readme for
+# additional example workflows available for the R community.
+
+name: R facebook survey
+
+on:
+  push:
+    branches: [ main, prod ]
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+    branches: [ main, prod ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    if: github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        r-version: [4.0]
+    defaults:
+      run:
+        working-directory: facebook/delphiFacebook
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: ${{ matrix.r-version }}
+      - name: Install linux dependencies
+        run: |
+            sudo apt-get install libcurl4-openssl-dev
+      - name: Get month
+        id: get-month
+        run: |
+          echo "::set-output name=month::$(/bin/date -u "+%Y%m")"
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-facebook-survey-${{ steps.get-month.outputs.month }}
+          restore-keys: |
+            ${{ runner.os }}-r-facebook-survey-
+      - name: Install R dependencies
+        run: |
+          install.packages("remotes")
+          remotes::update_packages(c("rcmdcheck", "mockr"), dependencies=TRUE, upgrade="always")
+          dependency_list <- remotes::dev_package_deps(dependencies=TRUE)
+          remotes::update_packages(dependency_list$package, dependencies=TRUE, upgrade="always")
+        shell: Rscript {0}
+      - name: Check
+        run: |
+          rcmdcheck::rcmdcheck(args = c("--no-manual", "--test-dir=unit-tests"), error_on = "error")
+        shell: Rscript {0}

--- a/facebook/delphiFacebook/unit-tests/testthat/test-variables.R
+++ b/facebook/delphiFacebook/unit-tests/testthat/test-variables.R
@@ -86,6 +86,7 @@ test_that("mask items correctly coded", {
   input_data$c_mask_often_7d <- NA
   input_data$c_others_masked <- c(TRUE, NA, NA, FALSE, TRUE, FALSE)
   input_data$c_others_masked_public <- NA
+  input_data$c_others_distanced_public <- NA
   input_data$c_work_outside_5d <- NA
 
   expect_equal(out, input_data)
@@ -105,6 +106,7 @@ test_that("mask items correctly coded", {
   input_data$c_mask_often_7d <- c(NA, TRUE, FALSE, NA, TRUE, FALSE)
   input_data$c_others_masked <- c(TRUE, NA, NA, FALSE, TRUE, FALSE)
   input_data$c_others_masked_public <- NA
+  input_data$c_others_distanced_public <- NA
   input_data$c_work_outside_5d <- NA
 
   expect_equal(out, input_data)
@@ -125,6 +127,7 @@ test_that("mask items correctly coded", {
   input_data$c_mask_often_7d <- NA
   input_data$c_others_masked <- c(TRUE, NA, NA, FALSE, TRUE, FALSE)
   input_data$c_others_masked_public <- NA
+  input_data$c_others_distanced_public <- NA
   input_data$c_work_outside_5d <- NA
 
   expect_equal(out, input_data)
@@ -133,6 +136,7 @@ test_that("mask items correctly coded", {
   input_data <- data.frame(
     C14 = c(NA, 1, 3, 6, 2, 4),
     H2 = c(1, NA, 6, 3, 2, 5),
+    H1 = c(1, NA, 6, 3, 2, 5),
     C6a = 1
   )
   
@@ -145,6 +149,7 @@ test_that("mask items correctly coded", {
   input_data$c_mask_often_7d <- NA
   input_data$c_others_masked <- NA
   input_data$c_others_masked_public <- c(FALSE, NA, NA, FALSE, FALSE, TRUE)
+  input_data$c_others_distanced_public <- c(FALSE, NA, NA, FALSE, FALSE, TRUE)
   input_data$c_work_outside_5d <- NA
   
   expect_equal(out, input_data)


### PR DESCRIPTION
### Description
Take 2 of #1081 to reduce package install time. Takes ~8 min to run with no cache; time with cache of dependencies takes ~2 min, as in #1081.

### Changelog
- Don't install "suggested" dependencies of survey package's dependencies or of `rcmdcheck` and `mockr`.