### PR TITLE
Remove US territories from valid zips list

### DIFF
--- a/facebook/delphiFacebook/R/geo.R
+++ b/facebook/delphiFacebook/R/geo.R
@@ -1,9 +1,12 @@
 #' Returns metadata about each U.S. Zip Code
+#' 
+#' Drops information about US territories, which FB does not provide weights for.
 #'
 #' @param static_dir     local directory containing the file "02_20_uszips.csv"
 #'
 #' @importFrom stringi stri_trans_tolower
 #' @importFrom readr read_csv cols
+#' @importFrom dplyr filter
 #' @export
 produce_zip_metadata <- function(static_dir)
 {
@@ -19,6 +22,8 @@ produce_zip_metadata <- function(static_dir)
   zip_metadata$fips <- sprintf("%05d", zip_metadata$fips)
   zip_metadata$zip5 <- sprintf("%05d", zip_metadata$zip)
   zip_metadata$keep_in_agg <- (zip_metadata$population > 100)
+  
+  zip_metadata <- filter(zip_metadata, !(state_id %in% c("as", "gu", "pr", "vi", "mp")))
 
   return(zip_metadata)
 }

--- a/facebook/delphiFacebook/man/produce_zip_metadata.Rd
+++ b/facebook/delphiFacebook/man/produce_zip_metadata.Rd
@@ -10,5 +10,5 @@ produce_zip_metadata(static_dir)
 \item{static_dir}{local directory containing the file "02_20_uszips.csv"}
 }
 \description{
-Returns metadata about each U.S. Zip Code
+Drops information about US territories, which FB does not provide weights for.
 }

--- a/facebook/delphiFacebook/unit-tests/testthat/test-contingency-utils.R
+++ b/facebook/delphiFacebook/unit-tests/testthat/test-contingency-utils.R
@@ -101,7 +101,7 @@ test_that("testing get_sparse_filenames command", {
   
   create_dir_not_exist(tdir)
   for (filename in files) {
-    write_csv(data.frame(), path = file.path(tdir, filename))
+    write_csv(data.frame(), file.path(tdir, filename))
   }
   
   params <- list(

--- a/facebook/delphiFacebook/unit-tests/testthat/test-geo.R
+++ b/facebook/delphiFacebook/unit-tests/testthat/test-geo.R
@@ -5,11 +5,15 @@ context("Testing geographic crosswalk file creation")
 static_dir <- "static"
 
 test_that("testing zip codes metadata", {
-
+  # Number of Puerto Rico zip codes to ignore; other territories not included in zips file.
+  n_pr <- 131L
+  
   zip_metadata <- produce_zip_metadata(static_dir)
+  
   expect_equal(class(zip_metadata$zip5), "character")
   expect_true(all(nchar(zip_metadata$zip5) == 5L))
-  expect_equal(nrow(zip_metadata), 33099L)
+  expect_equal(nrow(zip_metadata), 33099L - n_pr)
+  expect_equal(length(unique(zip_metadata$state_id)), 51) # 50 states + DC
   expect_equal(zip_metadata$keep_in_agg, zip_metadata$population > 100)
 
 })


### PR DESCRIPTION
### Description
Zip codes belonging to unweighted US territories are dropped from the list of valid zip codes. As a result, we will not include survey respondents reporting that they live in one of these non-valid zip codes in CID lists, microdata, or aggregate calculations.

### Changelog
- Drop entries in `zip_metadata` in `geo.R::produce_zip_metadata` corresponding to US territories (Puerto Rico, Guam, American Samoa, the Virgin Islands, and the Northern Mariana Islands).

### Fixes 
FB does not advertise our survey to users outside of the US proper. If a respondent is listed on FB as living in the US, but in the survey say they are currently living in a US territory, the weights assigned to them are incorrect since weights are based on demographics of their FB-reported location. 