### PR TITLE
Add support for retiring specific geo types to SirCAL

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        packages: [_delphi_utils_python, changehc, claims_hosp, combo_cases_and_deaths, covid_act_now, doctor_visits, google_symptoms, hhs_hosp, hhs_facilities, jhu, nchs_mortality, nowcast, quidel, quidel_covidtest, safegraph_patterns, usafacts]
+        packages: [_delphi_utils_python, changehc, claims_hosp, combo_cases_and_deaths, covid_act_now, doctor_visits, google_symptoms, hhs_hosp, hhs_facilities, jhu, nchs_mortality, nowcast, quidel, quidel_covidtest, safegraph_patterns, sir_complainsalot, usafacts]
     defaults:
       run:
         working-directory: ${{ matrix.packages }}

--- a/sir_complainsalot/delphi_sir_complainsalot/check_source.py
+++ b/sir_complainsalot/delphi_sir_complainsalot/check_source.py
@@ -63,7 +63,7 @@ def check_source(data_source, meta, params, grace, logger):  # pylint: disable=t
     gap_complaints = {}
 
     for _, row in signals.iterrows():
-        retired_signals = source_config.get("retired-signals", "")
+        retired_signals = source_config.get("retired-signals")
         if _is_retired(row, retired_signals):
             continue
 

--- a/sir_complainsalot/delphi_sir_complainsalot/check_source.py
+++ b/sir_complainsalot/delphi_sir_complainsalot/check_source.py
@@ -100,8 +100,7 @@ def check_source(data_source, meta, params, grace, logger):  # pylint: disable=t
         if current_lag_in_days > source_config["max_age"] + grace:
             if row["signal"] not in age_complaints:
                 age_complaints[row["signal"]] = Complaint(
-                    "is {current_lag_in_days} days old".format(
-                        current_lag_in_days=current_lag_in_days),
+                    f"is {current_lag_in_days} days old",
                     data_source,
                     row["signal"],
                     [row["geo_type"]],

--- a/sir_complainsalot/tests/test_check_source.py
+++ b/sir_complainsalot/tests/test_check_source.py
@@ -1,0 +1,30 @@
+import pytest
+
+from delphi_sir_complainsalot.check_source import _is_retired
+
+
+class TestCheckSource:
+
+    @pytest.mark.parametrize(
+        "row, expected",
+        [
+            ({"signal": "confirmed_7dav_cumulative_num", "geo_type": "county"}, True),
+            ({"signal": "confirmed_7dav_cumulative_num", "geo_type": "msa"}, True),
+            ({"signal": "confirmed_7dav_cumulative_num", "geo_type": "nation"}, False),
+            ({"signal": "confirmed_7dav_cumulative_prop", "geo_type": "nation"}, True),
+            ({"signal": "confirmed_7dav_cumulative_prop", "geo_type": "state"}, True),
+            ({"signal": "confirmed_7dav_cumulative_prop", "geo_type": "some_other_geo"}, True),
+            ({"signal": "deaths_7dav_cumulative_num", "geo_type": "state"}, True),
+            ({"signal": "deaths_7dav_cumulative_num", "geo_type": "county"}, False),
+            ({"signal": "deaths_7dav_cumulative_prop", "geo_type": "nation"}, True),
+            ({"signal": "deaths_7dav_cumulative_prop", "geo_type": "hhs"}, False),
+        ]
+    )
+    def test__is_retired(self, row, expected):
+        retired_signals = [
+            ["confirmed_7dav_cumulative_num", "county", "msa"],
+            "confirmed_7dav_cumulative_prop",
+            ["deaths_7dav_cumulative_num", "state"],
+            ["deaths_7dav_cumulative_prop", "nation"]
+        ]
+        assert _is_retired(row, retired_signals) == expected

--- a/sir_complainsalot/tests/test_check_source.py
+++ b/sir_complainsalot/tests/test_check_source.py
@@ -28,3 +28,4 @@ class TestCheckSource:
             ["deaths_7dav_cumulative_prop", "nation"]
         ]
         assert _is_retired(row, retired_signals) == expected
+        assert _is_retired(row, None) == False


### PR DESCRIPTION
### Description
SirCAL currently can only retire entire signals but not individual geo types. this PR adds support for retiring a subset of geos for a given signal. It is backwards compatible with the existing params files so they do not need to be altered.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add support for lists in retired-signals specifying multiple geo types to remove. Syntax determined via discussion with @krivard 
- Add tests for new function for determining retired signals
- Enable CI for sircal
- Fix linting errors to pass CI.

### Fixes 
- #1082
