### PR TITLE
Update URL for USAFacts

### DIFF
--- a/ansible/templates/usafacts-params-prod.json.j2
+++ b/ansible/templates/usafacts-params-prod.json.j2
@@ -4,7 +4,7 @@
     "log_filename": "/var/log/indicators/usafacts.log"
   },
   "indicator": {
-    "base_url": "https://usafactsstatic.blob.core.windows.net/public/data/covid-19/covid_{metric}_usafacts.csv",
+    "base_url": "https://static.usafacts.org/public/data/covid-19/covid_{metric}_usafacts.csv",
     "export_start_date": "2020-02-01"
   },
   "archive": {

--- a/usafacts/params.json.template
+++ b/usafacts/params.json.template
@@ -5,7 +5,7 @@
     "log_filename": "./usa-facts.log"
   },
   "indicator": {
-    "base_url": "https://usafactsstatic.blob.core.windows.net/public/data/covid-19/covid_{metric}_usafacts.csv",
+    "base_url": "https://static.usafacts.org/public/data/covid-19/covid_{metric}_usafacts.csv",
     "export_start_date": "2020-02-20"
   },
   "archive": {


### PR DESCRIPTION
### Description
USAFacts seems to have changed their URL. 

The previous one at https://usafactsstatic.blob.core.windows.net only goes out to 8/16; the new one at https://static.usafacts.org goes out to 8/20. 

I tracked the new one down by going to their website, [locating the cases & deaths page](https://usafacts.org/visualizations/coronavirus-covid-19-spread-map/), and scrolling down to “Download Data”.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- dev and prod params files

### Fixes 
- Fixes stale data notification in #system-monitoring.
