### PR TITLE
Use Epidata API for check_missing_geo_sig

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -126,28 +126,28 @@ def get_geo_signal_combos(data_source):
     new_geo_signal_combos = []
     # Use a seen dict to save on multiple calls:
     # True/False indicate if status is active, "unknown" means we should check
-    geo_seen = dict()
+    sig_combo_seen = dict()
     for combo in geo_signal_combos:
         if source_signal_mappings.get(data_source):
             src_list = source_signal_mappings.get(data_source)
         else:
             src_list = [data_source]
         for src in src_list:
-            geo = combo[1]
-            geo_status = geo_seen.get((combo[0], geo, src), "unknown")
+            sig = combo[1]
+            geo_status = sig_combo_seen.get(sig, src), "unknown")
             if geo_status is True:
                 new_geo_signal_combos.append(combo)
             elif geo_status == "unknown":
                 epidata_signal = requests.get(
                     "https://api.covidcast.cmu.edu/epidata/covidcast/meta",
-                    params={'signal': f"{src}:{geo}"})
+                    params={'signal': f"{src}:{sig}"})
                 # Not an active signal
                 active_status = [val['active'] for i in epidata_signal.json()
                     for val in i['signals']]
                 if active_status == []:
-                    geo_seen[(combo[0], geo, src)] = False
+                    sig_combo_seen[(sig, src)] = False
                     continue
-                geo_seen[(combo[0], geo, src)] = active_status[0]
+                sig_combo_seen[(sig, src)] = active_status[0]
                 if active_status[0] is True:
                     new_geo_signal_combos.append(combo)
     return new_geo_signal_combos

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -134,7 +134,7 @@ def get_geo_signal_combos(data_source):
             src_list = [data_source]
         for src in src_list:
             geo = combo[1]
-            geo_status = geo_seen.get(geo, "unknown")
+            geo_status = geo_seen.get((geo, src), "unknown")
             if geo_status is True:
                 new_geo_signal_combos.append(combo)
             elif geo_status == "unknown":
@@ -142,11 +142,12 @@ def get_geo_signal_combos(data_source):
                     "https://api.covidcast.cmu.edu/epidata/covidcast/meta",
                     params={'signal': f"{src}:{geo}"})
                 # Not an active signal
-                active_status = [i['active'] for i in epidata_signal.json()]
+                active_status = [val['active'] for i in epidata_signal.json()
+                    for val in i['signals']]
                 if active_status == []:
-                    geo_seen[geo] = False
+                    geo_seen[(geo, src)] = False
                     continue
-                geo_seen[geo] = active_status[0]
+                geo_seen[(geo, src)] = active_status[0]
                 if active_status[0] is True:
                     new_geo_signal_combos.append(combo)
     return new_geo_signal_combos

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -3,10 +3,10 @@
 
 import re
 import threading
-import requests
 from os import listdir
 from os.path import isfile, join
 import warnings
+import requests
 import pandas as pd
 import numpy as np
 

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -134,7 +134,7 @@ def get_geo_signal_combos(data_source):
             src_list = [data_source]
         for src in src_list:
             sig = combo[1]
-            geo_status = sig_combo_seen.get(sig, src), "unknown")
+            geo_status = sig_combo_seen.get((sig, src), "unknown")
             if geo_status is True:
                 new_geo_signal_combos.append(combo)
             elif geo_status == "unknown":

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -134,7 +134,7 @@ def get_geo_signal_combos(data_source):
             src_list = [data_source]
         for src in src_list:
             geo = combo[1]
-            geo_status = geo_seen.get((geo, src), "unknown")
+            geo_status = geo_seen.get((combo[0], geo, src), "unknown")
             if geo_status is True:
                 new_geo_signal_combos.append(combo)
             elif geo_status == "unknown":
@@ -145,9 +145,9 @@ def get_geo_signal_combos(data_source):
                 active_status = [val['active'] for i in epidata_signal.json()
                     for val in i['signals']]
                 if active_status == []:
-                    geo_seen[(geo, src)] = False
+                    geo_seen[(combo[0], geo, src)] = False
                     continue
-                geo_seen[(geo, src)] = active_status[0]
+                geo_seen[(combo[0], geo, src)] = active_status[0]
                 if active_status[0] is True:
                     new_geo_signal_combos.append(combo)
     return new_geo_signal_combos

--- a/_delphi_utils_python/tests/validator/test_datafetcher.py
+++ b/_delphi_utils_python/tests/validator/test_datafetcher.py
@@ -24,20 +24,29 @@ class TestDataFetcher:
     @mock.patch("covidcast.metadata")
     def test_get_geo_signal_combos(self, mock_metadata):
         """Test that the geo signal combos are correctly pulled from the covidcast metadata."""
-        mock_metadata.return_value = pd.DataFrame({"data_source": ["a", "a", "a",
-                                                                   "b", "b", "b"],
-                                                   "signal": ["w", "x", "x",
-                                                              "y", "y", "z"],
+        # Need to use actual data_source and signal names since we reference the API
+        mock_metadata.return_value = pd.DataFrame({"data_source": ["chng", "chng", "chng",
+                                                                   "covid-act-now",
+                                                                   "covid-act-now",
+                                                                   "covid-act-now"],
+                                                   "signal": ["smoothed_outpatient_cli",
+                                                              "smoothed_outpatient_covid",
+                                                              "smoothed_outpatient_covid",
+                                                              "pcr_specimen_positivity_rate",
+                                                              "pcr_specimen_positivity_rate",
+                                                              "pcr_specimen_total_tests"],
                                                    "geo_type": ["state", "state", "county",
                                                                 "hrr", "msa", "msa"]
                                                   })
 
-        assert set(get_geo_signal_combos("a")) == set([("state", "w"),
-                                                       ("state", "x"),
-                                                       ("county", "x")])
-        assert set(get_geo_signal_combos("b")) == set([("hrr", "y"),
-                                                       ("msa", "y"),
-                                                       ("msa", "z")])
+        assert set(get_geo_signal_combos("chng")) == set(
+            [("state", "smoothed_outpatient_cli"),
+             ("state", "smoothed_outpatient_covid"),
+             ("county", "smoothed_outpatient_covid")])
+        assert set(get_geo_signal_combos("covid-act-now")) == set(
+            [("hrr", "pcr_specimen_positivity_rate"),
+             ("msa", "pcr_specimen_positivity_rate"),
+             ("msa", "pcr_specimen_total_tests")])
 
     @mock.patch("covidcast.signal")
     def test_threaded_api_calls(self, mock_signal):


### PR DESCRIPTION
### Description
Check_missing_geo_sig currently uses covidcast.metadata() to identify all combinations of geo_type and signal_type. This leads to the inclusion of currently inactive signal types as well. We use the Epidata API to retrieve signal-level information on if a given signal is active or not.

### Changelog
- datafetcher.py
- test_datafetcher.py

### Fixes 
- Use actual names for test file since we need to cross-reference the API
- Use a dict to check if a particular signal type is an active signal, and only return active signals.