### PR TITLE
Drop indicator-combination from sirCAL checks

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -89,11 +89,6 @@
         ["smoothed_dontneed_reason_precautions", "hrr"], ["smoothed_wdontneed_reason_precautions", "hrr"]
       ]
     },
-    "indicator-combination": {
-      "max_age": 4,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
-      "retired-signals": ["nmf_day_doc_fbs_ght", "nmf_day_doc_fbc_fbs_ght", "confirmed_7dav_cumulative_num", "confirmed_7dav_cumulative_prop", "deaths_7dav_cumulative_num", "deaths_7dav_cumulative_prop"]
-    },
     "quidel": {
       "max_age":6,
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"],

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -88,11 +88,6 @@
         ["smoothed_dontneed_reason_precautions", "hrr"], ["smoothed_wdontneed_reason_precautions", "hrr"]
       ]
     },
-    "indicator-combination": {
-      "max_age": 4,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
-      "retired-signals": ["nmf_day_doc_fbs_ght", "nmf_day_doc_fbc_fbs_ght", "confirmed_7dav_cumulative_num", "confirmed_7dav_cumulative_prop", "deaths_7dav_cumulative_num", "deaths_7dav_cumulative_prop"]
-    },
     "quidel": {
       "max_age":6,
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"],


### PR DESCRIPTION
### Description
`indicator-combination` pipeline was stopped on November 18; this PR tells sirCAL to stop checking it.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- dev and production params for sirCAL: drop entry for indicator-combination

