### PR TITLE
Remove artificial day shift in labeling

### DIFF
--- a/claims_hosp/delphi_claims_hosp/config.py
+++ b/claims_hosp/delphi_claims_hosp/config.py
@@ -3,7 +3,7 @@ This file contains configuration variables used to generate the claims-based Hos
 
 Author: Maria Jahja
 Created: 2020-06-01
-Modified: 2020-09-27
+Modified: 2021-12-11
 
 """
 
@@ -26,8 +26,8 @@ class Config:
     # (one day needed for smoother to produce values)
     BURN_IN_PERIOD = timedelta(days=1)
 
-    # shift dates forward for labeling purposes
-    DAY_SHIFT = timedelta(days=1)
+    # if desired, shift dates forward for labeling purposes
+    DAY_SHIFT = timedelta(days=0)
 
     # data columns
     CLAIMS_COUNT_COLS = ["Denominator", "Covid_like"]

--- a/claims_hosp/tests/test_update_indicator.py
+++ b/claims_hosp/tests/test_update_indicator.py
@@ -141,7 +141,7 @@ class TestClaimsHospIndicatorUpdater:
         updater.write_to_csv(res0, td.name)
 
         # check outputs
-        expected_name = f"20200502_geography_{Config.signal_name}.csv"
+        expected_name = f"20200501_geography_{Config.signal_name}.csv"
         assert exists(join(td.name, expected_name))
         output_data = pd.read_csv(join(td.name, expected_name))
         assert (
@@ -155,7 +155,7 @@ class TestClaimsHospIndicatorUpdater:
         assert np.isnan(output_data.direction.values).all()
         assert np.isnan(output_data.sample_size.values).all()
 
-        expected_name = f"20200503_geography_{Config.signal_name}.csv"
+        expected_name = f"20200502_geography_{Config.signal_name}.csv"
         assert exists(join(td.name, expected_name))
         output_data = pd.read_csv(join(td.name, expected_name))
         assert (
@@ -167,7 +167,7 @@ class TestClaimsHospIndicatorUpdater:
         assert np.isnan(output_data.direction.values).all()
         assert np.isnan(output_data.sample_size.values).all()
 
-        expected_name = f"20200505_geography_{Config.signal_name}.csv"
+        expected_name = f"20200504_geography_{Config.signal_name}.csv"
         assert exists(join(td.name, expected_name))
         output_data = pd.read_csv(join(td.name, expected_name))
         assert (
@@ -221,7 +221,7 @@ class TestClaimsHospIndicatorUpdater:
         updater.write_to_csv(res0, td.name)
 
         # check outputs
-        expected_name = f"20200502_geography_{signal_name}.csv"
+        expected_name = f"20200501_geography_{signal_name}.csv"
         assert exists(join(td.name, expected_name))
         output_data = pd.read_csv(join(td.name, expected_name))
         assert (


### PR DESCRIPTION
### Description
Match config behavior in [doctor-visits](https://github.com/cmu-delphi/covidcast-indicators/blob/main/doctor_visits/delphi_doctor_visits/config.py) where `DAY_SHIFT` is set to 0. 

### Changelog
- delphi_claims_hosp/config.py
