### PR TITLE
Add delivery to runner params

### DIFF
--- a/ansible/templates/covid_act_now-params-prod.json.j2
+++ b/ansible/templates/covid_act_now-params-prod.json.j2
@@ -1,6 +1,6 @@
 {
   "common": {
-    "export_dir": "/common/covidcast/receiving/covid-act-now",
+    "export_dir": "./receiving",
     "log_filename": "/var/log/indicators/covid_act_now.log"
   },
   "indicator": {
@@ -44,5 +44,8 @@
       "smoothed_signals": [
       ]
     }
-  }  
+  },
+  "delivery": {
+    "delivery_dir": "/common/covidcast/receiving/covid-act-now"
+  }
 }

--- a/ansible/templates/quidel_covidtest-params-prod.json.j2
+++ b/ansible/templates/quidel_covidtest-params-prod.json.j2
@@ -1,6 +1,6 @@
 {
   "common": {
-    "export_dir": "/common/covidcast/receiving/quidel",
+    "export_dir": "./receiving",
     "log_filename": "/var/log/indicators/quidel_covidtest.log"
   },
   "indicator": {
@@ -47,5 +47,8 @@
         "covid_ag_smoothed_pct_positive"
       ]
     }
+  },
+  "delivery": {
+    "delivery_dir": "/common/covidcast/receiving/quidel"
   }
 }

--- a/ansible/templates/usafacts-params-prod.json.j2
+++ b/ansible/templates/usafacts-params-prod.json.j2
@@ -1,6 +1,6 @@
 {
   "common": {
-    "export_dir": "/common/covidcast/receiving/usa-facts",
+    "export_dir": "./receiving",
     "input_dir": "./input-cache",
     "log_filename": "/var/log/indicators/usafacts.log"
   },
@@ -48,5 +48,8 @@
         "deaths_7dav_incidence_num",
         "deaths_7dav_incidence_prop"]
     }
+  },
+  "delivery": {
+    "delivery_dir": "/common/covidcast/receiving/usa-facts"
   }
 }

--- a/covid_act_now/params.json.template
+++ b/covid_act_now/params.json.template
@@ -44,5 +44,8 @@
       "smoothed_signals": [
       ]
     }
+  },
+  "delivery": {
+    "delivery_dir": "./receiving"
   }
 }

--- a/quidel_covidtest/params.json.template
+++ b/quidel_covidtest/params.json.template
@@ -48,5 +48,8 @@
         "covid_ag_smoothed_pct_positive"
       ]
     }
+  },
+  "delivery": {
+    "delivery_dir": "./receiving"
   }
 }

--- a/usafacts/params.json.template
+++ b/usafacts/params.json.template
@@ -49,5 +49,8 @@
         "deaths_7dav_incidence_num",
         "deaths_7dav_incidence_prop"]
     }
+  },
+  "delivery": {
+    "delivery_dir": "./receiving"
   }
 }


### PR DESCRIPTION
### Description
Add delivery dir to CAN, Quidel, USAFacts

Also change export_dir to ./receiving so that gating can take place

### Changelog
- params.json.template for indicator params and ansible
