### PR TITLE
Add 02261 to valid geo-codes for jhu

### DIFF
--- a/ansible/templates/jhu-params-prod.json.j2
+++ b/ansible/templates/jhu-params-prod.json.j2
@@ -24,7 +24,7 @@
       "minimum_sample_size": 100,
       "missing_se_allowed": true,
       "missing_sample_size_allowed": true,
-      "additional_valid_geo_values": {"county": ["46113", "02270"]}
+      "additional_valid_geo_values": {"county": ["46113", "02270", "02261"]}
     },
     "dynamic": {
       "ref_window_size": 7,

--- a/jhu/params.json.template
+++ b/jhu/params.json.template
@@ -25,7 +25,7 @@
       "minimum_sample_size": 100,
       "missing_se_allowed": true,
       "missing_sample_size_allowed": true,
-      "additional_valid_geo_values": {"county": ["46113", "02270"]}
+      "additional_valid_geo_values": {"county": ["46113", "02270", "02261"]}
     },
     "dynamic": {
       "ref_window_size": 7,


### PR DESCRIPTION
### Description
Fix check_geo_id for validator: data from 02261 was split into 02263 and 02266 in this [commit](https://github.com/cmu-delphi/covidcast-indicators/commit/9ff0f46d603d8fcae5b2a8d08278cd7729e1e945#diff-68ed56b7a741f7fc5187a7701877e602c6d5c842f19923eca9b3159f125736b5) (#1325), but there's still rows coming from jhu for 02261, which is now not a valid geo_id. We add this as a valid geo_id to go about this.

### Changelog
- params.json.template in /jhu/ and ansible
