### PR TITLE
Use archiver.run function in runner

### DIFF
--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -45,7 +45,7 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
             name = indicator_fn.__module__,
             filename=params["common"].get("log_filename", None)))
     if archiver and (not validator or validation_report.success()):
-        archiver.archive()
+        archiver.run()
 
 
 if __name__ == "__main__":

--- a/_delphi_utils_python/tests/test_runner.py
+++ b/_delphi_utils_python/tests/test_runner.py
@@ -53,7 +53,7 @@ class TestRunIndicator:
         mock_validator_fn.assert_called_once_with(self.PARAMS)
         mock_archiver_fn.assert_called_once_with(self.PARAMS)
         mock_validator_fn.return_value.validate.assert_called_once()
-        mock_archiver_fn.return_value.archive.assert_called_once()
+        mock_archiver_fn.return_value.run.assert_called_once()
 
     @mock.patch("delphi_utils.runner.read_params")
     def test_failed_validation(self, mock_read_params,
@@ -69,7 +69,7 @@ class TestRunIndicator:
         mock_validator_fn.assert_called_once_with(self.PARAMS)
         mock_archiver_fn.assert_called_once_with(self.PARAMS)
         mock_validator_fn.return_value.validate.assert_called_once()
-        mock_archiver_fn.return_value.archive.assert_not_called()
+        mock_archiver_fn.return_value.run.assert_not_called()
 
     @mock.patch("delphi_utils.runner.read_params")
     def test_indicator_only(self, mock_read_params, mock_indicator_fn):
@@ -96,7 +96,7 @@ class TestRunIndicator:
 
         mock_indicator_fn.assert_called_once_with(self.PARAMS)
         mock_archiver_fn.assert_called_once_with(self.PARAMS)
-        mock_archiver_fn.return_value.archive.assert_called_once()
+        mock_archiver_fn.return_value.run.assert_called_once()
 
     @mock.patch("delphi_utils.runner.read_params")
     def test_no_archive(self, mock_read_params, mock_indicator_fn, mock_validator_fn):


### PR DESCRIPTION
### Description
archiver.archive() isn't actually a function, we use run() instead which was implemented here: https://github.com/cmu-delphi/covidcast-indicators/commit/ead53c8af78c833e578967a1a11c53f87d55cfaf#diff-817ffd086856eae7a95f784aee9b38cb94e4ef48e9d9307e5dc6930f93729225

Also fixed tests

### Changelog
Itemize code/test/documentation changes and files added/removed.
- runner.py
- archiver.py

### Fixes 
- changed all calls of archiver.archive() to archiver.run()
