### PR TITLE
Remove NAs and Infs from validator Z score check

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Dict, Set
 import pandas as pd
+import numpy as np
 from .errors import ValidationFailure, APIDataFetchError
 from .datafetcher import get_geo_signal_combos, threaded_api_calls
 from .utils import relative_difference_by_min, TimeWindow, lag_converter
-import numpy as np
 
 
 class DynamicValidator:

--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -6,6 +6,7 @@ import pandas as pd
 from .errors import ValidationFailure, APIDataFetchError
 from .datafetcher import get_geo_signal_combos, threaded_api_calls
 from .utils import relative_difference_by_min, TimeWindow, lag_converter
+import numpy as np
 
 
 class DynamicValidator:
@@ -594,6 +595,8 @@ class DynamicValidator:
             z=lambda x: (
                 x["test"] - x["reference mean"]) / x["reference sd"],
             abs_z=lambda x: abs(x["z"])
+        ).replace([np.inf, -np.inf], np.nan, inplace = False
+        ).dropna(
         ).groupby(
             ["geo_id", "variable"], as_index=False
         ).agg(


### PR DESCRIPTION
Removing edge cases where ref sd is 0, leading to Z scores being NA/inf

### Description
Using replace/drop to remove all rows with invalid z scores (likely because reference data doesn't support this)

### Changelog
Itemize code/test/documentation changes and files added/removed.
- dynamic.py

