### PR TITLE
Update outlier check for clarity

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -529,14 +529,15 @@ class DynamicValidator:
             "time_value >= @source_frame_start & time_value <= @source_frame_end")
 
         if source_outliers.shape[0] > 0:
-            report.add_raised_error(
-                ValidationFailure(
-                    "check_positive_negative_spikes",
-                    source_outliers["time_value"].max(),
-                    geo,
-                    sig,
-                    "Source dates with flagged ouliers based on the previous 14 days of data "
-                    "available"))
+            for time_val in source_outliers["time_value"].unique():
+                report.add_raised_error(
+                    ValidationFailure(
+                        "check_positive_negative_spikes",
+                        time_val,
+                        geo,
+                        sig,
+                        "Source dates with flagged ouliers based on the previous 14 days of data "
+                        "available"))
 
     def check_avg_val_vs_reference(self, df_to_test, df_to_reference, checking_date, geo_type,
                                    signal_type, report):

--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -419,7 +419,11 @@ class DynamicValidator:
         report.increment_total_checks()
         # Combine all possible frames so that the rolling window calculations make sense.
         source_frame_start = source_df["time_value"].min()
+        # This variable is interpolated into the call to `add_raised_error()`
+        # below but pylint doesn't recognize that.
+        # pylint: disable=unused-variable
         source_frame_end = source_df["time_value"].max()
+        # pylint: enable=unused-variable
         all_frames = pd.concat([api_frames, source_df]). \
             drop_duplicates(subset=["geo_id", "time_value"], keep='last'). \
             sort_values(by=['time_value']).reset_index(drop=True)
@@ -528,7 +532,7 @@ class DynamicValidator:
             report.add_raised_error(
                 ValidationFailure(
                     "check_positive_negative_spikes",
-                    source_frame_end,
+                    source_outliers["time_value"].max(),
                     geo,
                     sig,
                     "Source dates with flagged ouliers based on the previous 14 days of data "

--- a/_delphi_utils_python/tests/validator/test_dynamic.py
+++ b/_delphi_utils_python/tests/validator/test_dynamic.py
@@ -282,7 +282,7 @@ class TestDataOutlier:
         validator.check_positive_negative_spikes(
             test_df, ref_df, "state", "signal", report)
 
-        assert len(report.raised_errors) == 1
+        assert len(report.raised_errors) == 2
         assert report.raised_errors[0].check_name == "check_positive_negative_spikes"
 
     def test_neg_outlier(self):
@@ -319,7 +319,7 @@ class TestDataOutlier:
         validator.check_positive_negative_spikes(
             test_df, ref_df, "state", "signal", report)
 
-        assert len(report.raised_errors) == 1
+        assert len(report.raised_errors) == 2
         assert report.raised_errors[0].check_name == "check_positive_negative_spikes"
 
     def test_zero_outlier(self):
@@ -428,5 +428,5 @@ class TestDataOutlier:
         validator.check_positive_negative_spikes(
             test_df, ref_df, "state", "signal", report)
 
-        assert len(report.raised_errors) == 1
+        assert len(report.raised_errors) == 2
         assert report.raised_errors[0].check_name == "check_positive_negative_spikes"


### PR DESCRIPTION
### Description
Outlier check currently indicates the end of the checking period as the dates with outliers, for clarity we make it such that the date given is the most recent outlier.
Should we keep it like this, or raise errors for each unique date with an outlier?

### Changelog
-dynamic.py

### Fixes 
- Fixes #(issue)
