### PR TITLE
Make FilesystemArchiveDiffer actually apply changes to cache

### DIFF
--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -641,8 +641,24 @@ class FilesystemArchiveDiffer(ArchiveDiffer):
             successes: All files from input
             fails: Empty list
         """
+
+        archive_success, archive_fail = [], []
+        for exported_file in exported_files:
+            archive_file = abspath(
+                join(self.cache_dir, basename(exported_file)))
+
+            # Copy export to cache
+            try:
+                # Archive
+                shutil.copyfile(exported_file, archive_file)
+                archive_success.append(exported_file)
+
+            except FileNotFoundError as ex:
+                print(ex)
+                archive_fail.append(exported_file)
+
         self._exports_archived = True
-        return exported_files, []
+        return archive_success, archive_fail
 
     def update_cache(self):
         """Handle cache updates with a no-op.

--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -641,7 +641,6 @@ class FilesystemArchiveDiffer(ArchiveDiffer):
             successes: All files from input
             fails: Empty list
         """
-
         archive_success, archive_fail = [], []
         for exported_file in exported_files:
             archive_file = abspath(


### PR DESCRIPTION
### Description
FilesystemArchiveDiffer, which is used to build diff-based issues out of confirmation-based issues for data patches without disturbing the S3 archive, is supposed to update the local archive cache in-place. It has apparently _not_ been doing that, this whole time. This PR adds the update mechanism.

I have no idea why we ever thought this was working. Maybe diff_exports used to modify the local cache too, but that was moved in a recent refactor?

### Changelog
Itemize code/test/documentation changes and files added/removed.
- archive.py:FilesystemArchiveDiffer - copy the exported files over to the local cache directory. Stole template code from GitArchiveDiffer for this.

### Fixes 
- Fixes 🤯  from building hhs+flu backissues
