### PR TITLE
Ignore existing *.tgz files when creating tidy archives

### DIFF
--- a/facebook/Makefile
+++ b/facebook/Makefile
@@ -54,7 +54,7 @@ tidy: receiving
 	cp params.json tidy/
 	mv $(RECEIVING)/*.csv tidy/$(RECEIVING)
 	mv $(INDIVIDUAL)/*.csv* tidy/$(INDIVIDUAL)
-	tar -czf scratch/tidy-`date +"%Y-%m-%d-%H%M%S"`.tgz tidy
+	tar -czf scratch/tidy-`date +"%Y-%m-%d-%H%M%S"`.tgz --exclude='tidy-*.tgz' tidy
 	mv scratch/*.tgz tidy/
 
 clean:


### PR DESCRIPTION
### Description
Fix:

Recent changes to the survey indicator's Makefile mean that we now end up storing the tidy .tgz archive files in ./tidy. We need to exclude these archive files so we don't have runaway storage issues.

### Changelog
- Update Makefile