### PR TITLE
Route validator to validator_dir

### DIFF
--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -4,7 +4,7 @@ import importlib
 from typing import Any, Callable, Dict, Optional
 from .archive import ArchiveDiffer, archiver_from_params
 from .logger import get_structured_logger
-from .utils import read_params
+from .utils import read_params, transfer_files
 from .validator.validate import Validator
 from .validator.run import validator_from_params
 
@@ -44,8 +44,11 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
         validation_report.log(get_structured_logger(
             name = indicator_fn.__module__,
             filename=params["common"].get("log_filename", None)))
-    if archiver and (not validator or validation_report.success()):
-        archiver.run()
+    if (not validator or validation_report.success()):
+        transfer_files()
+        if archiver:
+            archiver.run()
+
 
 
 if __name__ == "__main__":

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -1,8 +1,8 @@
 """Read parameter files containing configuration information."""
 # -*- coding: utf-8 -*-
 from json import load,dump
-from os.path import exists
-from shutil import copyfile
+from shutil import copyfile, move
+import os
 import sys
 
 def read_params():
@@ -11,7 +11,7 @@ def read_params():
     If the file does not exist, it copies the file 'params.json.template' to
     'params.json' and then reads the file.
     """
-    if not exists("params.json"):
+    if not os.path.exists("params.json"):
         copyfile("params.json.template", "params.json")
 
     with open("params.json", "r") as json_file:
@@ -87,3 +87,12 @@ Usage:
         with open("params.json", "w") as f:
             dump(params, f, sort_keys=True, indent=2)
         print(f"Updated {n} items")
+
+def transfer_files():
+    """Transfer files to prepare for acquisition."""
+    params = read_params()
+    validation_dir = params["common"].get("validation_dir", None)
+    export_dir = params["common"].get("export_dir", None)
+    files_to_export = os.listdir(validation_dir)
+    for file_name in files_to_export:
+        move(os.path.join(validation_dir, file_name), export_dir)

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -56,12 +56,12 @@ def make_date_filter(start_date, end_date):
     return custom_date_filter
 
 
-def load_all_files(export_dir, start_date, end_date):
+def load_all_files(validation_dir, start_date, end_date):
     """Load all files in a directory.
 
     Parameters
     ----------
-    export_dir: str
+    validation_dir: str
         directory from which to load files
 
     Returns
@@ -69,11 +69,11 @@ def load_all_files(export_dir, start_date, end_date):
     loaded_data: List[Tuple(str, re.match, pd.DataFrame)]
         triples of filenames, filename matches with the geo regex, and the data from the file
     """
-    export_files = read_filenames(export_dir)
+    export_files = read_filenames(validation_dir)
     date_filter = make_date_filter(start_date, end_date)
 
     # Make list of tuples of CSV names and regex match objects.
-    return [(f, m, load_csv(join(export_dir, f))) for (f, m) in export_files if date_filter(m)]
+    return [(f, m, load_csv(join(validation_dir, f))) for (f, m) in export_files if date_filter(m)]
 
 
 def read_filenames(path):

--- a/_delphi_utils_python/delphi_utils/validator/validate.py
+++ b/_delphi_utils_python/delphi_utils/validator/validate.py
@@ -21,7 +21,7 @@ class Validator:
             - params: dictionary of user settings read from params.json file; if empty, defaults
                 will be used
         """
-        self.export_dir = params["common"]["export_dir"]
+        self.validation_dir = params["common"]["validation_dir"]
 
         assert "validation" in params, "params must have a top-level 'validation' object to run "\
             "validation"
@@ -49,13 +49,13 @@ class Validator:
         Run all data checks.
 
         Arguments:
-            - export_dir: path to data CSVs
+            - validation_dir: path to data CSVs
 
         Returns:
             - ValidationReport collating the validation outcomes
         """
         report = ValidationReport(self.suppressed_errors, self.data_source, self.dry_run)
-        frames_list = load_all_files(self.export_dir, self.time_window.start_date,
+        frames_list = load_all_files(self.validation_dir, self.time_window.start_date,
                                      self.time_window.end_date)
         self.static_validation.validate(frames_list, report)
         all_frames = aggregate_frames(frames_list)

--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -1,6 +1,7 @@
 {
   "common": {
     "export_dir": "/common/covidcast/receiving/google-symptoms",
+    "validation_dir": "./receiving",
     "log_filename": "/var/log/indicators/google_symptoms.log"
   },
   "indicator": {

--- a/google_symptoms/delphi_google_symptoms/run.py
+++ b/google_symptoms/delphi_google_symptoms/run.py
@@ -118,7 +118,7 @@ def run_module(params):
                 continue
             exported_csv_dates = create_export_csv(
                 df,
-                validation_dir=validation_dir,
+                export_dir=validation_dir,
                 start_date=SMOOTHERS_MAP[smoother][1](export_start_date),
                 metric=metric.lower(),
                 geo_res=geo_res,

--- a/google_symptoms/delphi_google_symptoms/run.py
+++ b/google_symptoms/delphi_google_symptoms/run.py
@@ -33,7 +33,7 @@ def run_module(params):
     params
         Dictionary containing indicator configuration. Expected to have the following structure:
     - "common":
-        - "export_dir": str, directory to write output
+        - "validation_dir": str, directory to write output
         - "log_exceptions" (optional): bool, whether to log exceptions to file
         - "log_filename" (optional): str, name of file to write logs
     - "indicator":
@@ -54,7 +54,7 @@ def run_module(params):
             "export_end_date", datetime.strftime(date.today(), "%Y-%m-%d")
         ), "%Y-%m-%d")
 
-    export_dir = params["common"]["export_dir"]
+    validation_dir = params["common"]["validation_dir"]
     num_export_days = params["indicator"]["num_export_days"]
 
     if num_export_days is None:
@@ -118,7 +118,7 @@ def run_module(params):
                 continue
             exported_csv_dates = create_export_csv(
                 df,
-                export_dir=export_dir,
+                validation_dir=validation_dir,
                 start_date=SMOOTHERS_MAP[smoother][1](export_start_date),
                 metric=metric.lower(),
                 geo_res=geo_res,

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -1,6 +1,7 @@
 {
   "common": {
     "export_dir": "./receiving",
+    "validation_dir": "./receiving",
     "log_exceptions": false,
     "log_filename": "./google-symptoms.log"   
   },


### PR DESCRIPTION
### Description
Make validator (and indicator functions) run in ./receiving, only transfer files to export_dir if validation is passed.
We ensure that changes aren't too drastic by only making one indicator (google_symptoms) send data to ./receiving, the rest directly upload files to export_dir and skip validation.

### Changelog
Add code for transferring files between folders:
- runner.py
- utils.py
Make validation run in validation_dir:
- validate.py
- datafetcher.py
Change indicator function to use validation_dir:
- run.py (in google_symptoms)
- params.json.template (in google_symptoms, ansible)
