### PR TITLE
wrong prefix :(

### DIFF
--- a/ansible/templates/changehc-params-prod.json.j2
+++ b/ansible/templates/changehc-params-prod.json.j2
@@ -62,6 +62,6 @@
     },
     "bucket_name": "delphi-covidcast-indicator-output",
     "cache_dir": "./cache",
-    "indicator_prefix": "delphi_hhs"
+    "indicator_prefix": "delphi_changehc"
   }
 }


### PR DESCRIPTION
### Description
Production CHNG archiver should go to changhc S3, not hhs

### Changelog
Itemize code/test/documentation changes and files added/removed.
- production CHNG params
