### PR TITLE
Fix Check SE errors

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/static.py
+++ b/_delphi_utils_python/delphi_utils/validator/static.py
@@ -328,8 +328,8 @@ class StaticValidator:
         df_to_test.eval(
             'se_upper_limit = (val * sample_size + 50)/(sample_size + 1)', inplace=True)
 
-        df_to_test['se'] = df_to_test['se'].round(3)
-        df_to_test['se_upper_limit'] = df_to_test['se_upper_limit'].round(3)
+        df_to_test['se'] = df_to_test['se'].round(5)
+        df_to_test['se_upper_limit'] = df_to_test['se_upper_limit'].round(5)
 
         if self.params.missing_se_allowed:
             result = df_to_test.query(
@@ -345,13 +345,13 @@ class StaticValidator:
         else:
             # Find rows not in the allowed range for se.
             result = df_to_test.query(
-                '~((se > 0) & (se < 50) & (se <= se_upper_limit))')
+                '~((se >= 0) & (se < 50) & (se <= se_upper_limit))')
 
             if not result.empty:
                 report.add_raised_error(
                     ValidationFailure("check_se_not_missing_and_in_range",
                                       filename=nameformat,
-                                      message="se must be in (0, min(50,val*(1+eps))] and not "
+                                      message="se must be in [0, min(50,val*(1+eps))] and not "
                                               "missing"))
 
             report.increment_total_checks()


### PR DESCRIPTION
### Description
In covid-act-now, noticed high degree of overlap between check_se_0 and check_se_not_missing_and_in_range: reason being that having se=0 triggers both checks right now. Also, lack of precision involving SEs, where SEs < 0.0005 get turned to 0 due to rounding

### Changelog
Itemize code/test/documentation changes and files added/removed.
- static.py
- (looked through test_static.py, but changes are passing all current tests)

### Fixes 
Added more precision to SE and upper limits since covid-act-now has very small SEs mistaken for 0

Added clarity to check_se_not_missing_and_in_range: Removing edge-case where se=0 to prevent duplicate errors for a single problem
