### PR TITLE
Change CAN max lag to 9

### DIFF
--- a/ansible/templates/covid_act_now-params-prod.json.j2
+++ b/ansible/templates/covid_act_now-params-prod.json.j2
@@ -20,7 +20,7 @@
       "data_source": "covid-act-now",
       "span_length": 14,
       "min_expected_lag": {"all": "3"},
-      "max_expected_lag": {"all": "6"},
+      "max_expected_lag": {"all": "9"},
       "dry_run": true,
       "suppressed_errors": [
         {"check_name": "check_se_many_missing",

--- a/covid_act_now/params.json.template
+++ b/covid_act_now/params.json.template
@@ -20,7 +20,7 @@
       "data_source": "covid-act-now",
       "span_length": 14,
       "min_expected_lag": {"all": "3"},
-      "max_expected_lag": {"all": "6"},
+      "max_expected_lag": {"all": "9"},
       "dry_run": true,
       "suppressed_errors": [
         {"check_name": "check_se_many_missing",


### PR DESCRIPTION


### Description
Following similar update in sirCAL (See #1366): adjusting covid-act-now max indicator lag to 9 since the CDC increases lag on their end

### Changelog
Itemize code/test/documentation changes and files added/removed.
- params.json.template files

