### PR TITLE
Make survey tests robust to not having a restore cache

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -48,7 +48,7 @@ jobs:
             ${{ runner.os }}-r-facebook-survey-
       - name: Install R dependencies
         run: |
-          if ( packageVersion("readr") != "1.4.0" ) {
+          if ( !require("readr") || packageVersion("readr") != "1.4.0" ) {
             install.packages("devtools")
             devtools::install_version("readr", version = "1.4.0")
           }


### PR DESCRIPTION
### Description
Make survey tests not fail when cache containing installed R packages from previous test run is not loaded.

### Changelog
- Check if readr is installed before checking its version, to avoid "there is no package called readr" errors.

### Fixes 
When no cache is loaded, the call `packageVersion("readr")` errors out since the `readr` package doesn't exist yet.