### PR TITLE
Switch indicators from logging to delphi_utils structured logger

### DIFF
--- a/cdc_covidnet/delphi_cdc_covidnet/covidnet.py
+++ b/cdc_covidnet/delphi_cdc_covidnet/covidnet.py
@@ -6,7 +6,7 @@ Created: 2020-06-12
 """
 
 import json
-import logging
+from logging import Logger
 import os
 from typing import Tuple, List
 from multiprocessing import cpu_count, Pool
@@ -100,7 +100,7 @@ class CovidNet:
 
     @staticmethod
     def download_all_hosp_data(
-            mappings_file: str, cache_path: str, parallel: bool = False
+            mappings_file: str, cache_path: str, logger: Logger, parallel: bool = False
         ) -> List[str]:
         """
         Download hospitalization data for all states listed in the mappings JSON file to disk.
@@ -146,7 +146,7 @@ class CovidNet:
         else:
             for args in state_args:
                 CovidNet.download_hosp_data(*args)
-                logging.debug("Downloading for nid=%s, cid=%s", args[0], args[1])
+                logger.debug("Downloading for nid=%s, cid=%s", args[0], args[1])
 
         return state_files
 

--- a/cdc_covidnet/delphi_cdc_covidnet/run.py
+++ b/cdc_covidnet/delphi_cdc_covidnet/run.py
@@ -4,11 +4,12 @@
 This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m delphi_cdc_covidnet`.
 """
-import logging
 from datetime import datetime
 from os import remove
 from os.path import join
 from typing import Dict, Any
+
+from delphi_utils import get_structured_logger
 
 from .covidnet import CovidNet
 from .update_sensor import update_sensor
@@ -32,7 +33,9 @@ def run_module(params: Dict[str, Dict[str, Any]]):
             - "wip_signal": list of str or bool, to be passed to delphi_utils.add_prefix.
             - "input_cache_dir": str, directory to download source files.
     """
-    logging.basicConfig(level=logging.DEBUG)
+    logger = get_structured_logger(
+        __name__, filename=params["common"].get("log_filename"),
+        log_exceptions=params["common"].get("log_exceptions", True))
 
     start_date = datetime.strptime(params["indicator"]["start_date"], "%Y-%m-%d")
 
@@ -42,15 +45,15 @@ def run_module(params: Dict[str, Dict[str, Any]]):
     else:
         end_date = datetime.strptime(params["indicator"]["end_date"], "%Y-%m-%d")
 
-    logging.info("start date:\t%s", start_date.date())
-    logging.info("end date:\t%s", end_date.date())
+    logger.info("start date:\t%s", start_date.date())
+    logger.info("end date:\t%s", end_date.date())
 
-    logging.info("outpath:\t%s", params["common"]["export_dir"])
-    logging.info("parallel:\t%s", params["indicator"]["parallel"])
+    logger.info("outpath:\t%s", params["common"]["export_dir"])
+    logger.info("parallel:\t%s", params["indicator"]["parallel"])
 
     # Only geo is state, and no weekday adjustment for now
     # COVID-NET data is by weeks anyway, not daily
-    logging.info("starting state, no adj")
+    logger.info("starting state, no adj")
 
     # Download latest COVID-NET files into the cache directory first
     mappings_file = join(params["indicator"]["input_cache_dir"], "init.json")
@@ -58,7 +61,8 @@ def run_module(params: Dict[str, Dict[str, Any]]):
     _, mmwr_info, _ = CovidNet.read_mappings(mappings_file)
     state_files = CovidNet.download_all_hosp_data(
         mappings_file, params["indicator"]["input_cache_dir"],
-        parallel=params["indicator"]["parallel"])
+        parallel=params["indicator"]["parallel"],
+        logger=logger)
 
     update_sensor(
         state_files,
@@ -73,4 +77,4 @@ def run_module(params: Dict[str, Dict[str, Any]]):
     for state_file in state_files:
         remove(state_file)
 
-    logging.info("finished all")
+    logger.info("finished all")

--- a/cdc_covidnet/tests/test_covidnet.py
+++ b/cdc_covidnet/tests/test_covidnet.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from os.path import join, exists
 from tempfile import TemporaryDirectory
 
@@ -7,6 +8,7 @@ import numpy as np
 from delphi_cdc_covidnet.api_config import APIConfig
 from delphi_cdc_covidnet.covidnet import CovidNet
 
+TEST_LOGGER = logging.getLogger()
 
 class TestCovidNet:
 
@@ -65,14 +67,14 @@ class TestCovidNet:
 
             # Non-parallel
             state_files = CovidNet.download_all_hosp_data(
-                init_file, temp_dir, parallel=False)
+                init_file, temp_dir, TEST_LOGGER, parallel=False)
             assert len(state_files) == num_states
             for state_file in state_files:
                 assert exists(state_file)
 
             # Parallel
             state_files_par = CovidNet.download_all_hosp_data(
-                init_file, temp_dir, parallel=True)
+                init_file, temp_dir, TEST_LOGGER, parallel=True)
             assert set(state_files) == set(state_files_par)
             assert len(state_files_par) == num_states
             for state_file in state_files_par:

--- a/changehc/delphi_changehc/run.py
+++ b/changehc/delphi_changehc/run.py
@@ -173,7 +173,8 @@ def run_module(params: Dict[str, Dict[str, Any]]):
                     weekday,
                     numtype,
                     params["indicator"]["se"],
-                    params["indicator"]["wip_signal"]
+                    params["indicator"]["wip_signal"],
+                    logger
                 )
                 if numtype == "covid":
                     data = load_combined_data(file_dict["denom"],

--- a/changehc/delphi_changehc/sensor.py
+++ b/changehc/delphi_changehc/sensor.py
@@ -87,7 +87,7 @@ class CHCSensor:
         return new_num, new_den
 
     @staticmethod
-    def fit(y_data, first_sensor_date, geo_id, num_col="num", den_col="den"):
+    def fit(y_data, first_sensor_date, geo_id, logger, num_col="num", den_col="den"):
         """Fitting routine.
 
         Args:
@@ -121,7 +121,7 @@ class CHCSensor:
         se_valid = valid_rates.eval('sqrt(rate * (1 - rate) / den)')
         rate_data['se'] = se_valid
 
-        logging.debug("{0}: {1:.3f},[{2:.3f}]".format(
+        logger.debug("{0}: {1:.3f},[{2:.3f}]".format(
             geo_id, rate_data['rate'][-1], rate_data['se'][-1]
         ))
         return {"geo_id": geo_id,

--- a/changehc/delphi_changehc/update_sensor.py
+++ b/changehc/delphi_changehc/update_sensor.py
@@ -20,7 +20,7 @@ from .sensor import CHCSensor
 from .weekday import Weekday
 
 
-def write_to_csv(df, geo_level, write_se, day_shift, out_name, output_path=".", start_date=None, end_date=None):
+def write_to_csv(df, geo_level, write_se, day_shift, out_name, logger, output_path=".", start_date=None, end_date=None):
     """Write sensor values to csv.
 
     Args:
@@ -47,7 +47,7 @@ def write_to_csv(df, geo_level, write_se, day_shift, out_name, output_path=".", 
     assert df[suspicious_se_mask].empty, " se contains suspiciously large values"
     assert not df["se"].isna().any(), " se contains nan values"
     if write_se:
-        logging.info("========= WARNING: WRITING SEs TO {0} =========".format(out_name))
+        logger.info("========= WARNING: WRITING SEs TO {0} =========".format(out_name))
     else:
         df.loc[:, "se"] = np.nan
 
@@ -55,7 +55,7 @@ def write_to_csv(df, geo_level, write_se, day_shift, out_name, output_path=".", 
     suspicious_val_mask = df["val"].gt(90)
     if not df[suspicious_val_mask].empty:
         for geo in df.loc[suspicious_val_mask, "geo_id"]:
-            logging.warning("value suspiciously high, {0}: {1}".format(
+            logger.warning("value suspiciously high, {0}: {1}".format(
                 geo, out_name
             ))
 
@@ -68,10 +68,10 @@ def write_to_csv(df, geo_level, write_se, day_shift, out_name, output_path=".", 
         sensor=out_name,
         write_empty_days=True
     )
-    logging.debug("wrote {0} rows for {1} {2}".format(
+    logger.debug("wrote {0} rows for {1} {2}".format(
         df.size, df["geo_id"].unique().size, geo_level
     ))
-    logging.debug("wrote files to {0}".format(output_path))
+    logger.debug("wrote files to {0}".format(output_path))
     return dates
 
 
@@ -87,7 +87,8 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
                  weekday,
                  numtype,
                  se,
-                 wip_signal):
+                 wip_signal,
+                 logger):
         """Init Sensor Updator.
 
         Args:
@@ -100,7 +101,9 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
             numtype: type of count data used, one of ["covid", "cli"]
             se: boolean to write out standard errors, if true, use an obfuscated name
             wip_signal: Prefix for WIP signals
+            logger: the structured logger
         """
+        self.logger = logger
         self.startdate, self.enddate, self.dropdate = [
             pd.to_datetime(t) for t in (startdate, enddate, dropdate)]
         # handle dates
@@ -149,7 +152,7 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
         geo = self.geo
         gmpr = GeoMapper()
         if geo not in {"county", "state", "msa", "hrr", "nation", "hhs"}:
-            logging.error("{0} is invalid, pick one of 'county', "
+            self.logger.error("{0} is invalid, pick one of 'county', "
                           "'state', 'msa', 'hrr', 'hss','nation'".format(geo))
             return False
         if geo == "county":
@@ -201,12 +204,12 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
                 sub_data.reset_index(level=0,inplace=True)
                 if self.weekday:
                     sub_data = Weekday.calc_adjustment(wd_params, sub_data)
-                res = CHCSensor.fit(sub_data, self.burnindate, geo_id)
+                res = CHCSensor.fit(sub_data, self.burnindate, geo_id, self.logger)
                 res = pd.DataFrame(res).loc[final_sensor_idxs]
                 dfs.append(res)
         else:
             n_cpu = min(10, cpu_count())
-            logging.debug("starting pool with {0} workers".format(n_cpu))
+            self.logger.debug("starting pool with {0} workers".format(n_cpu))
             with Pool(n_cpu) as pool:
                 pool_results = []
                 for geo_id, sub_data in data_frame.groupby(level=0,as_index=False):
@@ -215,7 +218,7 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
                         sub_data = Weekday.calc_adjustment(wd_params, sub_data)
                     pool_results.append(
                         pool.apply_async(
-                            CHCSensor.fit, args=(sub_data, self.burnindate, geo_id,),
+                            CHCSensor.fit, args=(sub_data, self.burnindate, geo_id, self.logger),
                         )
                     )
                 pool_results = [proc.get() for proc in pool_results]
@@ -244,7 +247,8 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
                 write_se=self.se,
                 day_shift=Config.DAY_SHIFT,
                 out_name=signal,
-                output_path=output_path
+                output_path=output_path,
+                logger=self.logger
             )
             if len(dates) > 0:
                 stats.append((max(dates), len(dates)))

--- a/changehc/tests/test_sensor.py
+++ b/changehc/tests/test_sensor.py
@@ -1,4 +1,5 @@
 # standard
+import logging
 
 import numpy as np
 import numpy.random as nr
@@ -19,6 +20,7 @@ PARAMS = {
 COVID_FILEPATH = PARAMS["indicator"]["input_covid_file"]
 DENOM_FILEPATH = PARAMS["indicator"]["input_denom_file"]
 DROP_DATE = pd.to_datetime(PARAMS["indicator"]["drop_date"])
+TEST_LOGGER = logging.getLogger()
 
 class TestLoadData:
     combined_data = load_combined_data(DENOM_FILEPATH, COVID_FILEPATH, DROP_DATE,
@@ -56,7 +58,7 @@ class TestLoadData:
         for fips in all_fips:
             sub_data = self.combined_data.loc[fips]
             sub_data = sub_data.reindex(date_range, fill_value=0)
-            res0 = CHCSensor.fit(sub_data, date_range[0], fips)
+            res0 = CHCSensor.fit(sub_data, date_range[0], fips, TEST_LOGGER)
 
             if np.isnan(res0["rate"]).all():
                 assert res0["incl"].sum() == 0

--- a/changehc/tests/test_update_sensor.py
+++ b/changehc/tests/test_update_sensor.py
@@ -1,4 +1,5 @@
 # standard
+import logging
 from copy import deepcopy
 import os
 from os.path import join, exists
@@ -27,6 +28,7 @@ COVID_FILEPATH = PARAMS["indicator"]["input_covid_file"]
 DENOM_FILEPATH = PARAMS["indicator"]["input_denom_file"]
 DROP_DATE = pd.to_datetime(PARAMS["indicator"]["drop_date"])
 OUTPATH="test_data/"
+TEST_LOGGER = logging.getLogger()
 
 class TestCHCSensorUpdator:
     """Tests for updating the sensors."""
@@ -53,7 +55,8 @@ class TestCHCSensorUpdator:
             self.weekday,
             self.numtype,
             self.se,
-            ""
+            "",
+            TEST_LOGGER
         )
         ## Test init
         assert su_inst.startdate.month == 2
@@ -77,7 +80,8 @@ class TestCHCSensorUpdator:
                 self.weekday,
                 self.numtype,
                 self.se,
-                ""
+                "",
+               TEST_LOGGER
             )
             su_inst.shift_dates()
             test_data = pd.DataFrame({
@@ -103,7 +107,8 @@ class TestCHCSensorUpdator:
                 self.weekday,
                 self.numtype,
                 self.se,
-                ""
+                "",
+                TEST_LOGGER
             )
             # As of 3/3/21 (40c258a), this set of data has county outputting data, state and hhs not
             # outputting data, and nation outputting data, which is undesirable. Ideal behaviour
@@ -149,7 +154,8 @@ class TestWriteToCsv:
             write_se=False,
             day_shift=CONFIG.DAY_SHIFT,
             out_name="name_of_signal",
-            output_path=td.name
+            output_path=td.name,
+            logger=TEST_LOGGER
         )
 
         # check outputs
@@ -203,7 +209,8 @@ class TestWriteToCsv:
             write_se=True,
             day_shift=CONFIG.DAY_SHIFT,
             out_name="name_of_signal",
-            output_path=td.name
+            output_path=td.name,
+            logger=TEST_LOGGER
         )
 
         # check outputs
@@ -243,7 +250,8 @@ class TestWriteToCsv:
                 write_se=False,
                 day_shift=CONFIG.DAY_SHIFT,
                 out_name="name_of_signal",
-                output_path=td.name
+                output_path=td.name,
+                logger=TEST_LOGGER
             )
 
         # nan se for included loc-date
@@ -258,7 +266,8 @@ class TestWriteToCsv:
                 write_se=True,
                 day_shift=CONFIG.DAY_SHIFT,
                 out_name="name_of_signal",
-                output_path=td.name
+                output_path=td.name,
+                logger=TEST_LOGGER
             )
 
         # large se value
@@ -273,7 +282,8 @@ class TestWriteToCsv:
                 write_se=True,
                 day_shift=CONFIG.DAY_SHIFT,
                 out_name="name_of_signal",
-                output_path=td.name
+                output_path=td.name,
+                logger=TEST_LOGGER
             )
 
         td.cleanup()

--- a/doctor_visits/delphi_doctor_visits/run.py
+++ b/doctor_visits/delphi_doctor_visits/run.py
@@ -6,9 +6,10 @@ when the module is run with `python -m delphi_doctor_visits`.
 """
 
 # standard packages
-import logging
 from datetime import datetime, timedelta
 from pathlib import Path
+
+from delphi_utils import get_structured_logger
 
 # first party
 from .update_sensor import update_sensor, write_to_csv
@@ -37,7 +38,9 @@ def run_module(params):
             - "obfuscated_prefix": str, prefix for signal name if write_se is True.
             - "parallel": bool, whether to update sensor in parallel.
     """
-    logging.basicConfig(level=logging.DEBUG)
+    logger = get_structured_logger(
+        __name__, filename=params["common"].get("log_filename"),
+        log_exceptions=params["common"].get("log_exceptions", True))
 
     ## get end date from input file
     # the filename is expected to be in the format:
@@ -61,30 +64,30 @@ def run_module(params):
     startdate_dt = enddate_dt - timedelta(days=n_backfill_days)
     enddate = str(enddate_dt.date())
     startdate = str(startdate_dt.date())
-    logging.info("drop date:\t\t%s", dropdate)
-    logging.info("first sensor date:\t%s", startdate)
-    logging.info("last sensor date:\t%s", enddate)
-    logging.info("n_backfill_days:\t%s", n_backfill_days)
-    logging.info("n_waiting_days:\t%s", n_waiting_days)
+    logger.info("drop date:\t\t%s", dropdate)
+    logger.info("first sensor date:\t%s", startdate)
+    logger.info("last sensor date:\t%s", enddate)
+    logger.info("n_backfill_days:\t%s", n_backfill_days)
+    logger.info("n_waiting_days:\t%s", n_waiting_days)
 
     ## geographies
     geos = ["state", "msa", "hrr", "county", "hhs", "nation"]
 
 
     ## print out other vars
-    logging.info("outpath:\t\t%s", export_dir)
-    logging.info("parallel:\t\t%s", params["indicator"]["parallel"])
-    logging.info("weekday:\t\t%s", params["indicator"]["weekday"])
-    logging.info("write se:\t\t%s", se)
-    logging.info("obfuscated prefix:\t%s", prefix)
+    logger.info("outpath:\t\t%s", export_dir)
+    logger.info("parallel:\t\t%s", params["indicator"]["parallel"])
+    logger.info("weekday:\t\t%s", params["indicator"]["weekday"])
+    logger.info("write se:\t\t%s", se)
+    logger.info("obfuscated prefix:\t%s", prefix)
 
     ## start generating
     for geo in geos:
         for weekday in params["indicator"]["weekday"]:
             if weekday:
-                logging.info("starting %s, weekday adj", geo)
+                logger.info("starting %s, weekday adj", geo)
             else:
-                logging.info("starting %s, no adj", geo)
+                logger.info("starting %s, no adj", geo)
             sensor = update_sensor(
                 filepath=params["indicator"]["input_file"],
                 startdate=startdate,
@@ -93,10 +96,11 @@ def run_module(params):
                 geo=geo,
                 parallel=params["indicator"]["parallel"],
                 weekday=weekday,
-                se=params["indicator"]["se"]
+                se=params["indicator"]["se"],
+                logger=logger,
             )
             if sensor is None:
-                logging.error("No sensors calculated, no output will be produced")
+                logger.error("No sensors calculated, no output will be produced")
                 continue
             # write out results
             out_name = "smoothed_adj_cli" if weekday else "smoothed_cli"
@@ -104,8 +108,8 @@ def run_module(params):
                 assert prefix is not None, "template has no obfuscated prefix"
                 out_name = prefix + "_" + out_name
 
-            write_to_csv(sensor, geo, se, out_name, export_dir)
-            logging.debug(f"wrote files to {export_dir}")
-        logging.info("finished %s", geo)
+            write_to_csv(sensor, geo, se, out_name, logger, export_dir)
+            logger.debug(f"wrote files to {export_dir}")
+        logger.info("finished %s", geo)
 
-    logging.info("finished all")
+    logger.info("finished all")

--- a/doctor_visits/delphi_doctor_visits/sensor.py
+++ b/doctor_visits/delphi_doctor_visits/sensor.py
@@ -6,9 +6,6 @@ Created: 2020-04-17
 
 """
 
-# standard packages
-import logging
-
 # third party
 import numpy as np
 import pandas as pd
@@ -162,7 +159,8 @@ class DoctorVisitsSensor:
             geo_id,
             recent_min_visits,
             min_recent_obs,
-            jeffreys):
+            jeffreys,
+            logger):
         """Fitting routine.
 
         Args:
@@ -217,7 +215,7 @@ class DoctorVisitsSensor:
             # if all rates are zero, don't bother
             if code_vals.sum() == 0:
                 if jeffreys:
-                    logging.error("p is 0 even though we used Jefferys estimate")
+                    logger.error("p is 0 even though we used Jefferys estimate")
                 new_rates.append(np.zeros((n_dates,)))
                 continue
 
@@ -240,7 +238,7 @@ class DoctorVisitsSensor:
         se[include] = np.sqrt(
             np.divide((new_rates[include] * (1 - new_rates[include])), den[include]))
 
-        logging.debug(f"{geo_id}: {new_rates[-1]:.3f},[{se[-1]:.3f}]")
+        logger.debug(f"{geo_id}: {new_rates[-1]:.3f},[{se[-1]:.3f}]")
 
         included_indices = [x for x in final_sensor_idxs if include[x]]
 

--- a/doctor_visits/delphi_doctor_visits/update_sensor.py
+++ b/doctor_visits/delphi_doctor_visits/update_sensor.py
@@ -9,7 +9,6 @@ Modified:
 """
 
 # standard packages
-import logging
 from datetime import timedelta
 from multiprocessing import Pool, cpu_count
 
@@ -24,7 +23,7 @@ from .sensor import DoctorVisitsSensor
 from .weekday import Weekday
 
 
-def write_to_csv(output_df: pd.DataFrame, geo_level, se, out_name, output_path="."):
+def write_to_csv(output_df: pd.DataFrame, geo_level, se, out_name, logger, output_path="."):
     """Write sensor values to csv.
 
     Args:
@@ -34,7 +33,7 @@ def write_to_csv(output_df: pd.DataFrame, geo_level, se, out_name, output_path="
       output_path: outfile path to write the csv (default is current directory)
     """
     if se:
-        logging.info(f"========= WARNING: WRITING SEs TO {out_name} =========")
+        logger.info(f"========= WARNING: WRITING SEs TO {out_name} =========")
 
     out_n = 0
     for d in set(output_df["date"]):
@@ -64,12 +63,12 @@ def write_to_csv(output_df: pd.DataFrame, geo_level, se, out_name, output_path="
                     outfile.write(
                         "%s,%f,%s,%s,%s\n" % (geo_id, sensor, "NA", "NA", "NA"))
                 out_n += 1
-    logging.debug(f"wrote {out_n} rows for {geo_level}")
+    logger.debug(f"wrote {out_n} rows for {geo_level}")
 
 
 def update_sensor(
         filepath, startdate, enddate, dropdate, geo, parallel,
-        weekday, se
+        weekday, se, logger
 ):
     """Generate sensor values.
 
@@ -82,6 +81,7 @@ def update_sensor(
       parallel: boolean to run the sensor update in parallel
       weekday: boolean to adjust for weekday effects
       se: boolean to write out standard errors, if true, use an obfuscated name
+      logger: the structured logger
     """
     # as of 2020-05-11, input file expected to have 10 columns
     # id cols: ServiceDate, PatCountyFIPS, PatAgeGroup, Pat HRR ID/Pat HRR Name
@@ -125,7 +125,7 @@ def update_sensor(
         (burn_in_dates >= startdate) & (burn_in_dates <= enddate))[0][:len(sensor_dates)]
 
     # handle if we need to adjust by weekday
-    params = Weekday.get_params(data) if weekday else None
+    params = Weekday.get_params(data, logger) if weekday else None
     if weekday and np.any(np.all(params == 0,axis=1)):
         # Weekday correction failed for at least one count type
         return None
@@ -155,13 +155,14 @@ def update_sensor(
                 geo_id,
                 Config.MIN_RECENT_VISITS,
                 Config.MIN_RECENT_OBS,
-                jeffreys
+                jeffreys,
+                logger
             )
             out.append(res)
 
     else:
         n_cpu = min(10, cpu_count())
-        logging.debug(f"starting pool with {n_cpu} workers")
+        logger.debug(f"starting pool with {n_cpu} workers")
 
         with Pool(n_cpu) as pool:
             pool_results = []
@@ -182,6 +183,7 @@ def update_sensor(
                             Config.MIN_RECENT_VISITS,
                             Config.MIN_RECENT_OBS,
                             jeffreys,
+                            logger
                         ),
                     )
                 )

--- a/doctor_visits/delphi_doctor_visits/weekday.py
+++ b/doctor_visits/delphi_doctor_visits/weekday.py
@@ -4,8 +4,7 @@ Weekday effects (code from Aaron Rumack).
 Created: 2020-05-06
 """
 
-# standard packages
-import logging
+
 
 # third party
 import cvxpy as cp
@@ -19,7 +18,7 @@ class Weekday:
     """Class to handle weekday effects."""
 
     @staticmethod
-    def get_params(data):
+    def get_params(data, logger):
         r"""Correct a signal estimated as numerator/denominator for weekday effects.
 
         The ordinary estimate would be numerator_t/denominator_t for each time point
@@ -98,7 +97,7 @@ class Weekday:
                     pass
             else:
                 # Leaving params[i,:] = 0 is equivalent to not performing weekday correction
-                logging.error("Unable to calculate weekday correction")
+                logger.error("Unable to calculate weekday correction")
 
         return params
 

--- a/doctor_visits/tests/test_update_sensor.py
+++ b/doctor_visits/tests/test_update_sensor.py
@@ -1,8 +1,10 @@
 """Tests for update_sensor.py."""
-
+import logging
 import pandas as pd
 
 from delphi_doctor_visits.update_sensor import update_sensor
+
+TEST_LOGGER = logging.getLogger()
 
 class TestUpdateSensor:
     def test_update_sensor(self):
@@ -14,7 +16,8 @@ class TestUpdateSensor:
             geo="state",
             parallel=False,
             weekday=False,
-            se=False
+            se=False,
+            logger=TEST_LOGGER,
         )
 
         comparison = pd.read_csv("./comparison/update_sensor/all.csv", parse_dates=["date"])


### PR DESCRIPTION
### Description
CDC Covidnet, CHNG, and DV were using the standard library logger. This pr switches them to use the structured logger created by delphi_utils.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Refactor indicators to use structured logger, passing it in to functions where necessary.

