### PR TITLE
Add archiveDiffer to production changehc params

### DIFF
--- a/ansible/templates/changehc-params-prod.json.j2
+++ b/ansible/templates/changehc-params-prod.json.j2
@@ -55,5 +55,13 @@
         "smoothed_outpatient_covid"
       ]
     }
+  },
+  "archive": {
+    "aws_credentials": {
+      "aws_access_key_id": "{{ delphi_aws_access_key_id }}",
+      "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"
+    },
+    "bucket_name": "delphi-covidcast-indicator-output",
+    "cache_dir": "./cache"
   }
 }


### PR DESCRIPTION
### Description
The CHNG indicator wasn't using the archive differ. Now it shall.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- production changehc params - added archive section.

Also added matching delphi_changehc directory to S3.

### Fixes 
- Fixes #1140 
