### PR TITLE
Drop cdc_covidnet from Jenkins indicator list

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@
    - Keep in sync with '.github/workflows/python-ci.yml'.
    - TODO: #527 Get this list automatically from python-ci.yml at runtime.
  */
-def indicator_list = ["cdc_covidnet", "changehc", "claims_hosp", "combo_cases_and_deaths", "covid_act_now", "facebook", "google_symptoms", "hhs_hosp", "jhu", "nchs_mortality", "quidel", "quidel_covidtest", "safegraph_patterns", "sir_complainsalot", "usafacts"]
+def indicator_list = ["changehc", "claims_hosp", "covid_act_now", "facebook", "google_symptoms", "hhs_hosp", "jhu", "nchs_mortality", "quidel", "quidel_covidtest", "safegraph_patterns", "sir_complainsalot", "usafacts"]
 def build_package = [:]
 def deploy_staging = [:]
 def deploy_production = [:]


### PR DESCRIPTION
### Description
Jenkins build is currently failing on main for cdc-covidnet, but since we've never released that indicator, it's more expedient to just...stop trying to build it.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Jenkinsfile - remove cdc-covidnet. Also removes indicator-combination while we're at it (see also https://github.com/cmu-delphi/covidcast-indicators/pull/1380)

### Fixes 
- Fixes [failing Jenkins build](https://jenkins-ci-prod-01.delphi.cmu.edu/blue/organizations/jenkins/covidcast-indicators/detail/main/266/pipeline)
