### PR TITLE
[fb-package] Fix failing contingency CI due to `readr` version change

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -48,6 +48,10 @@ jobs:
             ${{ runner.os }}-r-facebook-survey-
       - name: Install R dependencies
         run: |
+          if ( packageVersion("readr") != "1.4.0" ) {
+            install.packages("devtools")
+            devtools::install_version("readr", version = "1.4.0")
+          }
           install.packages("remotes")
           remotes::update_packages(c("rcmdcheck", "mockr"), upgrade="always")
           dependency_list <- remotes::dev_package_deps(dependencies=TRUE)

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -51,7 +51,7 @@ jobs:
           install.packages("remotes")
           remotes::update_packages(c("rcmdcheck", "mockr"), upgrade="always")
           dependency_list <- remotes::dev_package_deps(dependencies=TRUE)
-          remotes::update_packages(dependency_list$package, upgrade="always")
+          remotes::update_packages(dependency_list$package[dependency_list$package != "readr"], upgrade="always")
         shell: Rscript {0}
       - name: Check
         run: |

--- a/facebook/delphiFacebook/unit-tests/testthat/test-contingency-utils.R
+++ b/facebook/delphiFacebook/unit-tests/testthat/test-contingency-utils.R
@@ -53,7 +53,7 @@ test_that("testing get_filenames_in_range command", {
   
   create_dir_not_exist(tdir)
   for (filename in files) {
-    write_csv(data.frame(), path = file.path(tdir, filename))
+    write_csv(data.frame(), file.path(tdir, filename))
   }
   
   params <- list(

--- a/facebook/delphiFacebook/unit-tests/testthat/test-contingency-variables.R
+++ b/facebook/delphiFacebook/unit-tests/testthat/test-contingency-variables.R
@@ -1,4 +1,0 @@
-library(data.table)
-library(tibble)
-
-context("Testing response recoding and renaming")

--- a/facebook/delphiFacebook/unit-tests/testthat/test-utils.R
+++ b/facebook/delphiFacebook/unit-tests/testthat/test-utils.R
@@ -24,7 +24,7 @@ test_that("testing create dir function", {
 
 test_that("testing read params when missing file", {
 
-  # expect error if missing file, since no template in test dir
+  # expect error if missing file, since no template in test dir
   tdir <- tempfile()
   expect_warning(expect_error(read_params(tdir)))
 })


### PR DESCRIPTION
### Description
Prevent survey CI from updating to new major release of `readr`. A couple bugs ([apparently spurious compilation errors on install ](https://github.com/tidyverse/readr/issues/1233) and [failure to write empty files](https://github.com/tidyverse/readr/issues/1234)) cause test failures. I've filed issues and hopefully those are fixed in the next minor version; will keep an eye on future `readr` releases.

### Changelog
- Remove `path` argname. Argument will by default use the new `file` arg.
- Exclude `readr` from being updated in Actions workflow.
