### PR TITLE
Fix 0 rounding error in pandas std()

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -558,7 +558,7 @@ class DynamicValidator:
         reference_mean = df_to_reference.groupby(['geo_id'], as_index=False)[
             ['val', 'se', 'sample_size']].mean().assign(type="reference mean")
         reference_sd = df_to_reference.groupby(['geo_id'], as_index=False)[
-            ['val', 'se', 'sample_size']].std().assign(type="reference sd")
+            ['val', 'se', 'sample_size']].std().round(8).assign(type="reference sd")
 
         # Replace standard deviations of 0 with non-zero min sd for that type. Ignores NA.
         replacements = {"val": {0: reference_sd.val[reference_sd.val > 0].min()},


### PR DESCRIPTION
### Description
Python has rounding errors for std when dealing with columns of values that are exactly the same. We use round() to make these columns zero.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- dynamic.py

### Fixes 
- Fixes #(issue)
