### PR TITLE
Add bash initializer needed for temp environment

### DIFF
--- a/facebook/Makefile
+++ b/facebook/Makefile
@@ -1,4 +1,4 @@
-SHELL:=/bin/bash
+SHELL:=/bin/bash --rcfile bash-init.sh
 
 # dry-run mode: generate all files, but do not post them anywhere, and disable all emails to outside parties.
 DRY:=yes


### PR DESCRIPTION
### Description
Dangling change to Makefile so that we get the right Python when we run in the temporary production environment. Most systems won't need this. In tmp-prod, the rc file contains the following content:

```
scl enable rh-python38 bash
```

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Makefile -- source an rc file when constructing the shell
- bash-init.sh.template -- empty; copy this to bash-init.sh to use

