### PR TITLE
Suppress outlier check for pcr_specimen_positivity_rate

### DIFF
--- a/ansible/templates/covid_act_now-params-prod.json.j2
+++ b/ansible/templates/covid_act_now-params-prod.json.j2
@@ -29,7 +29,9 @@
          "signal": "pcr_specimen_total_tests"},
         {"check_name": "check_n_missing",
          "signal": "pcr_specimen_total_tests"},
-        {"check_name": "check_se_0_when_val_0"}         
+        {"check_name": "check_se_0_when_val_0"},
+        {"check_name": "check_test_vs_reference_avg_changed",
+         "signal": "pcr_specimen_positivity_rate"}         
       ]
     },
     "static": {

--- a/covid_act_now/params.json.template
+++ b/covid_act_now/params.json.template
@@ -29,7 +29,9 @@
          "signal": "pcr_specimen_total_tests"},
         {"check_name": "check_n_missing",
          "signal": "pcr_specimen_total_tests"},
-        {"check_name": "check_se_0_when_val_0"}         
+        {"check_name": "check_se_0_when_val_0"},
+        {"check_name": "check_test_vs_reference_avg_changed",
+         "signal": "pcr_specimen_positivity_rate"}           
       ]
     },
     "static": {


### PR DESCRIPTION
### Description
Signal is locally monotonic, producing a lot of false positives in the outlier check (since each data point tends to be a new high)

### Changelog
Itemize code/test/documentation changes and files added/removed.
- params.json.template file in both indicator folder and ansible

### Fixes 
- Fixes #(issue)
