### PR TITLE
Make convex solver more robust for weekday correction

### DIFF
--- a/doctor_visits/delphi_doctor_visits/run.py
+++ b/doctor_visits/delphi_doctor_visits/run.py
@@ -95,6 +95,9 @@ def run_module(params):
                 weekday=weekday,
                 se=params["indicator"]["se"]
             )
+            if sensor is None:
+                logging.error("No sensors calculated, no output will be produced")
+                continue
             # write out results
             out_name = "smoothed_adj_cli" if weekday else "smoothed_cli"
             if params["indicator"]["se"]:

--- a/doctor_visits/delphi_doctor_visits/update_sensor.py
+++ b/doctor_visits/delphi_doctor_visits/update_sensor.py
@@ -126,6 +126,9 @@ def update_sensor(
 
     # handle if we need to adjust by weekday
     params = Weekday.get_params(data) if weekday else None
+    if weekday and np.any(np.all(params == 0,axis=1)):
+        # Weekday correction failed for at least one count type
+        return None
 
     # handle explicitly if we need to use Jeffreys estimate for binomial proportions
     jeffreys = bool(se)

--- a/doctor_visits/delphi_doctor_visits/weekday.py
+++ b/doctor_visits/delphi_doctor_visits/weekday.py
@@ -82,14 +82,16 @@ class Weekday:
             penalty = (
                 lmbda * cp.norm(cp.diff(b[6:], 3), 1) / (X.shape[0] - 2)
             )  # L-1 Norm of third differences, rewards smoothness
-            try:
-                prob = cp.Problem(cp.Minimize(-ll + lmbda * penalty))
-                _ = prob.solve()
-            except:
-                # If the magnitude of the objective function is too large, an error is
-                # thrown; Rescale the objective function
-                prob = cp.Problem(cp.Minimize((-ll + lmbda * penalty) / 1e5))
-                _ = prob.solve()
+            scales = [1, 1e5, 1e10, 1e15]
+            for scale in scales:
+                try:
+                    prob = cp.Problem(cp.Minimize((-ll + lmbda * penalty) / scale))
+                    _ = prob.solve()
+                    break
+                except:
+                    # If the magnitude of the objective function is too large, an error is
+                    # thrown; Rescale the objective function by going through loop
+                    pass
             params[i, :] = b.value
 
         return params

--- a/doctor_visits/delphi_doctor_visits/weekday.py
+++ b/doctor_visits/delphi_doctor_visits/weekday.py
@@ -90,15 +90,15 @@ class Weekday:
                 try:
                     prob = cp.Problem(cp.Minimize((-ll + lmbda * penalty) / scale))
                     _ = prob.solve()
+                    params[i,:] = b.value
                     break
                 except:
                     # If the magnitude of the objective function is too large, an error is
                     # thrown; Rescale the objective function by going through loop
                     pass
             else:
-                logging.error("Unable to calculate weekday correction, will not adjust")
                 # Leaving params[i,:] = 0 is equivalent to not performing weekday correction
-            params[i, :] = b.value
+                logging.error("Unable to calculate weekday correction")
 
         return params
 

--- a/doctor_visits/delphi_doctor_visits/weekday.py
+++ b/doctor_visits/delphi_doctor_visits/weekday.py
@@ -4,6 +4,9 @@ Weekday effects (code from Aaron Rumack).
 Created: 2020-05-06
 """
 
+# standard packages
+import logging
+
 # third party
 import cvxpy as cp
 import numpy as np
@@ -92,6 +95,9 @@ class Weekday:
                     # If the magnitude of the objective function is too large, an error is
                     # thrown; Rescale the objective function by going through loop
                     pass
+            else:
+                logging.error("Unable to calculate weekday correction, will not adjust")
+                # Leaving params[i,:] = 0 is equivalent to not performing weekday correction
             params[i, :] = b.value
 
         return params


### PR DESCRIPTION
### Description
For the doctor visits indicator, we use cvxpy to solve an optimization problem that provides a weekday correction. This solver is not always robust, occasionally it will fail if the magnitude of the objective function is too large. A quick and dirty way to make it more robust is to divide the objective function by some large number.

### Changelog
`weekday.py`: Try up to four times to rescale the objective function, up from two times.

### Fixes 
- No issue linked.
