### PR TITLE
Add max_expected_lag check to check_missing_geo_sig_date_combo

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -246,15 +246,18 @@ class DynamicValidator:
         report.increment_total_checks()
 
         if recent_df.empty:
-            report.add_raised_error(
-                ValidationFailure("check_missing_geo_sig_date_combo",
-                                  checking_date,
-                                  geo_type,
-                                  signal_type,
-                                  "test data for a given checking date-geo type-signal type"
-                                  " combination is missing. Source data may be missing"
-                                  " for one or more dates"))
-            return False
+            min_thres = timedelta(days = self.params.max_expected_lag.get(
+                signal_type, self.params.max_expected_lag.get('all', 10)))
+            if checking_date < self.params.generation_date - min_thres:
+                report.add_raised_error(
+                    ValidationFailure("check_missing_geo_sig_date_combo",
+                                    checking_date,
+                                    geo_type,
+                                    signal_type,
+                                    "test data for a given checking date-geo type-signal type"
+                                    " combination is missing. Source data may be missing"
+                                    " for one or more dates"))
+                return False
 
         # Reference dataframe runs backwards from the recent_cutoff_date
         #

--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -257,7 +257,7 @@ class DynamicValidator:
                                     "test data for a given checking date-geo type-signal type"
                                     " combination is missing. Source data may be missing"
                                     " for one or more dates"))
-                return False
+            return False
 
         # Reference dataframe runs backwards from the recent_cutoff_date
         #


### PR DESCRIPTION
Checks to see if the checking date is within than max_lag days away, if yes then ignore and don't throw an error

### Description
Re-adding the max_expected_lag fix that got removed accidentally when create_dfs() function was added:
Used to exist in #1105 under line 161 [here](https://github.com/cmu-delphi/covidcast-indicators/pull/1105/files#), but got replaced by #1121 under line 249 [here](https://github.com/cmu-delphi/covidcast-indicators/pull/1121/files).

### Changelog
Itemize code/test/documentation changes and files added/removed.
- dynamic.py

### Fixes 
- Added code back
- Changed direction of sign to match with the logic (for another example, can consider line 180 in dynamic.py under check_min_max_date()
