### PR TITLE
Prevent multiple log outputs

### DIFF
--- a/_delphi_utils_python/delphi_utils/logger.py
+++ b/_delphi_utils_python/delphi_utils/logger.py
@@ -82,7 +82,7 @@ def get_structured_logger(name=__name__,
 
     # Create the underlying python logger and wrap it with structlog
     system_logger = logging.getLogger(name)
-    if filename:
+    if filename and not system_logger.handlers:
         system_logger.addHandler(logging.FileHandler(filename))
     system_logger.setLevel(logging.INFO)
     logger = structlog.wrap_logger(system_logger)


### PR DESCRIPTION
Multiple calls to get_structured_logger creating multiple FileHandlers, this checks to see if a handler is already present, and if so doesn't add another one.

### Description
Bug fix: Preventing multiple duplicate log messages in the output due to more than one FileHandler being instantiated.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- logger.py (get_structured_logger function)

### Fixes 
Checks to see if a handler is already present, and if so doesn't add another one. Referring to [this link](https://stackoverflow.com/a/6729713) for solution
