### PR TITLE
[fb-package] Use `input_data` instead of `df` in `appointment_not_vaccinated` definition

### DIFF
--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -462,9 +462,9 @@ code_vaccines <- function(input_data, wave) {
     )
   }
   
-  if ("V11a" %in% names(df)) {
+  if ("V11a" %in% names(input_data)) {
     # Have an appointment to get vaccinated conditional on not being vaccinated.
-    input_data$v_appointment_not_vaccinated <- df$V11a == 1
+    input_data$v_appointment_not_vaccinated <- input_data$V11a == 1
   } else {
     input_data$v_appointment_not_vaccinated <- NA  
   }


### PR DESCRIPTION
### Description
Use `input_data` instead of undefined `df` to define `v_appointment_not_vaccinated`, used in indicators of the same name in the API and contingency tables. Undefined `df` caused a null column and missing indicators. No other improper use of `df` occurs in definitions in `variables.R`.

### Implications
`smoothed_wappointment_not_vaccinated` and `smoothed_appointment_not_vaccinated` will need to be generated going back to May 20, 2021.