### PR TITLE
Fix: Make the facebook indicator actually build correctly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     stages {
         stage('Build and Package') {
             when {
-                branch "main";
+                branch "minimal-facebook-setup";
             }
             steps {
                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
     stages {
         stage('Build and Package') {
             when {
-                branch "minimal-facebook-setup";
+                branch "main";
             }
             steps {
                 script {

--- a/facebook/setup.py
+++ b/facebook/setup.py
@@ -1,3 +1,7 @@
+# this file is used only as a hookup for Jenkins. 
+# if you are looking for the setup.py file associated with the 
+# delphi_facebook python package, see `delphiFacebook/python/setup.py`
+
 from setuptools import setup
 from setuptools import find_packages
 

--- a/facebook/setup.py
+++ b/facebook/setup.py
@@ -14,7 +14,7 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     packages=find_packages(),
 )

--- a/facebook/setup.py
+++ b/facebook/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup
+from setuptools import find_packages
+
+required = [ "" ]
+
+setup(
+    name="facebook",
+    version="0.0.1",
+    description="Facebook Survey",
+    author="",
+    author_email="",
+    url="https://github.com/cmu-delphi/covidcast-indicators",
+    install_requires=required,
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3.7",
+    ],
+    packages=find_packages(),
+)


### PR DESCRIPTION
### Description
Fix

I forgot to include a basic setup.py which caused Jenkins to fail. 

### Changelog
- Adds setup.py