### PR TITLE
Only install `remotes` if not in cache

### DIFF
--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -52,8 +52,11 @@ jobs:
             install.packages("devtools")
             devtools::install_version("readr", version = "1.4.0")
           }
-          install.packages("remotes")
-          remotes::update_packages(c("rcmdcheck", "mockr"), upgrade="always")
+
+          if ( !require("remotes") ) {
+            install.packages("remotes")
+          }
+          remotes::update_packages(c("rcmdcheck", "mockr", "remotes"), upgrade="always")
           dependency_list <- remotes::dev_package_deps(dependencies=TRUE)
           remotes::update_packages(dependency_list$package[dependency_list$package != "readr"], upgrade="always")
         shell: Rscript {0}

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -43,12 +43,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-facebook-survey-${{ steps.get-date.outputs.date }}
+          key: ${{ runner.os }}-r-facebook-survey-${{ steps.get-date.outputs.date }}-testcache
           restore-keys: |
-            ${{ runner.os }}-r-facebook-survey-
+            ${{ runner.os }}-r-facebook-survey-testcache
       - name: Install R dependencies
         run: |
-          if ( packageVersion("readr") != "1.4.0" ) {
+          if ( !require("readr") || packageVersion("readr") != "1.4.0" ) {
             install.packages("devtools")
             devtools::install_version("readr", version = "1.4.0")
           }

--- a/.github/workflows/r-ci.yml
+++ b/.github/workflows/r-ci.yml
@@ -43,12 +43,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-facebook-survey-${{ steps.get-date.outputs.date }}-testcache
+          key: ${{ runner.os }}-r-facebook-survey-${{ steps.get-date.outputs.date }}
           restore-keys: |
-            ${{ runner.os }}-r-facebook-survey-testcache
+            ${{ runner.os }}-r-facebook-survey-
       - name: Install R dependencies
         run: |
-          if ( !require("readr") || packageVersion("readr") != "1.4.0" ) {
+          if ( packageVersion("readr") != "1.4.0" ) {
             install.packages("devtools")
             devtools::install_version("readr", version = "1.4.0")
           }


### PR DESCRIPTION
### Description
Check if `remotes` package is already available before installing. Expect to reduce workflow setup time.

### Changelog
- Check if `remotes` package is installed via `require`
- Add `remotes` to upgrade list.