### PR TITLE
Update safegraph-patterns sunday params for min and max

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/utils.py
+++ b/_delphi_utils_python/delphi_utils/validator/utils.py
@@ -108,9 +108,9 @@ def lag_converter(lag_dict):
             # Check that the number proceeding sunday+ has length of 1
             assert value[8] == ","
             # Value_num calculates the number of days between today and the
-            # Update day, except that if both days of the week are the same,
-            # Expected lag is 7 (in case updates aren't in yet)
-            value_num = (date.today().isoweekday() - int(value[7:8]) - 1) % 7 + 1
+            # Update day, if both days of the week are the same,
+            # Expected lag is 0
+            value_num = (date.today().isoweekday() - int(value[7:8])) % 7
             # Add on expected lag to lag from weekdays
             value_num += int(value[9:])
         else:

--- a/ansible/templates/safegraph_patterns-params-prod.json.j2
+++ b/ansible/templates/safegraph_patterns-params-prod.json.j2
@@ -19,7 +19,7 @@
       "data_source": "safegraph",
       "span_length": 14,
       "min_expected_lag": {"all": "sunday+4,4"},
-      "max_expected_lag": {"all": "sunday+4,4"},
+      "max_expected_lag": {"all": "sunday+5,5"},
       "suppressed_errors": [
         {"signal": "completely_home_prop"},
         {"signal": "completely_home_prop_7dav"},

--- a/safegraph_patterns/params.json.template
+++ b/safegraph_patterns/params.json.template
@@ -19,7 +19,7 @@
       "data_source": "safegraph",
       "span_length": 14,
       "min_expected_lag": {"all": "sunday+4,4"},
-      "max_expected_lag": {"all": "sunday+4,4"},
+      "max_expected_lag": {"all": "sunday+5,5"},
       "suppressed_errors": [
         {"signal": "completely_home_prop"},
         {"signal": "completely_home_prop_7dav"},


### PR DESCRIPTION
- "Sunday+" method made more intuitive
- Safegraph-patterns params to have different lags for min and max days to ease confusion

### Description
Type of change (bug fix, new feature, etc), brief description, and motivation for these changes.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- utils.py (Clarifying sunday+)
- params.json.template for safegraph-patterns

### Fixes 
- Currently, the "sunday+x,y" method works by using two variables: x, denoting the day of the week, and y, the lag. For example, something like "sunday+4,4" means that the indicator updates on Thursdays, up to 4 days before the update day (Sundays).
- However, this means that the expected lag for Thursdays would either be 4 (if data is updated) or 11 (if validation happens before the signal updates).
- We originally write the sunday+4,4 method to always equal to 11, but change it to be 4 since it makes more intuitive sense.
- When setting max and min lags, we want the max and min lags to be the same on every other day (5 for Friday, 6 for Sunday, ... 10 for wed), but for Thursday min=4, max=11.
- We do this by making min = sunday+4,4, and max = sunday+5,5. The latter gives us 11 since there's 6 days between the last expected update (Friday) and today (the next Thursday), and a lag of 5 days. 
- In layman's terms, we are saying that the minimum lag outcome is when data is updated at the start of Thursday, up to the Sunday before (4 days past). The worst-case scenario is that data is updated by the end of Thursday (start of Friday), by which there would be a lag of 5 with respect to the update day.
