### PR TITLE
Add delivery to params

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -1,6 +1,6 @@
 {
   "common": {
-    "export_dir": "/common/covidcast/receiving/google-symptoms",
+    "export_dir": "./receiving",
     "log_filename": "/var/log/indicators/google_symptoms.log"
   },
   "indicator": {
@@ -41,6 +41,9 @@
         "sum_anosmia_ageusia_smoothed_search",
         "anosmia_smoothed_search"
       ]
+    },
+    "delivery": {
+      "delivery_dir": "/common/covidcast/receiving/google-symptoms"
     }
   }
 }

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -31,6 +31,9 @@
         "sum_anosmia_ageusia_smoothed_search",
         "anosmia_smoothed_search"
       ]
+    },
+    "delivery": {
+      "delivery_dir": "./receiving"
     }
   }
 }


### PR DESCRIPTION
Changed export_dir to ./receiving, added delivery_dir

### Description
To add an indicator to the new gating procedure, we would add a new "delivery_dir" to its params and change the current export_dir to ./receiving. This means:
- validation/archiving can be done within ./receiving
- Delivery transfers it to /common/covidcast for acquisition
- If validation fails, we perform the gating step by keeping the data within ./receiving, until validation passes (either by the source correcting inaccuracies raised by validation, or by us adding exceptions to validation errors)

### Changelog
- params.json.template