### PR TITLE
[DRAFT] Standardize weekday calc_adjustment() function

### DIFF
--- a/changehc/delphi_changehc/update_sensor.py
+++ b/changehc/delphi_changehc/update_sensor.py
@@ -201,9 +201,10 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
         if not self.parallel:
             dfs = []
             for geo_id, sub_data in data_frame.groupby(level=0):
-                sub_data.reset_index(level=0,inplace=True)
+                sub_data.reset_index(inplace=True)
                 if self.weekday:
-                    sub_data = Weekday.calc_adjustment(wd_params, sub_data)
+                    sub_data = Weekday.calc_adjustment(wd_params, sub_data, ["num"])
+                sub_data.set_index(Config.DATE_COL, inplace=True)
                 res = CHCSensor.fit(sub_data, self.burnindate, geo_id, self.logger)
                 res = pd.DataFrame(res).loc[final_sensor_idxs]
                 dfs.append(res)
@@ -213,9 +214,10 @@ class CHCSensorUpdator:  # pylint: disable=too-many-instance-attributes
             with Pool(n_cpu) as pool:
                 pool_results = []
                 for geo_id, sub_data in data_frame.groupby(level=0,as_index=False):
-                    sub_data.reset_index(level=0, inplace=True)
+                    sub_data.reset_index(inplace=True)
                     if self.weekday:
-                        sub_data = Weekday.calc_adjustment(wd_params, sub_data)
+                        sub_data = Weekday.calc_adjustment(wd_params, sub_data, ["num"])
+                    sub_data.set_index(Config.DATE_COL, inplace=True)
                     pool_results.append(
                         pool.apply_async(
                             CHCSensor.fit, args=(sub_data, self.burnindate, geo_id, self.logger),

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -160,9 +160,10 @@ class ClaimsHospIndicatorUpdater:
         valid_inds = {}
         if not self.parallel:
             for geo_id, sub_data in data_frame.groupby(level=0):
-                sub_data.reset_index(level=0, inplace=True)
+                sub_data.reset_index(inplace=True)
                 if self.weekday:
-                    sub_data = Weekday.calc_adjustment(wd_params, sub_data)
+                    sub_data = Weekday.calc_adjustment(wd_params, sub_data, ["num"])
+                sub_data.set_index(Config.DATE_COL, inplace=True)
                 res = ClaimsHospIndicator.fit(sub_data, self.burnindate, geo_id)
                 res = pd.DataFrame(res)
                 rates[geo_id] = np.array(res.loc[final_output_inds, "rate"])
@@ -174,9 +175,10 @@ class ClaimsHospIndicatorUpdater:
             with Pool(n_cpu) as pool:
                 pool_results = []
                 for geo_id, sub_data in data_frame.groupby(level=0, as_index=False):
-                    sub_data.reset_index(level=0, inplace=True)
+                    sub_data.reset_index(inplace=True)
                     if self.weekday:
-                        sub_data = Weekday.calc_adjustment(wd_params, sub_data)
+                        sub_data = Weekday.calc_adjustment(wd_params, sub_data, ["num"])
+                    sub_data.set_index(Config.DATE_COL, inplace=True)
                     pool_results.append(
                         pool.apply_async(
                             ClaimsHospIndicator.fit,

--- a/doctor_visits/delphi_doctor_visits/update_sensor.py
+++ b/doctor_visits/delphi_doctor_visits/update_sensor.py
@@ -145,7 +145,7 @@ def update_sensor(
         for geo_id in unique_geo_ids:
             sub_data = data_groups.get_group(geo_id).copy()
             if weekday:
-                sub_data = Weekday.calc_adjustment(params, sub_data)
+                sub_data = Weekday.calc_adjustment(params,  sub_data,   Config.CLI_COLS + Config.FLU1_COL)
 
             res = DoctorVisitsSensor.fit(
                 sub_data,
@@ -169,7 +169,9 @@ def update_sensor(
             for geo_id in unique_geo_ids:
                 sub_data = data_groups.get_group(geo_id).copy()
                 if weekday:
-                    sub_data = Weekday.calc_adjustment(params, sub_data)
+                    sub_data = Weekday.calc_adjustment(params,
+                                                       sub_data,
+                                                       Config.CLI_COLS + Config.FLU1_COL)
 
                 pool_results.append(
                     pool.apply_async(

--- a/doctor_visits/delphi_doctor_visits/weekday.py
+++ b/doctor_visits/delphi_doctor_visits/weekday.py
@@ -103,7 +103,7 @@ class Weekday:
         return params
 
     @staticmethod
-    def calc_adjustment(params, sub_data):
+    def calc_adjustment(params, sub_data, cols):
         """Apply the weekday adjustment to a specific time series.
 
         Extracts the weekday fixed effects from the parameters and uses these to
@@ -122,14 +122,15 @@ class Weekday:
         -- this has the same effect.
 
         """
-        for i, c in enumerate(Config.CLI_COLS + Config.FLU1_COL):
-            wd_correction = np.zeros((len(sub_data[c])))
+        tmp = sub_data.copy()
+
+        for i, c in enumerate(cols):
+            wd_correction = np.zeros((len(tmp[c])))
 
             for wd in range(7):
-                mask = sub_data[Config.DATE_COL].dt.dayofweek == wd
-                wd_correction[mask] = sub_data.loc[mask, c] / (
+                mask = tmp[Config.DATE_COL].dt.dayofweek == wd
+                wd_correction[mask] = tmp.loc[mask, c] / (
                     np.exp(params[i, wd]) if wd < 6 else np.exp(-np.sum(params[i, :6]))
                 )
-            sub_data.loc[:, c] = wd_correction
-
-        return sub_data
+            tmp.loc[:, c] = wd_correction
+        return tmp


### PR DESCRIPTION
### Description
As first step for #1269, refactor DV, CHNG, and Claims_hosp to use the same calc_adjustment function. CHNG and claims_hosp were previously using the same one while DV had a multi-column version.  This means all 3 indicators have the exact same function, and later we'll move them out to a single shared file

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Add column argument to calc_adjustment and have it loop through each one.
- Update index management outside function 
- Reshape returns weekday params to be 2D arrays universally (further refactoring to unify get_params() is next)

### Fixes 
- Partially addresses #1269
