### PR TITLE
Add 2019 and 2020 directories to delphi-utils package_data

### DIFF
--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -40,5 +40,5 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     packages=find_packages(),
-    package_data={'': ['data/*.csv']}
+    package_data={'': ['data/20*/*.csv']}
 )


### PR DESCRIPTION
### Description
We missed this in https://github.com/cmu-delphi/covidcast-indicators/pull/1351, and CI didn't catch it because we install with -e 😢 

Update the package_data for delphi-utils to include the 2019 and 2020 directories, not just the root csv files.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- setup.py: package_data

### Fixes 
- Fixes #1388
