### PR TITLE
Run outlier check only on cases/deaths

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -116,24 +116,29 @@ class DynamicValidator:
                 report.add_raised_error(api_df_or_error)
                 continue
 
-            # Outlier dataframe
-            earliest_available_date = geo_sig_df["time_value"].min()
-            source_df = geo_sig_df.query(
-                'time_value <= @self.params.time_window.end_date & '
-                'time_value >= @self.params.time_window.start_date'
-            )
+            # Only do outlier check for cases and deaths signals
+            if (signal_type in ["confirmed_7dav_cumulative_num", "confirmed_7dav_incidence_num",
+                                "confirmed_cumulative_num", "confirmed_incidence_num",
+                                "deaths_7dav_cumulative_num",
+                                "deaths_cumulative_num"]):
+                # Outlier dataframe
+                earliest_available_date = geo_sig_df["time_value"].min()
+                source_df = geo_sig_df.query(
+                    'time_value <= @self.params.time_window.end_date & '
+                    'time_value >= @self.params.time_window.start_date'
+                )
 
-            # These variables are interpolated into the call to `api_df_or_error.query()`
-            # below but pylint doesn't recognize that.
-            # pylint: disable=unused-variable
-            outlier_start_date = earliest_available_date - outlier_lookbehind
-            outlier_end_date = earliest_available_date - timedelta(days=1)
-            outlier_api_df = api_df_or_error.query(
-                'time_value <= @outlier_end_date & time_value >= @outlier_start_date')
-            # pylint: enable=unused-variable
+                # These variables are interpolated into the call to `api_df_or_error.query()`
+                # below but pylint doesn't recognize that.
+                # pylint: disable=unused-variable
+                outlier_start_date = earliest_available_date - outlier_lookbehind
+                outlier_end_date = earliest_available_date - timedelta(days=1)
+                outlier_api_df = api_df_or_error.query(
+                    'time_value <= @outlier_end_date & time_value >= @outlier_start_date')
+                # pylint: enable=unused-variable
 
-            self.check_positive_negative_spikes(
-                source_df, outlier_api_df, geo_type, signal_type, report)
+                self.check_positive_negative_spikes(
+                    source_df, outlier_api_df, geo_type, signal_type, report)
 
             # Check data from a group of dates against recent (previous 7 days,
             # by default) data from the API.


### PR DESCRIPTION
Outlier checks only previously tuned on cases/deaths data, reverting back to that following https://github.com/cmu-delphi/covidcast-indicators/blob/185915f93d00aae2cf7ca84431969bc2b3eeec9a/_delphi_utils_python/delphi_utils/validator/dynamic.py#L121

### Description
Allowing check_positive_negative_spikes to only run on certain signals
(since it's only a few, its easier to leave it in the code rather than define in params)

### Changelog
Itemize code/test/documentation changes and files added/removed.
- dynamic.py

