### PR TITLE
Appease linter

### DIFF
--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -696,8 +696,6 @@ if __name__ == "__main__":
     if "archive" not in _params:
         _params = {"archive": _params, "common": _params}
 
-    logger = get_structured_logger(
+    archiver_from_params(_params).run(get_structured_logger(
         __name__, filename=_params["common"].get("log_filename"),
-        log_exceptions=_params["common"].get("log_exceptions", True))
-
-    archiver_from_params(_params).run(logger)
+        log_exceptions=_params["common"].get("log_exceptions", True)))


### PR DESCRIPTION
### Description
For some reason this didn't show up in #1367 or #1368 but only when they were combined 🤷  

### Changelog
Itemize code/test/documentation changes and files added/removed.
- archive.py: don't store logger in local variable before running from `__main__`

### Fixes 
- Fixes [failed build](https://github.com/cmu-delphi/covidcast-indicators/actions/runs/1517170608)
