### PR TITLE
Suppress fb survey `dontneed_reasons_*` in sirCAL

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -78,7 +78,14 @@
         ["smoothed_vaccine_barrier_time_tried", "msa"], ["smoothed_wvaccine_barrier_time_tried", "msa"],
         ["smoothed_vaccine_barrier_travel_tried", "msa"], ["smoothed_wvaccine_barrier_travel_tried", "msa"],
         ["smoothed_vaccine_barrier_type_tried", "msa"], ["smoothed_wvaccine_barrier_type_tried", "msa"],
-        ["smoothed_try_vaccinate_1m", "hrr"], ["smoothed_wtry_vaccinate_1m", "hrr"]
+        ["smoothed_try_vaccinate_1m", "hrr"], ["smoothed_wtry_vaccinate_1m", "hrr"],
+        ["smoothed_dontneed_reason_dont_spend_time", "hrr"], ["smoothed_wdontneed_reason_dont_spend_time", "hrr"],
+        ["smoothed_dontneed_reason_had_covid", "hrr"], ["smoothed_wdontneed_reason_had_covid", "hrr"],
+        ["smoothed_dontneed_reason_not_beneficial", "hrr"], ["smoothed_wdontneed_reason_not_beneficial", "hrr"],
+        ["smoothed_dontneed_reason_not_high_risk", "hrr"], ["smoothed_wdontneed_reason_not_high_risk", "hrr"],
+        ["smoothed_dontneed_reason_not_serious", "hrr"], ["smoothed_wdontneed_reason_not_serious", "hrr"],
+        ["smoothed_dontneed_reason_other", "hrr"], ["smoothed_wdontneed_reason_other", "hrr"],
+        ["smoothed_dontneed_reason_precautions", "hrr"], ["smoothed_wdontneed_reason_precautions", "hrr"]
       ]
     },
     "indicator-combination": {

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -78,7 +78,13 @@
         ["smoothed_vaccine_barrier_time_tried", "msa"], ["smoothed_wvaccine_barrier_time_tried", "msa"],
         ["smoothed_vaccine_barrier_travel_tried", "msa"], ["smoothed_wvaccine_barrier_travel_tried", "msa"],
         ["smoothed_vaccine_barrier_type_tried", "msa"], ["smoothed_wvaccine_barrier_type_tried", "msa"],
-        ["smoothed_try_vaccinate_1m", "hrr"], ["smoothed_wtry_vaccinate_1m", "hrr"]
+        ["smoothed_try_vaccinate_1m", "hrr"], ["smoothed_wtry_vaccinate_1m", "hrr"],
+        ["smoothed_dontneed_reason_had_covid", "hrr"], ["smoothed_wdontneed_reason_had_covid", "hrr"],
+        ["smoothed_dontneed_reason_not_beneficial", "hrr"], ["smoothed_wdontneed_reason_not_beneficial", "hrr"],
+        ["smoothed_dontneed_reason_not_high_risk", "hrr"], ["smoothed_wdontneed_reason_not_high_risk", "hrr"],
+        ["smoothed_dontneed_reason_not_serious", "hrr"], ["smoothed_wdontneed_reason_not_serious", "hrr"],
+        ["smoothed_dontneed_reason_other", "hrr"], ["smoothed_wdontneed_reason_other", "hrr"],
+        ["smoothed_dontneed_reason_precautions", "hrr"], ["smoothed_wdontneed_reason_precautions", "hrr"]
       ]
     },
     "indicator-combination": {


### PR DESCRIPTION
### Description
Suppress fb survey `dontneed_reasons_*` in sirCAL. These signals have too low sample size to be reported at the HRR level.