### PR TITLE
Remove end_date

### DIFF
--- a/ansible/templates/changehc-params-prod.json.j2
+++ b/ansible/templates/changehc-params-prod.json.j2
@@ -35,7 +35,6 @@
     "common": {
       "data_source": "chng",
       "span_length": 14,
-      "end_date": "today-4",
       "min_expected_lag": {"all": "4"},
       "max_expected_lag": {"all": "6"},
       "suppressed_errors": [

--- a/ansible/templates/covid_act_now-params-prod.json.j2
+++ b/ansible/templates/covid_act_now-params-prod.json.j2
@@ -18,7 +18,6 @@
     "common": {
       "data_source": "covid-act-now",
       "span_length": 14,
-      "end_date": "today-5",
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "6"},
       "suppressed_errors": [

--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -23,7 +23,6 @@
     "common": {
       "data_source": "google-symptoms",
       "span_length": 14,
-      "end_date": "today-8",
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
       "suppressed_errors": [

--- a/ansible/templates/hhs_hosp-params-prod.json.j2
+++ b/ansible/templates/hhs_hosp-params-prod.json.j2
@@ -7,7 +7,6 @@
     "common": {
       "data_source": "hhs",
       "span_length": 14,
-      "end_date": "today-2",
       "min_expected_lag": {"all": "1"},
       "max_expected_lag": {"all": "7"},
       "suppressed_errors": []

--- a/ansible/templates/jhu-params-prod.json.j2
+++ b/ansible/templates/jhu-params-prod.json.j2
@@ -12,7 +12,6 @@
     "common": {
       "data_source": "jhu-csse",
       "span_length": 14,
-      "end_date": "today-1",
       "min_expected_lag": {"all": "1"},
       "max_expected_lag": {"all": "1"},
       "test_mode": false,

--- a/ansible/templates/quidel_covidtest-params-prod.json.j2
+++ b/ansible/templates/quidel_covidtest-params-prod.json.j2
@@ -23,7 +23,6 @@
     "common": {
       "data_source": "quidel",
       "span_length": 14,
-      "end_date": "today-5",
       "min_expected_lag": {"all": "5"},
       "max_expected_lag": {"all": "5"},
       "suppressed_errors": []

--- a/ansible/templates/safegraph_patterns-params-prod.json.j2
+++ b/ansible/templates/safegraph_patterns-params-prod.json.j2
@@ -18,7 +18,6 @@
     "common": {
       "data_source": "safegraph",
       "span_length": 14,
-      "end_date": "today-4",
       "min_expected_lag": {"all": "sunday+4,4"},
       "max_expected_lag": {"all": "sunday+4,4"},
       "suppressed_errors": [

--- a/ansible/templates/usafacts-params-prod.json.j2
+++ b/ansible/templates/usafacts-params-prod.json.j2
@@ -19,7 +19,6 @@
     "common": {
       "data_source": "usa-facts",
       "span_length": 14,
-      "end_date": "today-2",
       "min_expected_lag": {"all": "1"},
       "max_expected_lag": {"all": "5"},
       "suppressed_errors": [

--- a/changehc/params.json.template
+++ b/changehc/params.json.template
@@ -36,7 +36,6 @@
     "common": {
       "data_source": "chng",
       "span_length": 14,
-      "end_date": "today-4",
       "min_expected_lag": {"all": "4"},
       "max_expected_lag": {"all": "6"},
       "suppressed_errors": [

--- a/claims_hosp/params.json.template
+++ b/claims_hosp/params.json.template
@@ -20,7 +20,6 @@
     "common": {
       "data_source": "hospital-admissions",
       "span_length": 14,
-      "end_date": "today-4",
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
       "suppressed_errors": []

--- a/combo_cases_and_deaths/params.json.template
+++ b/combo_cases_and_deaths/params.json.template
@@ -15,7 +15,6 @@
     "common": {
       "data_source": "indicator-combination",
       "span_length": 14,
-      "end_date": "today-7",
       "min_expected_lag": {"all": "2"},
       "max_expected_lag": {"all": "6"},
       "suppressed_errors": [{"check_name": "check_val_lt_0"} ]

--- a/covid_act_now/params.json.template
+++ b/covid_act_now/params.json.template
@@ -18,7 +18,6 @@
     "common": {
       "data_source": "covid-act-now",
       "span_length": 14,
-      "end_date": "today-5",
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "6"},
       "suppressed_errors": [

--- a/doctor_visits/params.json.template
+++ b/doctor_visits/params.json.template
@@ -17,7 +17,6 @@
     "common": {
       "data_source": "doctor-visits",
       "span_length": 14,
-      "end_date": "today-5",
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
       "suppressed_errors": [

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -13,7 +13,6 @@
     "common": {
       "data_source": "google-symptoms",
       "span_length": 14,
-      "end_date": "today-8",
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
       "suppressed_errors": [

--- a/hhs_hosp/params.json.template
+++ b/hhs_hosp/params.json.template
@@ -7,7 +7,6 @@
     "common": {
       "data_source": "hhs",
       "span_length": 14,
-      "end_date": "today-2",
       "min_expected_lag": {"all": "1"},
       "max_expected_lag": {"all": "7"},
       "suppressed_errors": []

--- a/jhu/params.json.template
+++ b/jhu/params.json.template
@@ -13,7 +13,6 @@
     "common": {
       "data_source": "jhu-csse",
       "span_length": 14,
-      "end_date": "today-1",
       "min_expected_lag": {"all": "1"},
       "max_expected_lag": {"all": "1"},
       "test_mode": false,

--- a/quidel_covidtest/params.json.template
+++ b/quidel_covidtest/params.json.template
@@ -24,7 +24,6 @@
     "common": {
       "data_source": "quidel",
       "span_length": 14,
-      "end_date": "today-5",
       "min_expected_lag": {"all": "5"},
       "max_expected_lag": {"all": "5"},
       "suppressed_errors": []

--- a/safegraph_patterns/params.json.template
+++ b/safegraph_patterns/params.json.template
@@ -18,7 +18,6 @@
     "common": {
       "data_source": "safegraph",
       "span_length": 14,
-      "end_date": "today-4",
       "min_expected_lag": {"all": "sunday+4,4"},
       "max_expected_lag": {"all": "sunday+4,4"},
       "suppressed_errors": [

--- a/usafacts/params.json.template
+++ b/usafacts/params.json.template
@@ -20,7 +20,6 @@
     "common": {
       "data_source": "usa-facts",
       "span_length": 14,
-      "end_date": "today-2",
       "min_expected_lag": {"all": "1"},
       "max_expected_lag": {"all": "5"},
       "suppressed_errors": [


### PR DESCRIPTION


### Description
Removing end_date due to new default calculation of end_date that uses min_expected_lag

### Changelog
All params.json.template files for indicators that have been configured for validator

Note: waiting on #1158 
