### PR TITLE
Correctly ignore all receiving/*.csv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 params.json
 
 # Do not commit output files
-receiving/*.csv
+**/receiving/*.csv
 
 # Do not commit hidden macOS files
 .DS_Store


### PR DESCRIPTION
### Description
Currently not all CSV files in receiving folders get ignored. Updating the main .gitignore to do that.

### Changelog
Change `receiving/*.csv` to `**/receiving/*.csv`.
