### PR TITLE
Add python3.8-dev

### DIFF
--- a/facebook/Dockerfile
+++ b/facebook/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update && apt-get install -qq -y \
     python3-venv \
     sshpass \
     openssh-server \
-    ssmtp
+    ssmtp \
+    python3.8-dev
 
 ADD ./delphiFacebook /facebook/delphiFacebook/
 ADD ./static /facebook/static/


### PR DESCRIPTION
### Description

Fix:

The container image build was failing, presumably due to a mising Python header file that was causing numpy (as a dependency of cvxpy) to fail its build process.

- Add python3.8-dev package

### Changelog

- Update Dockefile