### PR TITLE
Fix pipeline when barrier column is all NAs part 2

### DIFF
--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -646,7 +646,9 @@ code_vaccines <- function(input_data, wave) {
     # If the entire column is NA, ifelse() results in a logical vector, not a
     # character vector, which confuses split_options; since the result should be
     # NA anyway
-    vaccine_barriers <- ifelse(vaccine_barriers == "13", NA_character_, vaccine_barriers)
+    vaccine_barriers <- as.character(
+      ifelse(vaccine_barriers == "13", NA_character_, vaccine_barriers)
+    )
     if (any(!is.na(vaccine_barriers))) {
       vaccine_barriers <- split_options(vaccine_barriers)
     }
@@ -786,7 +788,9 @@ code_vaccines <- function(input_data, wave) {
     # If the entire column is NA, ifelse() results in a logical vector, not a
     # character vector, which confuses split_options; since the result should be
     # NA anyway
-    vaccine_barriers <- ifelse(input_data$V15b == "13", NA, input_data$V15b)
+    vaccine_barriers <- as.character(
+      ifelse(input_data$V15b == "13", NA, input_data$V15b)
+    )
     if (any(!is.na(vaccine_barriers))) {
       vaccine_barriers <- split_options(vaccine_barriers)
     } else {

--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -646,8 +646,8 @@ code_vaccines <- function(input_data, wave) {
     # If the entire column is NA, ifelse() results in a logical vector, not a
     # character vector, which confuses split_options; since the result should be
     # NA anyway
+    vaccine_barriers <- ifelse(vaccine_barriers == "13", NA_character_, vaccine_barriers)
     if (any(!is.na(vaccine_barriers))) {
-      vaccine_barriers <- ifelse(vaccine_barriers == "13", NA_character_, vaccine_barriers)
       vaccine_barriers <- split_options(vaccine_barriers)
     }
 
@@ -786,8 +786,8 @@ code_vaccines <- function(input_data, wave) {
     # If the entire column is NA, ifelse() results in a logical vector, not a
     # character vector, which confuses split_options; since the result should be
     # NA anyway
-    if (any(!is.na(input_data$V15b))) {
-      vaccine_barriers <- ifelse(input_data$V15b == "13", NA, input_data$V15b)
+    vaccine_barriers <- ifelse(input_data$V15b == "13", NA, input_data$V15b)
+    if (any(!is.na(vaccine_barriers))) {
       vaccine_barriers <- split_options(vaccine_barriers)
     } else {
       vaccine_barriers <- input_data$V15b

--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -793,8 +793,6 @@ code_vaccines <- function(input_data, wave) {
     )
     if (any(!is.na(vaccine_barriers))) {
       vaccine_barriers <- split_options(vaccine_barriers)
-    } else {
-      vaccine_barriers <- input_data$V15b
     }
 
     input_data$v_vaccine_barrier_eligible_tried <- is_selected(vaccine_barriers, "1")

--- a/facebook/delphiFacebook/src/RcppExports.cpp
+++ b/facebook/delphiFacebook/src/RcppExports.cpp
@@ -5,11 +5,6 @@
 
 using namespace Rcpp;
 
-#ifdef RCPP_USE_GLOBAL_ROSTREAM
-Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
-Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
-#endif
-
 // is_selected_cpp
 LogicalVector is_selected_cpp(List responses, String target);
 RcppExport SEXP _delphiFacebook_is_selected_cpp(SEXP responsesSEXP, SEXP targetSEXP) {


### PR DESCRIPTION
### Description
Followup to #1346. Set answer code 13 to NA *before* checking if col is all NA.

### Changelog
- `variables.R`

### Fixes 
In rare cases, `vaccine_barriers <- ifelse(vaccine_barriers == "13", NA, vaccine_barriers)` or `vaccine_barriers <- ifelse(input_data$V15b == "13", NA, input_data$V15b)` will make a column all NA when it wasn't before. This happens when the only non-NA responses have answer code "13".
