### PR TITLE
Explicitly install numpy in build-and-package

### DIFF
--- a/jenkins/build-and-package.sh
+++ b/jenkins/build-and-package.sh
@@ -19,6 +19,7 @@ cd "${WORKSPACE}/${local_indicator}" || exit
 python -m venv env
 source env/bin/activate
 pip install --upgrade pip --retries 10 --timeout 20
+pip install numpy --retries 10 --timeout 20
 pip install ../_delphi_utils_python/. --retries 10 --timeout 20
 pip install . --retries 10 --timeout 20
 


### PR DESCRIPTION
### Description
Averts crash while trying to install ecos, a dependency of cvxpy

### Changelog
Itemize code/test/documentation changes and files added/removed.
- build-and-package.sh: Install numpy before attempting to install delphi-utils.

### Fixes 
- Fixes [failing jenkins build](https://jenkins-ci-prod-01.delphi.cmu.edu/blue/organizations/jenkins/covidcast-indicators/detail/main/269/pipeline)
