### PR TITLE
Remove sirCAL check for `smoothed_try_vaccinate_1m` at the HRR level

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -77,7 +77,8 @@
         ["smoothed_vaccine_barrier_technology_access_tried", "msa"], ["smoothed_wvaccine_barrier_technology_access_tried", "msa"],
         ["smoothed_vaccine_barrier_time_tried", "msa"], ["smoothed_wvaccine_barrier_time_tried", "msa"],
         ["smoothed_vaccine_barrier_travel_tried", "msa"], ["smoothed_wvaccine_barrier_travel_tried", "msa"],
-        ["smoothed_vaccine_barrier_type_tried", "msa"], ["smoothed_wvaccine_barrier_type_tried", "msa"]
+        ["smoothed_vaccine_barrier_type_tried", "msa"], ["smoothed_wvaccine_barrier_type_tried", "msa"],
+        ["smoothed_try_vaccinate_1m", "hrr"], ["smoothed_wtry_vaccinate_1m", "hrr"]
       ]
     },
     "indicator-combination": {

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -77,7 +77,8 @@
         ["smoothed_vaccine_barrier_technology_access_tried", "msa"], ["smoothed_wvaccine_barrier_technology_access_tried", "msa"],
         ["smoothed_vaccine_barrier_time_tried", "msa"], ["smoothed_wvaccine_barrier_time_tried", "msa"],
         ["smoothed_vaccine_barrier_travel_tried", "msa"], ["smoothed_wvaccine_barrier_travel_tried", "msa"],
-        ["smoothed_vaccine_barrier_type_tried", "msa"], ["smoothed_wvaccine_barrier_type_tried", "msa"]
+        ["smoothed_vaccine_barrier_type_tried", "msa"], ["smoothed_wvaccine_barrier_type_tried", "msa"],
+        ["smoothed_try_vaccinate_1m", "hrr"], ["smoothed_wtry_vaccinate_1m", "hrr"]
       ]
     },
     "indicator-combination": {


### PR DESCRIPTION
### Description
`smoothed_try_vaccinate_1m` doesn't have enough sample size to report for HRR. Remove from sirCAL checks.

### Changelog
- Suppress in ansible template and sirCAL template.