### PR TITLE
Remove N/A Values for MA at state level

### DIFF
--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -117,6 +117,12 @@ def run_module(params):
             df=pop_proportion(df, geo_mapper)
         df = make_geo(df, geo, geo_mapper)
         df = smooth_values(df, smoother[0])
+        # Fix N/A MA values, see issue #1360
+        if geo == "state" and sensor.startswith(CONFIRMED_FLU):
+            print(df.shape, geo, smoother, sensor)
+            df = df[~np.logical_and(np.logical_and(df.val.isna(), df.geo_id == "ma"),
+                                    df.timestamp > "08-01-2021")]
+            print(df.shape)
         if df.empty:
             continue
         sensor_name = sensor + smoother[1]

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -119,10 +119,9 @@ def run_module(params):
         df = smooth_values(df, smoother[0])
         # Fix N/A MA values, see issue #1360
         if geo == "state" and sensor.startswith(CONFIRMED_FLU):
-            print(df.shape, geo, smoother, sensor)
-            df = df[~np.logical_and(np.logical_and(df.val.isna(), df.geo_id == "ma"),
-                                    df.timestamp > "08-01-2021")]
-            print(df.shape)
+            ma_filter = df.val.isna() & (df.geo_id == "ma") & (df.timestamp > "08-01-2021") & \
+                (df.timestamp.dt.day_name() == "Tuesday")
+            df = df[~ma_filter]
         if df.empty:
             continue
         sensor_name = sensor + smoother[1]


### PR DESCRIPTION
### Description
MA seems to always give N/A values on Tuesdays, we remove these rows from the dataframe. See #1360 for more details.
In particular, we apply the following filter to HHS:
- Only for confirmed_admissions_influenza_1d (including prop / 7dav variants)
- Dates after 1 August, 2021
- Value is N/A
- Geo_type is state, geo_id is "ma"

### Changelog
Itemize code/test/documentation changes and files added/removed.
- run.py for delphi_hhs
