### PR TITLE
Stop sirCAL from complaining about missing survey `received_2_vaccine_doses`

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -66,6 +66,7 @@
         "smoothed_vaccine_likely_doctors", "smoothed_wvaccine_likely_doctors",
         "smoothed_felt_isolated_7d", "smoothed_wfelt_isolated_7d",
         "smoothed_worried_become_ill", "smoothed_wworried_become_ill",
+        "smoothed_received_2_vaccine_doses", "smoothed_wreceived_2_vaccine_doses",
         ["smoothed_vaccine_barrier_appointment_time_tried", "msa"], ["smoothed_wvaccine_barrier_appointment_time_tried", "msa"],
         ["smoothed_vaccine_barrier_childcare_tried", "msa"], ["smoothed_wvaccine_barrier_childcare_tried", "msa"],
         ["smoothed_vaccine_barrier_document_tried", "msa"], ["smoothed_wvaccine_barrier_document_tried", "msa"],

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -66,6 +66,7 @@
         "smoothed_vaccine_likely_doctors", "smoothed_wvaccine_likely_doctors",
         "smoothed_felt_isolated_7d", "smoothed_wfelt_isolated_7d",
         "smoothed_worried_become_ill", "smoothed_wworried_become_ill",
+        "smoothed_received_2_vaccine_doses", "smoothed_wreceived_2_vaccine_doses",
         ["smoothed_vaccine_barrier_appointment_time_tried", "msa"], ["smoothed_wvaccine_barrier_appointment_time_tried", "msa"],
         ["smoothed_vaccine_barrier_childcare_tried", "msa"], ["smoothed_wvaccine_barrier_childcare_tried", "msa"],
         ["smoothed_vaccine_barrier_document_tried", "msa"], ["smoothed_wvaccine_barrier_document_tried", "msa"],


### PR DESCRIPTION
### Description
Item V2 was removed from the survey as of Nov 8, so stop sirCAL from checking if derived signals are up-to-date.

### Changelog
- sirCAL ansible template params and package template params.