### PR TITLE
Add phase=validation field in logs

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/report.py
+++ b/_delphi_utils_python/delphi_utils/validator/report.py
@@ -89,18 +89,20 @@ class ValidationReport:
                 checks_run = self.total_checks,
                 checks_failed = len(self.unsuppressed_errors),
                 checks_suppressed = self.num_suppressed,
-                warnings = len(self.raised_warnings))
+                warnings = len(self.raised_warnings),
+                phase = "validation")
         else:
             logger.info("Validation run unsuccessful",
                 data_source = self.data_source,
                 checks_run = self.total_checks,
                 checks_failed = len(self.unsuppressed_errors),
                 checks_suppressed = self.num_suppressed,
-                warnings = len(self.raised_warnings))
+                warnings = len(self.raised_warnings),
+                phase="validation")
         for error in self.unsuppressed_errors:
-            logger.critical(str(error))
+            logger.critical(str(error), phase="validation")
         for warning in self.raised_warnings:
-            logger.warning(str(warning))
+            logger.warning(str(warning), phase="validation")
 
     def print_and_exit(self, logger=None, die_on_failures=True):
         """Print results and exit.

--- a/_delphi_utils_python/tests/validator/test_report.py
+++ b/_delphi_utils_python/tests/validator/test_report.py
@@ -55,5 +55,6 @@ class TestValidationReport:
 
         report.log(mock_logger)
         mock_logger.critical.assert_called_once_with(
-            "bad failed for sig2 at resolution county on 2020-11-07: msg 2")
+            "bad failed for sig2 at resolution county on 2020-11-07: msg 2", 
+            phase = "validation")
         mock_logger.warning.assert_has_calls([mock.call("wrong import"), mock.call("right import")])

--- a/_delphi_utils_python/tests/validator/test_report.py
+++ b/_delphi_utils_python/tests/validator/test_report.py
@@ -57,4 +57,6 @@ class TestValidationReport:
         mock_logger.critical.assert_called_once_with(
             "bad failed for sig2 at resolution county on 2020-11-07: msg 2", 
             phase = "validation")
-        mock_logger.warning.assert_has_calls([mock.call("wrong import"), mock.call("right import")])
+        mock_logger.warning.assert_has_calls(
+            [mock.call("wrong import",phase = "validation"), 
+            mock.call("right import", phase = "validation")])


### PR DESCRIPTION
### Description
Adding phase=validation field in logs for easier retrieval in Discover/Elastic

### Changelog
Itemize code/test/documentation changes and files added/removed.
- report.py
