### PR TITLE
Modify summary for alerts

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/validate.py
+++ b/_delphi_utils_python/delphi_utils/validator/validate.py
@@ -37,6 +37,7 @@ class Validator:
         # Date/time settings
         self.time_window = TimeWindow.from_params(validation_params["common"]["end_date"],
                                                   validation_params["common"]["span_length"])
+        self.data_source = validation_params["common"].get("data_source", "")
 
         self.static_validation = StaticValidator(validation_params)
         self.dynamic_validation = DynamicValidator(validation_params)
@@ -51,7 +52,7 @@ class Validator:
         Returns:
             - ValidationReport collating the validation outcomes
         """
-        report = ValidationReport(self.suppressed_errors)
+        report = ValidationReport(self.suppressed_errors, self.data_source)
         frames_list = load_all_files(self.export_dir, self.time_window.start_date,
                                      self.time_window.end_date)
         self.static_validation.validate(frames_list, report)

--- a/_delphi_utils_python/tests/validator/test_report.py
+++ b/_delphi_utils_python/tests/validator/test_report.py
@@ -40,10 +40,6 @@ class TestValidationReport:
         report.add_raised_warning(ImportWarning("right import"))
         report.add_raised_error(self.ERROR_1)
         report.add_raised_error(self.ERROR_2)
-        report.set_summary()
-
-        assert report.summary ==\
-            "3 checks run\n1 checks failed\n1 checks suppressed\n2 warnings\n"
 
     def test_log(self):
         """Test that the logs contain all failures and warnings."""


### PR DESCRIPTION
### Description
Changing the summary log statement to a format recognizable by elastalert

### Changelog
Itemize code/test/documentation changes and files added/removed.
- report.py
- test_report.py
- validate.py

### Fixes 
- Removed set_summary() function as it's obsolete
- Added new summary messages based on whether validation run was successful
-Added data source field in summary statement (some sources like HHS doesn't indicate the data source from the logger statement)
- Removed obsolete tests
