### PR TITLE
Suppress rapid_change_num_rows

### DIFF
--- a/ansible/templates/quidel_covidtest-params-prod.json.j2
+++ b/ansible/templates/quidel_covidtest-params-prod.json.j2
@@ -28,7 +28,14 @@
       "dry_run": true,
       "suppressed_errors": [
         {"check_name": "check_rapid_change_num_rows",
-        "signal": "covid_ag_raw_pct_positive"}
+        "signal": "covid_ag_raw_pct_positive",
+        "geo_type": "hrr"},
+        {"check_name": "check_rapid_change_num_rows",
+        "signal": "covid_ag_raw_pct_positive",
+        "geo_type": "msa"},
+        {"check_name": "check_rapid_change_num_rows",
+        "signal": "covid_ag_raw_pct_positive",
+        "geo_type": "county"}
       ]
     },
     "static": {

--- a/quidel_covidtest/params.json.template
+++ b/quidel_covidtest/params.json.template
@@ -29,7 +29,14 @@
       "dry_run": true,
       "suppressed_errors": [
         {"check_name": "check_rapid_change_num_rows",
-        "signal": "covid_ag_raw_pct_positive"}
+        "signal": "covid_ag_raw_pct_positive",
+        "geo_type": "hrr"},
+        {"check_name": "check_rapid_change_num_rows",
+        "signal": "covid_ag_raw_pct_positive",
+        "geo_type": "msa"},
+        {"check_name": "check_rapid_change_num_rows",
+        "signal": "covid_ag_raw_pct_positive",
+        "geo_type": "county"}
       ]
     },
     "static": {


### PR DESCRIPTION
### Description
Test constantly failing for covid_ag_raw_pct_positive since not all geo_ids have data every day, we suppress errors for this since it's a false positive

### Changelog
Itemize code/test/documentation changes and files added/removed.
- params.json.template for both quidel folder and ansible.
