### PR TITLE
Increase GS amount of data produced per run

### DIFF
--- a/google_symptoms/delphi_google_symptoms/run.py
+++ b/google_symptoms/delphi_google_symptoms/run.py
@@ -64,13 +64,12 @@ def run_module(params):
         # Calculate number of days based on what validator expects.
         max_expected_lag = params["validation"]["common"].get("max_expected_lag", {"default": 4})
         global_max_expected_lag = max(map(int, list(max_expected_lag.values()) ))
-        span_length = params["validation"]["common"].get("span_length", 14)
 
         # Select the larger number of days. Prevents validator from complaining about missing dates
         # and backfills in case of an outage.
         num_export_days = max(
             (datetime.today() - to_datetime(min(gs_metadata.max_time))).days + 1,
-            span_length + global_max_expected_lag
+            params["validation"]["common"].get("span_length", 14) + global_max_expected_lag
             )
 
     logger = get_structured_logger(

--- a/google_symptoms/delphi_google_symptoms/run.py
+++ b/google_symptoms/delphi_google_symptoms/run.py
@@ -10,6 +10,7 @@ from itertools import product
 import covidcast
 
 import numpy as np
+from pandas import to_datetime
 from delphi_utils import (
     create_export_csv,
     geomap,
@@ -59,7 +60,7 @@ def run_module(params):
         # Get number of days based on what's missing from the API.
         metadata = covidcast.metadata()
         gs_metadata = metadata[(metadata.data_source == "google-symptoms")]
-        num_export_days = max(gs_metadata.min_lag)
+        num_export_days = (datetime.today() - to_datetime(min(gs_metadata.max_time))).days + 1
 
     logger = get_structured_logger(
         __name__, filename=params["common"].get("log_filename"),

--- a/google_symptoms/delphi_google_symptoms/run.py
+++ b/google_symptoms/delphi_google_symptoms/run.py
@@ -16,6 +16,7 @@ from delphi_utils import (
     geomap,
     get_structured_logger
 )
+from delphi_utils.validator.utils import lag_converter
 
 from .constants import (METRICS, COMBINED_METRIC,
                         GEO_RESOLUTIONS, SMOOTHERS, SMOOTHERS_MAP)
@@ -62,10 +63,12 @@ def run_module(params):
         gs_metadata = metadata[(metadata.data_source == "google-symptoms")]
 
         # Calculate number of days based on what validator expects.
-        max_expected_lag = params["validation"]["common"].get("max_expected_lag", {"default": 4})
-        global_max_expected_lag = max(map(int, list(max_expected_lag.values()) ))
+        max_expected_lag = lag_converter(
+            params["validation"]["common"].get("max_expected_lag", {"all": 4})
+            )
+        global_max_expected_lag = max( list(max_expected_lag.values()) )
 
-        # Select the larger number of days. Prevents validator from complaining about missing dates
+        # Select the larger number of days. Prevents validator from complaining about missing dates,
         # and backfills in case of an outage.
         num_export_days = max(
             (datetime.today() - to_datetime(min(gs_metadata.max_time))).days + 1,


### PR DESCRIPTION
### Description
Increase min amount of data pulled to improve compatibility with validator. Improve robustness to data source outages.

### Changelog
- Use min(max_time) instead of max(min_lag) in `num_export_days` default definition to prevent skipped dates in the case that GS hasn't issued data in a long time but the most recent issues had low lags.
- Produce at least enough days of data by default to prevent validator from complaining about missing dates. Uses `span_length` validation setting so stays up-to-date with validation.

### Fixes 
- Closes #1079
- Closes #1190
