### PR TITLE
Don't report contingency table if responses for supporting items are all `NA`

### DIFF
--- a/facebook/delphiFacebook/R/contingency_aggregate.R
+++ b/facebook/delphiFacebook/R/contingency_aggregate.R
@@ -158,7 +158,12 @@ post_process_aggs <- function(df, aggregations, cw_list) {
   metric_cols <- unique(aggregations$metric)
   
   cols_check_available <- unique(c(group_vars[group_vars != "geo_id"], metric_cols))
-  available <- cols_check_available %in% names(df)
+  available <- unlist(
+    lapply(cols_check_available, function(col) {
+      # Exists in dataframe and column is not only NAs
+      col %in% names(df) && !all(is.na( unique(df[[col]] )))
+    })
+  )
   cols_not_available <- cols_check_available[ !available ]
   for (col_var in cols_not_available) {
     # Remove from aggregations

--- a/facebook/delphiFacebook/R/contingency_aggregate.R
+++ b/facebook/delphiFacebook/R/contingency_aggregate.R
@@ -171,7 +171,7 @@ post_process_aggs <- function(df, aggregations, cw_list) {
                                    !mapply(aggregations$group_by,
                                            FUN=function(x) {col_var %in% x}), ]
     msg_plain(paste0(
-        col_var, " is not defined. Removing all aggregations that use it. ",
+        col_var, " is not available or not defined. Removing all aggregations that use it. ",
         nrow(aggregations), " remaining")
     )
   }


### PR DESCRIPTION
### Description
Some of the current contingency table demographic cuts aren't be available in 2020. For example, breakdowns by vaccination status aren't available before January 2021, and breakdowns by race are not available before September 2020. If we try to report these, we'll end up with all responses in the `NA` race, e.g., row, which isn't useful.

When all responses are missing for a given item during a given time period, drop requested aggregations that rely on that item.

### Changelog
- `contingency_aggregate.R::post_process_aggs` already removes aggregates if any requested fields are unavailable (not included in the dataframe). Expand that to include fields that are present but have all entries `NA`.

### Fixes 
Supports historical backfill of contingency tables.
