### PR TITLE
Add raceeth to production params

### DIFF
--- a/ansible/templates/facebook-params-prod.json.j2
+++ b/ansible/templates/facebook-params-prod.json.j2
@@ -11,6 +11,8 @@
   "end_date": "2021-08-16",
   "export_dir": "./receiving",
   "individual_dir": "./individual",
+  "individual_raceeth_dir": "./individual_raceeth",
+  "produce_individual_raceeth": false,
   "input": [
     "2021-08-17.2021-08-10.2021-08-17.Survey_of_COVID-Like_Illness_-_TODEPLOY_......_-_US_Expansion.csv",
     "2021-08-17.2021-08-10.2021-08-17.Survey_of_COVID-Like_Illness_-_Wave_10.csv",


### PR DESCRIPTION
### Description
This edit escaped https://github.com/cmu-delphi/covidcast-indicators/pull/1211 -- production params are now managed in `ansible/templates`.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- production survey params: add raceeth, default off.

