### PR TITLE
Set E2 to integer on read

### DIFF
--- a/facebook/delphiFacebook/R/responses.R
+++ b/facebook/delphiFacebook/R/responses.R
@@ -129,7 +129,10 @@ load_response_one <- function(input_filename, params, contingency_run) {
                            Q79 = col_integer(),
                            Q80 = col_integer(),
                            I5 = col_character(),
-                           I7 = col_character()),
+                           I7 = col_character(),
+                           E2_1 = col_integer(),
+                           E2_2 = col_integer()
+                         ),
                          locale = locale(grouping_mark = ""))
   if (nrow(input_data) == 0) {
     return(tibble())


### PR DESCRIPTION
### Description
Set read type for E2 schooling question. In some wave 11 input files, `read_csv` is trying to read as boolean.

### Changelog
- List E2_1 and E2_2 as integer in `read_csv` specs