### PR TITLE
[CTIS] Fix `latest_weight_date` regex input so date isn't missing

### DIFF
--- a/facebook/delphiFacebook/R/weights.R
+++ b/facebook/delphiFacebook/R/weights.R
@@ -65,7 +65,7 @@ join_weights <- function(data, params, weights = c("step1", "full"))
 
   latest_weight <- tail(weights_files, n = 1)
   latest_weight_date <- as.Date(
-    stri_extract_first(latest_weight, regex = "^[0-9]{4}-[0-9]{2}-[0-9]{2}")
+    stri_extract_first(basename(latest_weight), regex = "^[0-9]{4}-[0-9]{2}-[0-9]{2}")
   )
   
   col_types <- c("character", "double")


### PR DESCRIPTION
### Description
Apply regex that gets weight file date to weight filename only. The regex returns `NA` if given the whole path. Followup to #1379.

### Changelog
- `weights.R::join_weights()`: apply regex to filename only.

### Fixes
When `latest_weight_date` is missing, the pipeline generates too-recent smoothed weighted indicators since [the condition](https://github.com/cmu-delphi/covidcast-indicators/blob/a2004f38c3f70bdbdb65ddc5706cd8f9413a9ca6/facebook/delphiFacebook/R/aggregate.R#L184-L186) to suppress too-recent indicators never triggers.