### PR TITLE
Generalize weights file read procedure

### DIFF
--- a/facebook/delphiFacebook/R/weights.R
+++ b/facebook/delphiFacebook/R/weights.R
@@ -61,10 +61,15 @@ join_weights <- function(data, params, weights = c("step1", "full"))
 
   weights_files <- dir(params$weights_in_dir, pattern = pattern, full.names = TRUE)
   weights_files <- sort(weights_files)
+  
+  col_types <- c("character", "double")
+  col_names <- c("cid", "weight")
   agg_weights <- bind_rows(lapply(
     weights_files,
     fread,
-    colClasses = c(cid="character", weight="double"))
+    colClasses = col_types,
+    col.names = col_names
+    )
   )
   agg_weights <- agg_weights[!duplicated(cid),]
   data <- left_join(data, agg_weights, by = c("token" = "cid"))


### PR DESCRIPTION
### Description
Make weights file read procedure more explicit to work with small number of weights files that are missing headers.

### Changelog
- Specify field types by position, not name.
- Name fields by position on read.

### Fixes
Because the new weight files read procedure (#1227) specifies field types by name, it revealed two weights files that don't use those names. `2020-05-04_covid19_dap_adults_finish_step_1_weights.csv` and `2020-05-05_covid19_dap_adults_finish_step_1_weights.csv` don't use the "cid" and "weight" names or have any headers (presumably a bug in the early FB weights pipeline).

The pre-`fread` implementation of the weights file read procedure didn't specify names when setting field types, so they would have been assigned default names (X1, X2 in `read_csv`) on read. `bind_rows` thus would have created a dataframe containing four columns, "cid", "weight", "X1", and "X2", with "X1" and "X2" entirely ignored in later steps, e.g. joining onto the survey data.

### Implications
Due to the missing weights, data products from these dates were not generated correctly. For example, nation-level `raw_wcli` has no observations for 2020-05-04 or 2020-05-05 despite high sample size (~70k) on surrounding days (see `covidcast_signal("fb-survey", "raw_wcli", geo_type="nation", start_day = "2020-04-20", end_day="2020-05-20")`). We will need to reissue data products that include these dates.