### PR TITLE
Pre load geomap data files

### DIFF
--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -107,11 +107,6 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         """Initialize geomapper.
 
         Holds loading the crosswalk tables until a conversion function is first used.
-
-        Parameters
-        ---------
-        crosswalk_files : dict
-            A dictionary of the filenames for the crosswalk tables.
         """
         self.crosswalk_filepaths = CROSSWALK_FILEPATHS
         self.crosswalks = {
@@ -464,6 +459,8 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         geocode_col: str, default None
             The name of the column containing the geocodes. If None, uses the geocode_type
             as the name.
+        dropna: bool, default True
+            Determine whether to drop rows with no population data.
 
         Returns
         --------

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -632,6 +632,5 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         elif contained_geocode_type == "county" and container_geocode_type == "state":
             crosswalk = self._load_crosswalk_from_file("fips", "state")
             return set(crosswalk[crosswalk["state_id"] == container_geocode]["fips"])
-        else:
-            raise ValueError("(contained_geocode_type, container_geocode_type) must be one of "
-                             "(state, nation), (state, hhs), (county, state)")
+        raise ValueError("(contained_geocode_type, container_geocode_type) must be one of "
+                         "(state, nation), (state, hhs), (county, state)")

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -632,5 +632,6 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         elif contained_geocode_type == "county" and container_geocode_type == "state":
             crosswalk = self._load_crosswalk_from_file("fips", "state")
             return set(crosswalk[crosswalk["state_id"] == container_geocode]["fips"])
-        raise ValueError("(contained_geocode_type, container_geocode_type) must be one of "
+        raise ValueError("(contained_geocode_type, container_geocode_type) was "
+                         f"({contained_geocode_type}, {container_geocode_type}), but must be one of "
                          "(state, nation), (state, hhs), (county, state)")

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -135,65 +135,21 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
 
     def _load_crosswalk_from_file(self, from_code, to_code, data_path):
         stream = pkg_resources.resource_stream(__name__, data_path)
-        usecols = None
-        dtype = None
-        # Weighted crosswalks
-        if (from_code, to_code) in [
-            ("zip", "fips"),
-            ("fips", "zip"),
-            ("jhu_uid", "fips"),
-            ("zip", "msa"),
-            ("fips", "hrr"),
-            ("zip", "hhs")
-        ]:
-            dtype = {
-                from_code: str,
-                to_code: str,
-                "weight": float,
-            }
-
-        # Unweighted crosswalks
-        elif (from_code, to_code) in [
-            ("zip", "hrr"),
-            ("fips", "msa"),
-            ("fips", "hhs"),
-            ("state_code", "hhs")
-        ]:
-            dtype = {from_code: str, to_code: str}
-
-        # Special table of state codes, state IDs, and state names
-        elif (from_code, to_code) == ("state", "state"):
-            dtype = {
-                "state_code": str,
-                "state_id": str,
-                "state_name": str,
-            }
-        elif (from_code, to_code) == ("zip", "state"):
-            dtype = {
-                "zip": str,
-                "weight": float,
-                "state_code": str,
-                "state_id": str,
-                "state_name": str,
-            }
-        elif (from_code, to_code) == ("fips", "state"):
-            dtype = {
-                "fips": str,
-                "state_code": str,
-                "state_id": str,
-                "state_name": str,
-            }
-
-        # Population tables
-        elif to_code == "pop":
-            dtype = {
-                from_code: str,
-                "pop": int,
-            }
-            usecols = [
-                from_code,
-                "pop"
-            ]
+        dtype = {
+            from_code: str,
+            to_code: str,
+            "fips": str,
+            "zip": str,
+            "hrr": str,
+            "hhs": str,
+            "msa": str,
+            "state_code": str,
+            "state_id": str,
+            "state_name": str,
+            "pop": int,
+            "weight": float
+        }
+        usecols = [from_code, "pop"] if to_code == "pop" else None
         return pd.read_csv(stream, dtype=dtype, usecols=usecols)
 
     def _load_geo_values(self, geo_type):

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -612,7 +612,7 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         container_geocode: str
             Instance of nation/state/hhs to find the sub-regions of
         contained_geocode_type: str
-            The subregion type to get all instance of. One of "state", "county"
+            The subregion type to retrieve. One of "state", "county"
         container_geocode_type: str
             The parent region type. One of "state", "nation", "hhs"
 

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -14,40 +14,6 @@ import pandas as pd
 import pkg_resources
 from pandas.api.types import is_string_dtype
 
-DATA_PATH = "data"
-CROSSWALK_FILEPATHS = {
-    "zip": {
-        "fips": join(DATA_PATH, "zip_fips_table.csv"),
-        "hrr": join(DATA_PATH, "zip_hrr_table.csv"),
-        "msa": join(DATA_PATH, "zip_msa_table.csv"),
-        "pop": join(DATA_PATH, "zip_pop.csv"),
-        "state": join(DATA_PATH, "zip_state_code_table.csv"),
-        "hhs": join(DATA_PATH, "zip_hhs_table.csv")
-    },
-    "fips": {
-        "zip": join(DATA_PATH, "fips_zip_table.csv"),
-        "hrr": join(DATA_PATH, "fips_hrr_table.csv"),
-        "msa": join(DATA_PATH, "fips_msa_table.csv"),
-        "pop": join(DATA_PATH, "fips_pop.csv"),
-        "state": join(DATA_PATH, "fips_state_table.csv"),
-        "hhs": join(DATA_PATH, "fips_hhs_table.csv"),
-    },
-    "state": {"state": join(DATA_PATH, "state_codes_table.csv")},
-    "state_code": {
-        "hhs": join(DATA_PATH, "state_code_hhs_table.csv"),
-        "pop": join(DATA_PATH, "state_pop.csv")
-    },
-    "state_id": {
-        "pop": join(DATA_PATH, "state_pop.csv")
-    },
-    "state_name": {
-        "pop": join(DATA_PATH, "state_pop.csv")
-    },
-    "jhu_uid": {"fips": join(DATA_PATH, "jhu_uid_fips_table.csv")},
-    "hhs": {"pop": join(DATA_PATH, "hhs_pop.csv")},
-    "nation": {"pop": join(DATA_PATH, "nation_pop.csv")},
-}
-
 
 class GeoMapper:  # pylint: disable=too-many-public-methods
     """Geo mapping tools commonly used in Delphi.
@@ -103,13 +69,43 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
                                 date_col="timestamp", dropna=False)
     """
 
-    def __init__(self):
-        """Initialize geomapper.
+    DATA_PATH = "data"
+    CROSSWALK_FILEPATHS = {
+        "zip": {
+            "fips": join(DATA_PATH, "zip_fips_table.csv"),
+            "hrr": join(DATA_PATH, "zip_hrr_table.csv"),
+            "msa": join(DATA_PATH, "zip_msa_table.csv"),
+            "pop": join(DATA_PATH, "zip_pop.csv"),
+            "state": join(DATA_PATH, "zip_state_code_table.csv"),
+            "hhs": join(DATA_PATH, "zip_hhs_table.csv")
+        },
+        "fips": {
+            "zip": join(DATA_PATH, "fips_zip_table.csv"),
+            "hrr": join(DATA_PATH, "fips_hrr_table.csv"),
+            "msa": join(DATA_PATH, "fips_msa_table.csv"),
+            "pop": join(DATA_PATH, "fips_pop.csv"),
+            "state": join(DATA_PATH, "fips_state_table.csv"),
+            "hhs": join(DATA_PATH, "fips_hhs_table.csv"),
+        },
+        "state": {"state": join(DATA_PATH, "state_codes_table.csv")},
+        "state_code": {
+            "hhs": join(DATA_PATH, "state_code_hhs_table.csv"),
+            "pop": join(DATA_PATH, "state_pop.csv")
+        },
+        "state_id": {
+            "pop": join(DATA_PATH, "state_pop.csv")
+        },
+        "state_name": {
+            "pop": join(DATA_PATH, "state_pop.csv")
+        },
+        "jhu_uid": {"fips": join(DATA_PATH, "jhu_uid_fips_table.csv")},
+        "hhs": {"pop": join(DATA_PATH, "hhs_pop.csv")},
+        "nation": {"pop": join(DATA_PATH, "nation_pop.csv")},
+    }
 
-        Holds loading the crosswalk tables until a conversion function is first used.
-        """
-        self.crosswalk_filepaths = CROSSWALK_FILEPATHS
-        self.crosswalks = {
+    def __init__(self):
+        """Initialize geomapper."""
+        self._crosswalks = {
             "zip": {
                 geo: None for geo in ["fips", "hrr", "msa", "pop", "state", "hhs"]
             },
@@ -124,29 +120,21 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
             "nation": {"pop": None},
             "jhu_uid": {"fips": None},
         }
-        self.geo_lists = {
+        self._geo_sets = {
             geo: None for geo in ["zip", "fips", "hrr", "state_id", "state_code",
-                                  "state_name", "hhs", "msa"]
+                                  "state_name", "hhs", "msa", "nation"]
         }
-        self.geo_lists["nation"] = {"us"}
 
-    # Utility functions
-    def _load_crosswalk(self, from_code, to_code):
-        """Load the crosswalk from from_code -> to_code."""
-        assert from_code in self.crosswalk_filepaths, \
-            f"No crosswalk files for {from_code}; try {'; '.join(self.crosswalk_filepaths.keys())}"
-        assert to_code in self.crosswalk_filepaths[from_code], \
-            f"No crosswalk file from {from_code} to {to_code}; try " \
-            f"{'; '.join(self.crosswalk_filepaths[from_code].keys())}"
+        for from_code, to_codes in self.CROSSWALK_FILEPATHS.items():
+            for to_code, file_path in to_codes.items():
+                self._crosswalks[from_code][to_code] = \
+                    self._load_crosswalk_from_file(from_code, to_code, file_path)
 
-        if self.crosswalks[from_code][to_code] is None:
-            self.crosswalks[from_code][to_code] = self._load_crosswalk_from_file(from_code, to_code)
-        return self.crosswalks[from_code][to_code]
+        for geo_type in self._geo_sets:
+            self._geo_sets[geo_type] = self._load_geo_values(geo_type)
 
-    def _load_crosswalk_from_file(self, from_code, to_code):
-        stream = pkg_resources.resource_stream(
-            __name__, self.crosswalk_filepaths[from_code][to_code]
-        )
+    def _load_crosswalk_from_file(self, from_code, to_code, data_path):
+        stream = pkg_resources.resource_stream(__name__, data_path)
         usecols = None
         dtype = None
         # Weighted crosswalks
@@ -207,6 +195,22 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
                 "pop"
             ]
         return pd.read_csv(stream, dtype=dtype, usecols=usecols)
+
+    def _load_geo_values(self, geo_type):
+        if geo_type == "nation":
+            return {"us"}
+
+        if geo_type.startswith("state"):
+            to_code = from_code = "state"
+        elif geo_type == "fips":
+            from_code = "fips"
+            to_code = "pop"
+        else:
+            from_code = "fips"
+            to_code = geo_type
+
+        crosswalk = self._crosswalks[from_code][to_code]
+        return set(crosswalk[geo_type])
 
     @staticmethod
     def convert_fips_to_mega(data, fips_col="fips", mega_col="megafips"):
@@ -325,17 +329,17 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
 
         # state codes are all stored in one table
         if from_code in state_codes and new_code in state_codes:
-            crosswalk = self._load_crosswalk(from_code="state", to_code="state")
+            crosswalk = self._crosswalks["state"]["state"]
             crosswalk = crosswalk.rename(
                 columns={from_code: from_col, new_code: new_col}
             )
         elif new_code in state_codes:
-            crosswalk = self._load_crosswalk(from_code=from_code, to_code="state")
+            crosswalk = self._crosswalks[from_code]["state"]
             crosswalk = crosswalk.rename(
                 columns={from_code: from_col, new_code: new_col}
             )
         else:
-            crosswalk = self._load_crosswalk(from_code=from_code, to_code=new_code)
+            crosswalk = self._crosswalks[from_code][new_code]
             crosswalk = crosswalk.rename(
                 columns={from_code: from_col, new_code: new_col}
             )
@@ -474,7 +478,7 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
             raise ValueError(
                 f"Only {supported_geos} geocodes supported. For other codes, aggregate those."
             )
-        pop_df = self._load_crosswalk(from_code=geocode_type, to_code="pop")
+        pop_df = self._crosswalks[geocode_type]["pop"]
         if not is_string_dtype(data[geocode_col]):
             if geocode_type in ["zip", "fips"]:
                 data[geocode_col] = data[geocode_col].astype(str).str.zfill(5)
@@ -554,18 +558,28 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
             return "fips"
         return geo_type
 
+    def get_crosswalk(self, from_code, to_code):
+        """Return a dataframe mapping the given geocodes.
+
+        Parameters
+        ----------
+        from_code: str
+          The geo type to translate from.
+        to_code: str
+          The geo type (or "pop" for population) to translate to.
+
+        Returns
+        -------
+        A dataframe containing columbs with the two specified geo types.
+        """
+        try:
+            return self._crosswalks[from_code][to_code]
+        except KeyError as e:
+            raise ValueError(f'Mapping from "{from_code}" to "{to_code}" not found.') from e
+
     def get_geo_values(self, geo_type):
         """
         Return a set of all values for a given geography type.
-
-        Uses the same caching paradigm as _load_crosswalks, storing the value from previous calls
-        and not re-reading the CSVs if the same geo type is requested multiple times. Does not
-        share the same crosswalk cache to keep complexity down.
-
-        Reads the FIPS crosswalk files by default for reference data since those have mappings to
-        all other geos. Exceptions are nation, which has no mapping file and is hard-coded as 'us',
-        and state, which uses the state codes table since the fips/state mapping doesn't include
-        all territories.
 
         Parameters
         ----------
@@ -577,22 +591,10 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         -------
         Set of geo values, all in string format.
         """
-        if self.geo_lists[geo_type]:  # pylint: disable=no-else-return
-            return self.geo_lists[geo_type]
-        else:
-            from_code = "fips"
-            if geo_type.startswith("state"):
-                to_code = from_code = "state"
-            elif geo_type == "fips":
-                to_code = "pop"
-            else:
-                to_code = geo_type
-            stream = pkg_resources.resource_stream(
-                __name__, self.crosswalk_filepaths[from_code][to_code]
-            )
-            crosswalk = pd.read_csv(stream, dtype=str)
-            self.geo_lists[geo_type] = set(crosswalk[geo_type])
-            return self.geo_lists[geo_type]
+        try:
+            return self._geo_sets[geo_type]
+        except KeyError as e:
+            raise ValueError(f'Given geo type "{geo_type}" not found') from e
 
     def get_geos_within(self, container_geocode, contained_geocode_type, container_geocode_type):
         """
@@ -622,16 +624,16 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         """
         if contained_geocode_type == "state":
             if container_geocode_type == "nation" and container_geocode == "us":
-                crosswalk = self._load_crosswalk_from_file("state", "state")
-                return set(crosswalk["state_id"])
+                crosswalk = self._crosswalks["state"]["state"]
+                return set(crosswalk["state_id"])   # pylint: disable=unsubscriptable-object
             if container_geocode_type == "hhs":
-                crosswalk_hhs = self._load_crosswalk_from_file("fips", "hhs")
-                crosswalk_state = self._load_crosswalk_from_file("fips", "state")
+                crosswalk_hhs = self._crosswalks["fips"]["hhs"]
+                crosswalk_state = self._crosswalks["fips"]["state"]
                 fips_hhs = crosswalk_hhs[crosswalk_hhs["hhs"] == container_geocode]["fips"]
                 return set(crosswalk_state[crosswalk_state["fips"].isin(fips_hhs)]["state_id"])
         elif contained_geocode_type == "county" and container_geocode_type == "state":
-            crosswalk = self._load_crosswalk_from_file("fips", "state")
+            crosswalk = self._crosswalks["fips"]["state"]
             return set(crosswalk[crosswalk["state_id"] == container_geocode]["fips"])
         raise ValueError("(contained_geocode_type, container_geocode_type) was "
-                         f"({contained_geocode_type}, {container_geocode_type}), but must be one of "
-                         "(state, nation), (state, hhs), (county, state)")
+                         f"({contained_geocode_type}, {container_geocode_type}), but "
+                         f"must be one of (state, nation), (state, hhs), (county, state)")

--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -598,9 +598,9 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         """
         Return all contained regions of the given type within the given container geocode.
 
-        Given a container_geocode (e.g "ca" for California) of a container_geocode_type
+        Given container_geocode (e.g "ca" for California) of type container_geocode_type
         (e.g "state"), return:
-            - all (contained_geocode_type) within that (container_geocode_type)
+            - all (contained_geocode_type)s within container_geocode
 
         Supports these 3 combinations:
             - all states within a nation

--- a/_delphi_utils_python/tests/test_geomap.py
+++ b/_delphi_utils_python/tests/test_geomap.py
@@ -6,6 +6,11 @@ import pandas as pd
 import numpy as np
 
 
+@pytest.fixture(scope="class")
+def geomapper():
+    return GeoMapper()
+
+
 class TestGeoMapper:
     fips_data = pd.DataFrame(
         {
@@ -135,117 +140,107 @@ class TestGeoMapper:
     # jhu_big_data = pd.read_csv("test_dir/small_deaths.csv")
 
     # Loading tests updated 8/26
-    def test_crosswalks(self):
+    def test_crosswalks(self, geomapper):
         # These tests ensure that the one-to-many crosswalks have properly normalized weights
-        gmpr = GeoMapper()
         # FIPS -> HRR is allowed to be an incomplete mapping, since only a fraction of a FIPS
         # code can not belong to an HRR
-        cw = gmpr._load_crosswalk(from_code="fips", to_code="hrr")
+        cw = geomapper.get_crosswalk(from_code="fips", to_code="hrr")
         assert (
             cw.groupby("fips")["weight"].sum().round(5).ge(0.95).all()
         )  # some weight discrepancy is fine for HRR
-        cw = gmpr._load_crosswalk(from_code="fips", to_code="zip")
+        cw = geomapper.get_crosswalk(from_code="fips", to_code="zip")
         assert cw.groupby("fips")["weight"].sum().round(5).eq(1.0).all()
-        cw = gmpr._load_crosswalk(from_code="jhu_uid", to_code="fips")
+        cw = geomapper.get_crosswalk(from_code="jhu_uid", to_code="fips")
         assert cw.groupby("jhu_uid")["weight"].sum().round(5).eq(1.0).all()
-        cw = gmpr._load_crosswalk(from_code="zip", to_code="fips")
+        cw = geomapper.get_crosswalk(from_code="zip", to_code="fips")
         assert cw.groupby("zip")["weight"].sum().round(5).eq(1.0).all()
         # weight discrepancy is fine for MSA, for the same reasons as HRR
-        # cw = gmpr.load_crosswalk(from_code="zip", to_code="msa")
+        # cw = geomapper.get_crosswalk(from_code="zip", to_code="msa")
         # assert cw.groupby("zip")["weight"].sum().round(5).eq(1.0).all()
-        cw = gmpr._load_crosswalk(from_code="zip", to_code="state")
+        cw = geomapper.get_crosswalk(from_code="zip", to_code="state")
         assert cw.groupby("zip")["weight"].sum().round(5).eq(1.0).all()
-        cw = gmpr._load_crosswalk(from_code="zip", to_code="hhs")
+        cw = geomapper.get_crosswalk(from_code="zip", to_code="hhs")
         assert cw.groupby("zip")["weight"].sum().round(5).eq(1.0).all()
 
 
-    def test_load_zip_fips_table(self):
-        gmpr = GeoMapper()
-        fips_data = gmpr._load_crosswalk(from_code="zip", to_code="fips")
+    def test_load_zip_fips_table(self, geomapper):
+        fips_data = geomapper.get_crosswalk(from_code="zip", to_code="fips")
         assert set(fips_data.columns) == set(["zip", "fips", "weight"])
         assert pd.api.types.is_string_dtype(fips_data.zip)
         assert pd.api.types.is_string_dtype(fips_data.fips)
         assert pd.api.types.is_float_dtype(fips_data.weight)
 
-    def test_load_state_table(self):
-        gmpr = GeoMapper()
-        state_data = gmpr._load_crosswalk(from_code="state", to_code="state")
+    def test_load_state_table(self, geomapper):
+        state_data = geomapper.get_crosswalk(from_code="state", to_code="state")
         assert tuple(state_data.columns) == ("state_code", "state_id", "state_name")
         assert state_data.shape[0] == 60
 
-    def test_load_fips_msa_table(self):
-        gmpr = GeoMapper()
-        msa_data = gmpr._load_crosswalk(from_code="fips", to_code="msa")
+    def test_load_fips_msa_table(self, geomapper):
+        msa_data = geomapper.get_crosswalk(from_code="fips", to_code="msa")
         assert tuple(msa_data.columns) == ("fips", "msa")
 
-    def test_load_jhu_uid_fips_table(self):
-        gmpr = GeoMapper()
-        jhu_data = gmpr._load_crosswalk(from_code="jhu_uid", to_code="fips")
+    def test_load_jhu_uid_fips_table(self, geomapper):
+        jhu_data = geomapper.get_crosswalk(from_code="jhu_uid", to_code="fips")
         assert np.allclose(jhu_data.groupby("jhu_uid").sum(), 1.0)
 
-    def test_load_zip_hrr_table(self):
-        gmpr = GeoMapper()
-        zip_data = gmpr._load_crosswalk(from_code="zip", to_code="hrr")
+    def test_load_zip_hrr_table(self, geomapper):
+        zip_data = geomapper.get_crosswalk(from_code="zip", to_code="hrr")
         assert pd.api.types.is_string_dtype(zip_data["zip"])
         assert pd.api.types.is_string_dtype(zip_data["hrr"])
 
-    def test_megacounty(self):
-        gmpr = GeoMapper()
-        new_data = gmpr.fips_to_megacounty(self.mega_data, 6, 50)
+    def test_megacounty(self, geomapper):
+        new_data = geomapper.fips_to_megacounty(self.mega_data, 6, 50)
         assert (
             new_data[["count", "visits"]].sum()
             - self.mega_data[["count", "visits"]].sum()
         ).sum() < 1e-3
         with pytest.raises(ValueError):
-            new_data = gmpr.megacounty_creation(
+            new_data = geomapper.megacounty_creation(
                 self.mega_data_2, 6, 50, thr_col="_thr_col_roll"
             )
-        new_data = gmpr.fips_to_megacounty(
+        new_data = geomapper.fips_to_megacounty(
             self.mega_data, 6, 50, count_cols=["count", "visits"]
         )
         assert (
             new_data[["count"]].sum() - self.mega_data[["count"]].sum()
         ).sum() < 1e-3
 
-    def test_add_population_column(self):
-        gmpr = GeoMapper()
-        new_data = gmpr.add_population_column(self.fips_data_3, "fips")
+    def test_add_population_column(self, geomapper):
+        new_data = geomapper.add_population_column(self.fips_data_3, "fips")
         assert new_data.shape == (5, 5)
-        new_data = gmpr.add_population_column(self.zip_data, "zip")
+        new_data = geomapper.add_population_column(self.zip_data, "zip")
         assert new_data.shape == (6, 5)
         with pytest.raises(ValueError):
-            new_data = gmpr.add_population_column(self.zip_data, "hrr")
-        new_data = gmpr.add_population_column(self.fips_data_5, "fips")
+            new_data = geomapper.add_population_column(self.zip_data, "hrr")
+        new_data = geomapper.add_population_column(self.fips_data_5, "fips")
         assert new_data.shape == (4, 5)
-        new_data = gmpr.add_population_column(self.state_data, "state_code")
+        new_data = geomapper.add_population_column(self.state_data, "state_code")
         assert new_data.shape == (3, 3)
-        new_data = gmpr.add_population_column(self.hhs_data, "hhs")
+        new_data = geomapper.add_population_column(self.hhs_data, "hhs")
         assert new_data.shape == (3, 3)
-        new_data = gmpr.add_population_column(self.nation_data, "nation")
+        new_data = geomapper.add_population_column(self.nation_data, "nation")
         assert new_data.shape == (1, 3)
 
-    def test_add_geocode(self):
-        gmpr = GeoMapper()
-
+    def test_add_geocode(self, geomapper):
         # state_code -> nation
-        new_data = gmpr.add_geocode(self.zip_data, "zip", "state_code")
-        new_data2 = gmpr.add_geocode(new_data, "state_code", "nation")
+        new_data = geomapper.add_geocode(self.zip_data, "zip", "state_code")
+        new_data2 = geomapper.add_geocode(new_data, "state_code", "nation")
         assert new_data2["nation"].unique()[0] == "us"
 
         # state_code -> hhs
-        new_data = gmpr.add_geocode(self.zip_data, "zip", "state_code")
-        new_data2 = gmpr.add_geocode(new_data, "state_code", "hhs")
+        new_data = geomapper.add_geocode(self.zip_data, "zip", "state_code")
+        new_data2 = geomapper.add_geocode(new_data, "state_code", "hhs")
         assert new_data2["hhs"].unique().size == 2
 
         # state_name -> state_id
-        new_data = gmpr.replace_geocode(self.zip_data, "zip", "state_name")
-        new_data2 = gmpr.add_geocode(new_data, "state_name", "state_id")
+        new_data = geomapper.replace_geocode(self.zip_data, "zip", "state_name")
+        new_data2 = geomapper.add_geocode(new_data, "state_name", "state_id")
         assert new_data2.shape == (4, 5)
-        new_data2 = gmpr.replace_geocode(new_data, "state_name", "state_id", new_col="abbr")
+        new_data2 = geomapper.replace_geocode(new_data, "state_name", "state_id", new_col="abbr")
         assert "abbr" in new_data2.columns
 
         # fips -> nation
-        new_data = gmpr.replace_geocode(self.fips_data_5, "fips", "nation", new_col="NATION")
+        new_data = geomapper.replace_geocode(self.fips_data_5, "fips", "nation", new_col="NATION")
         pd.testing.assert_frame_equal(
             new_data,
             pd.DataFrame().from_dict(
@@ -259,7 +254,7 @@ class TestGeoMapper:
         )
 
         # zip -> nation
-        new_data = gmpr.replace_geocode(self.zip_data, "zip", "nation")
+        new_data = geomapper.replace_geocode(self.zip_data, "zip", "nation")
         pd.testing.assert_frame_equal(
             new_data,
             pd.DataFrame().from_dict(
@@ -277,15 +272,15 @@ class TestGeoMapper:
 
         # hrr -> nation
         with pytest.raises(ValueError):    
-            new_data = gmpr.replace_geocode(self.zip_data, "zip", "hrr")
-            new_data2 = gmpr.replace_geocode(new_data, "hrr", "nation")
+            new_data = geomapper.replace_geocode(self.zip_data, "zip", "hrr")
+            new_data2 = geomapper.replace_geocode(new_data, "hrr", "nation")
 
         # fips -> hrr (dropna=True/False check)
-        assert not gmpr.add_geocode(self.fips_data_3, "fips", "hrr").isna().any().any()
-        assert gmpr.add_geocode(self.fips_data_3, "fips", "hrr", dropna=False).isna().any().any()
+        assert not geomapper.add_geocode(self.fips_data_3, "fips", "hrr").isna().any().any()
+        assert geomapper.add_geocode(self.fips_data_3, "fips", "hrr", dropna=False).isna().any().any()
 
         # fips -> zip (date_col=None chech)
-        new_data = gmpr.replace_geocode(self.fips_data_5.drop(columns=["date"]), "fips", "hrr", date_col=None)
+        new_data = geomapper.replace_geocode(self.fips_data_5.drop(columns=["date"]), "fips", "hrr", date_col=None)
         pd.testing.assert_frame_equal(
             new_data,
             pd.DataFrame().from_dict(
@@ -298,7 +293,7 @@ class TestGeoMapper:
         )
 
         # fips -> hhs
-        new_data = gmpr.replace_geocode(self.fips_data_3.drop(columns=["date"]),
+        new_data = geomapper.replace_geocode(self.fips_data_3.drop(columns=["date"]),
                                         "fips", "hhs", date_col=None)
         pd.testing.assert_frame_equal(
             new_data,
@@ -312,7 +307,7 @@ class TestGeoMapper:
         )
 
         # zip -> hhs
-        new_data = gmpr.replace_geocode(self.zip_data, "zip", "hhs")
+        new_data = geomapper.replace_geocode(self.zip_data, "zip", "hhs")
         new_data = new_data.round(10)  # get rid of a floating point error with 99.00000000000001
         pd.testing.assert_frame_equal(
             new_data,
@@ -327,17 +322,15 @@ class TestGeoMapper:
             )
         )
 
-    def test_get_geos(self):
-        gmpr = GeoMapper()
-        assert gmpr.get_geo_values("nation") == {"us"}
-        assert gmpr.get_geo_values("hhs") == set(str(i) for i in range(1, 11))
-        assert len(gmpr.get_geo_values("fips")) == 3235
-        assert len(gmpr.get_geo_values("state_id")) == 60
-        assert len(gmpr.get_geo_values("zip")) == 32976
+    def test_get_geos(self, geomapper):
+        assert geomapper.get_geo_values("nation") == {"us"}
+        assert geomapper.get_geo_values("hhs") == set(str(i) for i in range(1, 11))
+        assert len(geomapper.get_geo_values("fips")) == 3235
+        assert len(geomapper.get_geo_values("state_id")) == 60
+        assert len(geomapper.get_geo_values("zip")) == 32976
 
-    def test_get_geos_within(self):
-        gmpr = GeoMapper()
-        assert len(gmpr.get_geos_within("us","state","nation")) == 60
-        assert len(gmpr.get_geos_within("al","county","state")) == 68
-        assert len(gmpr.get_geos_within("4","state","hhs")) == 8
-        assert gmpr.get_geos_within("4","state","hhs") =={'al', 'fl', 'ga', 'ky', 'ms', 'nc', "tn", "sc"}
+    def test_get_geos_within(self, geomapper):
+        assert len(geomapper.get_geos_within("us","state","nation")) == 60
+        assert len(geomapper.get_geos_within("al","county","state")) == 68
+        assert len(geomapper.get_geos_within("4","state","hhs")) == 8
+        assert geomapper.get_geos_within("4","state","hhs") =={'al', 'fl', 'ga', 'ky', 'ms', 'nc', "tn", "sc"}

--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -105,7 +105,7 @@ def merge_dfs_by_geos(usafacts_df, jhu_df, geo):
             jhu_df if jhu_df is None else jhu_df[jhu_df["geo_value"].str.startswith("72")])
     # For MSA and HRR level, they are the same
     elif geo == 'msa':
-        df = GMPR._load_crosswalk("fips", "msa") # pylint: disable=protected-access
+        df = GMPR.get_crosswalk("fips", "msa")
         puerto_rico_mask = df["fips"].str.startswith("72")
         puerto_rico_msas = df[puerto_rico_mask]["msa"].unique()
         combined_df = maybe_append(

--- a/google_symptoms/delphi_google_symptoms/geo.py
+++ b/google_symptoms/delphi_google_symptoms/geo.py
@@ -23,7 +23,7 @@ def generate_transition_matrix(geo_res):
         The first is a data frame for HRR regions and the second are MSA
         regions.
     """
-    map_df = gmpr._load_crosswalk("fips", geo_res)  # pylint: disable=protected-access
+    map_df = gmpr.get_crosswalk("fips", geo_res)
     # Add population as weights
     map_df = gmpr.add_population_column(map_df, "fips")
     if geo_res == "hrr":
@@ -58,7 +58,7 @@ def geo_map(df, geo_res):
         and columns for signal vals.
         The geo_id has been converted from fips to HRRs/MSAs
     """
-    if geo_res in set(["county", "state"]):
+    if geo_res in {"county", "state"}:
         return df
 
     map_df = generate_transition_matrix(geo_res)

--- a/quidel_covidtest/delphi_quidel_covidtest/geo_maps.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/geo_maps.py
@@ -38,11 +38,11 @@ def add_parent_state(data, geo_res, geo_key):
       population (since a msa/hrr may span multiple states)
     - map from county to the corresponding state
     """
-    fips_to_state = GMPR._load_crosswalk(from_code="fips", to_code="state")  # pylint: disable=protected-access
+    fips_to_state = GMPR.get_crosswalk(from_code="fips", to_code="state")
     if geo_res == "county":
         mix_map = fips_to_state[["fips", "state_id"]]  # pylint: disable=unsubscriptable-object
     else:
-        fips_to_geo_res = GMPR._load_crosswalk(from_code="fips", to_code=geo_res)  # pylint: disable=protected-access
+        fips_to_geo_res = GMPR.get_crosswalk(from_code="fips", to_code=geo_res)
         mix_map = fips_to_geo_res[["fips", geo_res]].merge(
                 fips_to_state[["fips", "state_id"]],  # pylint: disable=unsubscriptable-object
                 on="fips",


### PR DESCRIPTION
### Description
Update the Geomapper class to pre-load the crosswalk data on initialization.

This change was suggested by @chinandrew. It closes #282 by loading all of the data when the class is initialized. This loading is quick enough to not significantly slow down class creation:
![37556AD6-3553-4F7A-A268-61A56053D314](https://user-images.githubusercontent.com/7526291/132269157-3bcde516-a956-42fc-aecf-4f04bffd3b46.png)


### Changelog
- Change crosswalk and geo value sets to load when the class is initialized
- Add a public method `get_crosswalk` for directly accessing the crosswalk tables. This method is now used within combo_cases, quidel, and google_symptoms.
- Use a fixture in the tests to prevent from loading the data for each individual test

Note that this PR is branched off of #1228, to see just the diff for this PR, click [here](https://github.com/cmu-delphi/covidcast-indicators/pull/1232/commits/6a4480530e4b21e9af4961ff89e8f29fb3b3d9db).
