### PR TITLE
Change geomapper class to use "timestamp" as the default name for date_col's

### DIFF
--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -183,7 +183,7 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         thr_win_len,
         thr_col="visits",
         fips_col="fips",
-        date_col="date",
+        date_col="timestamp",
         mega_col="megafips",
     ):
         """Create megacounty column.
@@ -340,7 +340,7 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         new_code,
         from_col=None,
         new_col=None,
-        date_col="date",
+        date_col="timestamp",
         data_cols=None,
         dropna=True,
     ):
@@ -366,7 +366,7 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         new_code: {'fips', 'zip', 'state_code', 'state_id', 'state_name', 'hrr', 'msa',
                    'hhs'}
             Specifies the geocode type of the data in new_col.
-        date_col: str or None, default "date"
+        date_col: str or None, default "timestamp"
             Specify which column contains the date values. Used for value aggregation.
             If None, then the aggregation is done only on geo_id.
         data_cols: list, default None
@@ -457,7 +457,7 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
         thr_win_len,
         thr_col="visits",
         fips_col="fips",
-        date_col="date",
+        date_col="timestamp",
         mega_col="megafips",
         count_cols=None,
     ):

--- a/_delphi_utils_python/tests/test_geomap.py
+++ b/_delphi_utils_python/tests/test_geomap.py
@@ -15,7 +15,7 @@ class TestGeoMapper:
     fips_data = pd.DataFrame(
         {
             "fips": ["01123", "02340", "98633", "18181"],
-            "date": [pd.Timestamp("2018-01-01")] * 4,
+            "timestamp": [pd.Timestamp("2018-01-01")] * 4,
             "count": [2, 0, 20, 10021],
             "total": [4, 0, 400, 100001],
         }
@@ -23,7 +23,7 @@ class TestGeoMapper:
     fips_data_2 = pd.DataFrame(
         {
             "fips": ["01123", "02340", "02002", "18633", "18181"],
-            "date": [pd.Timestamp("2018-01-01")] * 5,
+            "timestamp": [pd.Timestamp("2018-01-01")] * 5,
             "count": [2, 1, 20, np.nan, 10021],
             "total": [4, 1, 400, np.nan, 100001],
         }
@@ -31,7 +31,7 @@ class TestGeoMapper:
     fips_data_3 = pd.DataFrame(
         {
             "fips": ["48059", "48253", "48441", "72003", "72005", "10999"],
-            "date": [pd.Timestamp("2018-01-01")] * 3 + [pd.Timestamp("2018-01-03")] * 3,
+            "timestamp": [pd.Timestamp("2018-01-01")] * 3 + [pd.Timestamp("2018-01-03")] * 3,
             "count": [1, 2, 3, 4, 8, 5],
             "total": [2, 4, 7, 11, 100, 10],
         }
@@ -39,7 +39,7 @@ class TestGeoMapper:
     fips_data_4 = pd.DataFrame(
         {
             "fips": ["01123", "48253", "72003", "18181"],
-            "date": [pd.Timestamp("2018-01-01")] * 4,
+            "timestamp": [pd.Timestamp("2018-01-01")] * 4,
             "count": [2, 1, np.nan, 10021],
             "total": [4, 1, np.nan, 100001],
         }
@@ -47,7 +47,7 @@ class TestGeoMapper:
     fips_data_5 = pd.DataFrame(
         {
             "fips": [1123, 48253, 72003, 18181],
-            "date": [pd.Timestamp("2018-01-01")] * 4,
+            "timestamp": [pd.Timestamp("2018-01-01")] * 4,
             "count": [2, 1, np.nan, 10021],
             "total": [4, 1, np.nan, 100001],
         }
@@ -55,7 +55,7 @@ class TestGeoMapper:
     zip_data = pd.DataFrame(
         {
             "zip": ["45140", "95616", "95618"] * 2,
-            "date": [pd.Timestamp("2018-01-01")] * 3 + [pd.Timestamp("2018-01-03")] * 3,
+            "timestamp": [pd.Timestamp("2018-01-01")] * 3 + [pd.Timestamp("2018-01-03")] * 3,
             "count": [99, 345, 456, 100, 344, 442],
         }
     )
@@ -66,7 +66,7 @@ class TestGeoMapper:
             pd.DataFrame(
                 {
                     "fips": ["01001"] * len(jan_month),
-                    "date": jan_month,
+                    "timestamp": jan_month,
                     "count": np.arange(len(jan_month)),
                     "visits": np.arange(len(jan_month)),
                 }
@@ -74,7 +74,7 @@ class TestGeoMapper:
             pd.DataFrame(
                 {
                     "fips": ["01002"] * len(jan_month),
-                    "date": jan_month,
+                    "timestamp": jan_month,
                     "count": np.arange(len(jan_month)),
                     "visits": 2 * np.arange(len(jan_month)),
                 }
@@ -86,7 +86,7 @@ class TestGeoMapper:
             pd.DataFrame(
                 {
                     "fips": ["01001"] * len(jan_month),
-                    "date": jan_month,
+                    "timestamp": jan_month,
                     "count": np.arange(len(jan_month)),
                     "_thr_col_roll": np.arange(len(jan_month)),
                 }
@@ -94,7 +94,7 @@ class TestGeoMapper:
             pd.DataFrame(
                 {
                     "fips": [11001] * len(jan_month),
-                    "date": jan_month,
+                    "timestamp": jan_month,
                     "count": np.arange(len(jan_month)),
                     "_thr_col_roll": np.arange(len(jan_month)),
                 }
@@ -112,7 +112,7 @@ class TestGeoMapper:
                 84000013,
                 84090002,
             ],
-            "date": [pd.Timestamp("2018-01-01")] * 3
+            "timestamp": [pd.Timestamp("2018-01-01")] * 3
             + [pd.Timestamp("2018-01-03")] * 3
             + [pd.Timestamp("2018-01-01")],
             "count": [1, 2, 3, 4, 8, 5, 20],
@@ -245,7 +245,7 @@ class TestGeoMapper:
             new_data,
             pd.DataFrame().from_dict(
                 {
-                    "date": {0: pd.Timestamp("2018-01-01 00:00:00")},
+                    "timestamp": {0: pd.Timestamp("2018-01-01 00:00:00")},
                     "NATION": {0: "us"},
                     "count": {0: 10024.0},
                     "total": {0: 100006.0},
@@ -259,7 +259,7 @@ class TestGeoMapper:
             new_data,
             pd.DataFrame().from_dict(
                 {
-                    "date": {
+                    "timestamp": {
                         0: pd.Timestamp("2018-01-01"),
                         1: pd.Timestamp("2018-01-03"),
                     },
@@ -280,7 +280,7 @@ class TestGeoMapper:
         assert geomapper.add_geocode(self.fips_data_3, "fips", "hrr", dropna=False).isna().any().any()
 
         # fips -> zip (date_col=None chech)
-        new_data = geomapper.replace_geocode(self.fips_data_5.drop(columns=["date"]), "fips", "hrr", date_col=None)
+        new_data = geomapper.replace_geocode(self.fips_data_5.drop(columns=["timestamp"]), "fips", "hrr", date_col=None)
         pd.testing.assert_frame_equal(
             new_data,
             pd.DataFrame().from_dict(
@@ -293,7 +293,7 @@ class TestGeoMapper:
         )
 
         # fips -> hhs
-        new_data = geomapper.replace_geocode(self.fips_data_3.drop(columns=["date"]),
+        new_data = geomapper.replace_geocode(self.fips_data_3.drop(columns=["timestamp"]),
                                         "fips", "hhs", date_col=None)
         pd.testing.assert_frame_equal(
             new_data,
@@ -313,7 +313,7 @@ class TestGeoMapper:
             new_data,
             pd.DataFrame().from_dict(
                 {
-                    "date": {0: pd.Timestamp("2018-01-01"), 1: pd.Timestamp("2018-01-01"),
+                    "timestamp": {0: pd.Timestamp("2018-01-01"), 1: pd.Timestamp("2018-01-01"),
                              2: pd.Timestamp("2018-01-03"), 3: pd.Timestamp("2018-01-03")},
                     "hhs": {0: "5", 1: "9", 2: "5", 3: "9"},
                     "count": {0: 99.0, 1: 801.0, 2: 100.0, 3: 786.0},

--- a/_template_python/delphi_NAME/run.py
+++ b/_template_python/delphi_NAME/run.py
@@ -47,10 +47,7 @@ def run_module(params):
     ## aggregate & smooth
     ## TODO: add num/prop variations if needed
     for sensor, smoother, geo in product(SIGNALS, SMOOTHERS, GEOS):
-        df = mapper.replace_geocode(
-            all_data, "zip", geo,
-            new_col="geo_id",
-            date_col="timestamp")
+        df = mapper.replace_geocode(all_data, "zip", geo, new_col="geo_id")
         ## TODO: recompute sample_size, se here if not NA
         df["val"] = df[["geo_id", "val"]].groupby("geo_id")["val"].transform(
             smoother[0].smooth

--- a/changehc/delphi_changehc/config.py
+++ b/changehc/delphi_changehc/config.py
@@ -29,7 +29,7 @@ class Config:
     FLU_LIKE_COL = "Flu-like"
     COVID_LIKE_COL = "Covid-like"
     COUNT_COLS = [COVID_COL,DENOM_COL,FLU_COL,MIXED_COL,FLU_LIKE_COL,COVID_LIKE_COL]
-    DATE_COL = "date"
+    DATE_COL = "timestamp"
     GEO_COL = "fips"
     ID_COLS = [DATE_COL] + [GEO_COL]
     FILT_COLS = ID_COLS + COUNT_COLS

--- a/changehc/tests/test_load_data.py
+++ b/changehc/tests/test_load_data.py
@@ -45,7 +45,7 @@ class TestLoadData:
 
     def test_denom_columns(self):
         assert "fips" in self.denom_data.index.names
-        assert "date" in self.denom_data.index.names
+        assert "timestamp" in self.denom_data.index.names
 
         expected_denom_columns = ["Denominator"]
         for col in expected_denom_columns:
@@ -54,7 +54,7 @@ class TestLoadData:
 
     def test_claims_columns(self):
         assert "fips" in self.covid_data.index.names
-        assert "date" in self.covid_data.index.names
+        assert "timestamp" in self.covid_data.index.names
 
         expected_covid_columns = ["COVID"]
         for col in expected_covid_columns:
@@ -63,7 +63,7 @@ class TestLoadData:
 
     def test_combined_columns(self):
         assert "fips" in self.combined_data.index.names
-        assert "date" in self.combined_data.index.names
+        assert "timestamp" in self.combined_data.index.names
 
         expected_combined_columns = ["num", "den"]
         for col in expected_combined_columns:
@@ -75,8 +75,8 @@ class TestLoadData:
         for data in [self.denom_data,
                      self.covid_data,
                      self.combined_data]:
-            assert data.index.get_level_values('date').max() >= Config.FIRST_DATA_DATE
-            assert data.index.get_level_values('date').min() < DROP_DATE
+            assert data.index.get_level_values("timestamp").max() >= Config.FIRST_DATA_DATE
+            assert data.index.get_level_values("timestamp").min() < DROP_DATE
 
     def test_fips_values(self):
         for data in [self.denom_data,
@@ -84,7 +84,7 @@ class TestLoadData:
                      self.combined_data]:
             assert (
                     len(data.index.get_level_values(
-                        'fips').unique()) <= len(self.gmpr.get_geo_values("fips"))
+                        "fips").unique()) <= len(self.gmpr.get_geo_values("fips"))
             )
 
     def test_combined_fips_values(self):

--- a/changehc/tests/test_update_sensor.py
+++ b/changehc/tests/test_update_sensor.py
@@ -40,7 +40,7 @@ class TestCHCSensorUpdator:
         "num": [0, 100, 200, 300, 400, 500, 600, 100, 200, 300, 400, 500, 600],
         "fips": ['01001'] * 7 + ['04007'] * 6,
         "den": [1000] * 7 + [2000] * 6,
-        "date": [pd.Timestamp(f'03-{i}-2020') for i in range(1, 14)]}).set_index(["fips","date"])
+        "timestamp": [pd.Timestamp(f'03-{i}-2020') for i in range(1, 14)]}).set_index(["fips","timestamp"])
 
     def test_shift_dates(self):
         """Tests that dates in the data are shifted according to the burn-in and lag."""
@@ -84,7 +84,7 @@ class TestCHCSensorUpdator:
                 "num": [0, 100, 200, 300, 400, 500, 600, 100, 200, 300, 400, 500, 600],
                 "fips": ['01001'] * 7 + ['04007'] * 6,
                 "den": [1000] * 7 + [2000] * 6,
-                "date": [pd.Timestamp(f'03-{i}-2020') for i in range(1, 14)]})
+                "timestamp": [pd.Timestamp(f'03-{i}-2020') for i in range(1, 14)]})
             data_frame = su_inst.geo_reindex(test_data)
             assert data_frame.shape[0] == multiple*len(su_inst.fit_dates)
             assert (data_frame.sum() == (4200,19000)).all()
@@ -113,8 +113,8 @@ class TestCHCSensorUpdator:
                 "num": [0, 100, 200, 300, 400, 500, 600, 100, 200, 300, 400, 500, 600] * 2,
                 "fips": ["01001"] * 13 + ["42003"] * 13,
                 "den": [30, 50, 50, 10, 1, 5, 5, 50, 50, 50, 0, 0, 0] * 2,
-                "date": list(pd.date_range("20200301", "20200313")) * 2
-            }).set_index(["fips", "date"])
+                "timestamp": list(pd.date_range("20200301", "20200313")) * 2
+            }).set_index(["fips", "timestamp"])
             su_inst.update_sensor(small_test_data,  td.name)
             for f in os.listdir(td.name):
                 outputs[f] = pd.read_csv(os.path.join(td.name, f))

--- a/claims_hosp/delphi_claims_hosp/config.py
+++ b/claims_hosp/delphi_claims_hosp/config.py
@@ -32,8 +32,13 @@ class Config:
     # data columns
     CLAIMS_COUNT_COLS = ["Denominator", "Covid_like"]
     CLAIMS_DATE_COL = "ServiceDate"
-    CLAIMS_RENAME_COLS = {"Pat HRR ID": "hrr", "ServiceDate": "date",
-                          "PatCountyFIPS": "fips", "PatAgeGroup": "age_group"}
+    FIPS_COL = "fips"
+    DATE_COL = "timestamp"
+    AGE_COL = "age_group"
+    HRR_COL = "hrr"
+
+    CLAIMS_RENAME_COLS = {"Pat HRR ID": HRR_COL, "ServiceDate":  DATE_COL,
+                          "PatCountyFIPS": FIPS_COL, "PatAgeGroup": AGE_COL}
     CLAIMS_DTYPES = {
         "ServiceDate": str,
         "PatCountyFIPS": str,
@@ -43,10 +48,7 @@ class Config:
         "Pat HRR ID": str,
     }
 
-    FIPS_COL = "fips"
-    DATE_COL = "date"
-    AGE_COL = "age_group"
-    HRR_COL = "hrr"
+
 
     SMOOTHER_BANDWIDTH = 100  # bandwidth for the linear left Gaussian filter
     MIN_DEN = 100  # number of total visits needed to produce a sensor

--- a/claims_hosp/delphi_claims_hosp/load_data.py
+++ b/claims_hosp/delphi_claims_hosp/load_data.py
@@ -48,7 +48,7 @@ def load_claims_data(claims_filepath, dropdate, base_geo):
     ), "Claims counts must be nonnegative"
 
     # aggregate age groups (so data is unique by date and base geography)
-    claims_data = claims_data.groupby([base_geo, "date"]).sum()
+    claims_data = claims_data.groupby([base_geo, Config.DATE_COL]).sum()
     claims_data.dropna(inplace=True)  # drop rows with any missing entries
 
     return claims_data

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -120,11 +120,11 @@ class ClaimsHospIndicatorUpdater:
             return False
 
         unique_geo_ids = pd.unique(data_frame[self.geo])
-        data_frame.set_index([self.geo, 'date'], inplace=True)
+        data_frame.set_index([self.geo, "timestamp"], inplace=True)
 
         # for each location, fill in all missing dates with 0 values
         multiindex = pd.MultiIndex.from_product((unique_geo_ids, self.fit_dates),
-                                                names=[self.geo, "date"])
+                                                names=[self.geo, Config.DATE_COL])
         assert (
                 len(multiindex) <= (GeoConstants.MAX_GEO[self.geo] * len(self.fit_dates))
         ), "more loc-date pairs than maximum number of geographies x number of dates"

--- a/claims_hosp/tests/test_indicator.py
+++ b/claims_hosp/tests/test_indicator.py
@@ -56,7 +56,7 @@ class TestLoadData:
     def test_fit_fips(self):
         date_range = pd.date_range("2020-05-01", "2020-05-20")
         all_fips = self.fips_data.fips.unique()
-        loc_index_fips_data = self.fips_data.set_index(["fips", "date"])
+        loc_index_fips_data = self.fips_data.set_index(["fips", "timestamp"])
         sample_fips = nr.choice(all_fips, 10)
 
         for fips in sample_fips:
@@ -79,7 +79,7 @@ class TestLoadData:
     def test_fit_hrrs(self):
         date_range = pd.date_range("2020-05-01", "2020-05-20")
         all_hrrs = self.hrr_data.hrr.unique()
-        loc_index_hrr_data = self.hrr_data.set_index(["hrr", "date"])
+        loc_index_hrr_data = self.hrr_data.set_index(["hrr", "timestamp"])
         sample_hrrs = nr.choice(all_hrrs, 10)
 
         for hrr in sample_hrrs:

--- a/claims_hosp/tests/test_load_data.py
+++ b/claims_hosp/tests/test_load_data.py
@@ -34,8 +34,8 @@ class TestLoadData:
     def test_claims_columns(self):
         assert "hrr" in self.hrr_claims_data.index.names
         assert "fips" in self.fips_claims_data.index.names
-        assert "date" in self.hrr_claims_data.index.names
-        assert "date" in self.fips_claims_data.index.names
+        assert "timestamp" in self.hrr_claims_data.index.names
+        assert "timestamp" in self.fips_claims_data.index.names
 
         expected_claims_columns = ["Denominator", "Covid_like"]
         for col in expected_claims_columns:
@@ -47,8 +47,8 @@ class TestLoadData:
     def test_data_columns(self):
         assert "hrr" in self.hrr_data.columns
         assert "fips" in self.fips_data.columns
-        assert "date" in self.hrr_data.columns
-        assert "date" in self.fips_data.columns
+        assert "timestamp" in self.hrr_data.columns
+        assert "timestamp" in self.fips_data.columns
 
         expected_columns = ["num", "den"]
         for col in expected_columns:
@@ -57,12 +57,12 @@ class TestLoadData:
 
     def test_edge_values(self):
         for data in [self.hrr_claims_data, self.fips_claims_data]:
-            assert data.index.get_level_values('date').max() >= Config.FIRST_DATA_DATE
-            assert data.index.get_level_values('date').min() < DROP_DATE
+            assert data.index.get_level_values("timestamp").max() >= Config.FIRST_DATA_DATE
+            assert data.index.get_level_values("timestamp").min() < DROP_DATE
 
         for data in [self.hrr_data, self.fips_data]:
-            assert data.date.max() >= Config.FIRST_DATA_DATE
-            assert data.date.min() < DROP_DATE
+            assert data["timestamp"].max() >= Config.FIRST_DATA_DATE
+            assert data["timestamp"].min() < DROP_DATE
 
     def test_hrrs_values(self):
         assert len(self.hrr_data.hrr.unique()) <= CONSTANTS.NUM_HRRS

--- a/claims_hosp/tests/test_update_indicator.py
+++ b/claims_hosp/tests/test_update_indicator.py
@@ -37,8 +37,8 @@ class TestClaimsHospIndicatorUpdater:
         "num": [0, 100, 200, 300, 400, 500, 600, 100, 200, 300, 400, 500, 600],
         "hrr": [1.0] * 7 + [2.0] * 6,
         "den": [1000] * 7 + [2000] * 6,
-        "date": [pd.Timestamp(f'03-{i}-2020') for i in range(1, 14)]}).set_index(
-        ["hrr", "date"])
+        "timestamp": [pd.Timestamp(f'03-{i}-2020') for i in range(1, 14)]}).set_index(
+        ["hrr", "timestamp"])
 
     def test_shift_dates(self):
         updater = ClaimsHospIndicatorUpdater(

--- a/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
+++ b/combo_cases_and_deaths/delphi_combo_cases_and_deaths/run.py
@@ -72,10 +72,9 @@ def compute_special_geo_dfs(df, signal, geo):
     df = GMPR.replace_geocode(df,
                               from_col="geo_id",
                               from_code="fips",
-                              new_code="state_code",
-                              date_col="timestamp")
+                              new_code="state_code")
     df = GMPR.add_population_column(df, "state_code")  # use total state population
-    df = GMPR.replace_geocode(df, from_code="state_code", new_code=geo, date_col="timestamp")
+    df = GMPR.replace_geocode(df, from_code="state_code", new_code=geo)
     if signal.endswith("_prop"):
         df["val"] = df["val"]/df["population"] * 100000
     df.drop("population", axis=1, inplace=True)

--- a/covid_act_now/delphi_covid_act_now/geo.py
+++ b/covid_act_now/delphi_covid_act_now/geo.py
@@ -92,8 +92,7 @@ def geo_map(df: pd.DataFrame, geo_res: str) -> pd.DataFrame:
 
         df = (df
             .loc[:, ["fips", "timestamp", "pcr_tests_positive", "pcr_tests_total"]]
-            .pipe(gmpr.replace_geocode, "fips", geo_res, new_col="geo_id",
-                date_col="timestamp")
+            .pipe(gmpr.replace_geocode, "fips", geo_res, new_col="geo_id")
             .rename(columns={"pcr_tests_total": "sample_size"})
             .assign(val=positivity_rate, se=std_err)
             .reset_index()

--- a/google_symptoms/delphi_google_symptoms/run.py
+++ b/google_symptoms/delphi_google_symptoms/run.py
@@ -90,8 +90,7 @@ def run_module(params):
         if geo_res == "state":
             df_pull = dfs["state"]
         elif geo_res in ["hhs", "nation"]:
-            df_pull = gmpr.replace_geocode(dfs["county"], "fips", geo_res, from_col="geo_id",
-                                           date_col="timestamp")
+            df_pull = gmpr.replace_geocode(dfs["county"], "fips", geo_res, from_col="geo_id")
             df_pull.rename(columns={geo_res: "geo_id"}, inplace=True)
         else:
             df_pull = geo_map(dfs["county"], geo_res)

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -162,10 +162,7 @@ def make_geo(state, geo, geo_mapper):
     if geo == "state":
         exported = state.rename(columns={"state": "geo_id"})
     else:
-        exported = geo_mapper.replace_geocode(
-            state, "state_code", geo,
-            new_col="geo_id",
-            date_col="timestamp")
+        exported = geo_mapper.replace_geocode(state, "state_code", geo, new_col="geo_id")
     exported["se"] = np.nan
     exported["sample_size"] = np.nan
     return exported

--- a/jhu/delphi_jhu/geo.py
+++ b/jhu/delphi_jhu/geo.py
@@ -44,9 +44,9 @@ def geo_map(df: pd.DataFrame, geo_res: str, sensor: str):
     elif geo_res in ("state", "hhs", "nation"):
         geo = "state_id" if geo_res == "state" else geo_res
         df = df.append(unassigned_counties) if not unassigned_counties.empty else df
-        df = gmpr.replace_geocode(df, "fips", geo, new_col="geo_id", date_col="timestamp")
+        df = gmpr.replace_geocode(df, "fips", geo, new_col="geo_id")
     else:
-        df = gmpr.replace_geocode(df, "fips", geo_res, new_col="geo_id", date_col="timestamp")
+        df = gmpr.replace_geocode(df, "fips", geo_res, new_col="geo_id")
     df["incidence"] = df["new_counts"] / df["population"] * INCIDENCE_BASE
     df["cumulative_prop"] = df["cumulative_counts"] / df["population"] * INCIDENCE_BASE
     return df

--- a/jhu/delphi_jhu/pull.py
+++ b/jhu/delphi_jhu/pull.py
@@ -99,9 +99,7 @@ def pull_jhu_data(base_url: str, metric: str, gmpr: GeoMapper) -> pd.DataFrame:
     df = download_data(base_url, metric)
 
     gmpr = GeoMapper()
-    df = gmpr.replace_geocode(
-        df, "jhu_uid", "fips", from_col="UID", date_col="timestamp"
-    )
+    df = gmpr.replace_geocode(df, "jhu_uid", "fips", from_col="UID")
     df = create_diffs_column(df)
     # Final sanity checks
     sanity_check_data(df)

--- a/jhu/tests/test_geo.py
+++ b/jhu/tests/test_geo.py
@@ -107,7 +107,7 @@ class TestGeoMap:
             new_df = geo_map(test_df, geo, "cumulative_prop")
             gmpr = GeoMapper()
             test_df = gmpr.add_population_column(test_df, "fips")
-            test_df = gmpr.replace_geocode(test_df, "fips", geo, date_col="timestamp")
+            test_df = gmpr.replace_geocode(test_df, "fips", geo)
 
             new_df = new_df.set_index(["geo_id", "timestamp"]).sort_index()
             test_df = test_df.set_index([geo, "timestamp"]).sort_index()

--- a/quidel_covidtest/delphi_quidel_covidtest/geo_maps.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/geo_maps.py
@@ -1,7 +1,6 @@
 """Contains geographic mapping tools."""
 from delphi_utils import GeoMapper
 
-DATE_COL = "timestamp"
 DATA_COLS = ['totalTest', 'numUniqueDevices', 'positiveTest', "population"]
 GMPR = GeoMapper()  # Use geo utils
 GEO_KEY_DICT = {
@@ -21,8 +20,7 @@ def geo_map(geo_res, df):
     # Add population for each zipcode
     data = GMPR.add_population_column(data, "zip")
     # zip -> geo_res
-    data = GMPR.replace_geocode(data, "zip", geo_key,
-                                date_col=DATE_COL, data_cols=DATA_COLS)
+    data = GMPR.replace_geocode(data, "zip", geo_key, data_cols=DATA_COLS)
     if geo_res in ["state", "hhs", "nation"]:
         return data, geo_key
     # Add parent state

--- a/safegraph_patterns/delphi_safegraph_patterns/process.py
+++ b/safegraph_patterns/delphi_safegraph_patterns/process.py
@@ -114,11 +114,7 @@ def aggregate(df, metric, geo_res):
     gmpr = GeoMapper()
     geo_key = GEO_KEY_DICT[geo_res]
     df = gmpr.add_population_column(df, "zip")
-    df = gmpr.replace_geocode(df,
-                              "zip",
-                              geo_key,
-                              date_col="timestamp",
-                              data_cols=[metric_count_name, "population"])
+    df = gmpr.replace_geocode(df, "zip", geo_key, data_cols=[metric_count_name, "population"])
 
     df[metric_prop_name] = df[metric_count_name] / df["population"] \
                             * INCIDENCE_BASE

--- a/usafacts/delphi_usafacts/geo.py
+++ b/usafacts/delphi_usafacts/geo.py
@@ -111,14 +111,14 @@ def geo_map(df: pd.DataFrame, geo_res: str, sensor: str):
     elif geo_res in ("state", "hhs", "nation"):
         state_geo = "state_id" if geo_res == "state" else geo_res
         df = df.append(unassigned_counties) if not unassigned_counties.empty else df
-        df = gmpr.replace_geocode(df, "fips", state_geo, new_col="geo_id", date_col="timestamp")
+        df = gmpr.replace_geocode(df, "fips", state_geo, new_col="geo_id")
     else:
         # Map "missing" secondary FIPS to those that are in our canonical set
         for fips, fips_list in SECONDARY_FIPS:
             df = disburse(df, fips, fips_list)
         for usafacts_fips, our_fips in REPLACE_FIPS:
             df.loc[df["fips"] == usafacts_fips, "fips"] = our_fips
-        merged = gmpr.replace_geocode(df, "fips", geo_res, new_col="geo_id", date_col="timestamp")
+        merged = gmpr.replace_geocode(df, "fips", geo_res, new_col="geo_id")
         if "weight" not in merged.columns:
             merged["weight"] = 1
         merged["cumulative_counts"] = merged["cumulative_counts"] * merged["weight"]


### PR DESCRIPTION
### Description
Change the default date_col name to "timestamp" from "date". The `export_csv` function expects "timestamp", and most indicators were specifying it as this anyways.

Note that there were two indicators (changehc, and claims_hosp) which were using the column named like "date" and this has been changed to "timestamp".