### PR TITLE
Temporarily list all CHNG signals as "retired"

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -13,7 +13,8 @@
     },
     "chng": {
       "max_age": 6,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
+      "retired-signals": ["smoothed_outpatient_covid", "smoothed_adj_outpatient_covid", "smoothed_outpatient_cli", "smoothed_adj_outpatient_cli"]
     },
     "google-symptoms": {
       "max_age": 6,


### PR DESCRIPTION
### Description
While CHNG is paused, stop SirCAL from complaining that it's out of date.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Production SirCAL params - list all CHNG signals as "retired"

### Fixes 
- Fixes #system-monitoring sircal violation messages from chng
