### PR TITLE
Archiver params

### DIFF
--- a/ansible/templates/covid_act_now-params-prod.json.j2
+++ b/ansible/templates/covid_act_now-params-prod.json.j2
@@ -9,6 +9,7 @@
   "archive": {
     "cache_dir": "./cache",
     "bucket_name": "delphi-covidcast-indicator-output",
+    "indicator_prefix": "CAN",
     "aws_credentials": {
       "aws_access_key_id": "{{ delphi_aws_access_key_id }}",
       "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"

--- a/ansible/templates/jhu-params-prod.json.j2
+++ b/ansible/templates/jhu-params-prod.json.j2
@@ -44,6 +44,7 @@
       "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"
     },
     "bucket_name": "delphi-covidcast-indicator-output",
-    "cache_dir": "./cache"
+    "cache_dir": "./cache",
+    "indicator_prefix": "jhu"
   }
 }

--- a/ansible/templates/usafacts-params-prod.json.j2
+++ b/ansible/templates/usafacts-params-prod.json.j2
@@ -13,6 +13,7 @@
       "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"
     },
     "bucket_name": "delphi-covidcast-indicator-output",
+    "indicator_prefix": "usafacts",
     "cache_dir": "./cache"
   },
   "validation": {

--- a/covid_act_now/params.json.template
+++ b/covid_act_now/params.json.template
@@ -9,6 +9,7 @@
   "archive": {
     "cache_dir": "./cache",
     "bucket_name": "",
+    "indicator_prefix": "CAN",
     "aws_credentials": {
       "aws_access_key_id": "",
       "aws_secret_access_key": ""

--- a/jhu/params.json.template
+++ b/jhu/params.json.template
@@ -38,5 +38,14 @@
         "deaths_7dav_incidence_num",
         "deaths_7dav_incidence_prop"]
     }
+  },
+  "archive": {
+    "aws_credentials": {
+      "aws_access_key_id": "",
+      "aws_secret_access_key": ""
+    },
+    "bucket_name": "",
+    "cache_dir": "./cache",
+    "indicator_prefix": "jhu"
   }
 }

--- a/usafacts/params.json.template
+++ b/usafacts/params.json.template
@@ -14,6 +14,7 @@
       "aws_secret_access_key": ""
     },
     "bucket_name": "",
+    "indicator_prefix": "usafacts",
     "cache_dir": "./cache"
   },
   "validation": {


### PR DESCRIPTION
### Description
Adding indicator-prefix to params.json.template as well as ansible so that we can call archiver from params directly.
Haven't previously noticed this issue since only the runner uses the from_params() method of calling the archiver. 
Prior to #1146, all indicators using the runner did not contain archiver params anyway and so the function was not called. The addition of chng archiver params did not cause an issue since there correctly was the indicator_prefix param.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- param.json.template and respective ansible params for USAfacts, JHU and CAN.

### Fixes 
- Added indicator_prefix param, based off what is currently used in individual indicator module run functions.
