### PR TITLE
remove -dry-run indicator for GS

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -25,7 +25,6 @@
       "span_length": 14,
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
-      "dry_run": true,
       "suppressed_errors": [
       ]
     },

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -15,7 +15,6 @@
       "span_length": 14,
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
-      "dry_run": true,
       "suppressed_errors": [
       ]
     },


### PR DESCRIPTION
### Description
Delivery params worked well for GS, removing dry run to see if validation gating happens 

### Changelog
-params.json.template for both indicator folders and ansible
