### PR TITLE
[survey] Stop with useful message if any input files fail on load/processing

### DIFF
--- a/facebook/delphiFacebook/R/responses.R
+++ b/facebook/delphiFacebook/R/responses.R
@@ -38,7 +38,7 @@ load_responses_all <- function(params, contingency_run = FALSE) {
   which_errors <- unlist(lapply(input_data, inherits, "try-error"))
   if (any( which_errors )) {
     errored_filenames <- paste(params$input[which_errors], collapse=", ")
-    stop(paste("ingestion and field creation failed for input data file(s)", errored_filenames))
+    stop("ingestion and field creation failed for input data file(s)", errored_filenames)
   }
   
   input_data <- bind_rows(input_data)

--- a/facebook/delphiFacebook/integration-tests/testthat/test-integration.R
+++ b/facebook/delphiFacebook/integration-tests/testthat/test-integration.R
@@ -385,3 +385,10 @@ test_that("testing national aggregation", {
   }
 
 })
+
+test_that("testing load_responses behavior for missing input", {
+  params <- relativize_params(read_params(test_path("params-test.json")))
+  params$input <- c(params$input, "file-does-not-exist.csv")
+  params$parallel <- TRUE
+  expect_error(load_responses_all(params), regexp="ingestion and field creation failed")
+})


### PR DESCRIPTION
### Description
Stop with useful message if any input files fail on initial load and processing in `responses.R::load_response_one`.

### Changelog
- `responses.R`
    - Before binding input file results together, check output type. If any are of type `try-error`, exit with message specifying problematic file names and error message.

### Fixes 
Closes #1349.
