### PR TITLE
Combine V15a/c logic properly for survey Wave 12

### DIFF
--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -665,22 +665,10 @@ code_vaccines <- function(input_data, wave) {
     input_data$v_vaccine_barrier_time <- is_selected(vaccine_barriers, "10")
     input_data$v_vaccine_barrier_type <- is_selected(vaccine_barriers, "12")
     input_data$v_vaccine_barrier_none <- is_selected(vaccine_barriers, "11")
-  } else {
-    input_data$v_vaccine_barrier_eligible <- NA
-    input_data$v_vaccine_barrier_no_appointments <- NA
-    input_data$v_vaccine_barrier_appointment_time <- NA
-    input_data$v_vaccine_barrier_technical_difficulties <- NA
-    input_data$v_vaccine_barrier_document <- NA
-    input_data$v_vaccine_barrier_technology_access <- NA
-    input_data$v_vaccine_barrier_travel <- NA
-    input_data$v_vaccine_barrier_language <- NA
-    input_data$v_vaccine_barrier_childcare <- NA
-    input_data$v_vaccine_barrier_time <- NA
-    input_data$v_vaccine_barrier_type <- NA
-    input_data$v_vaccine_barrier_none <- NA
-  }
-  
-  if ( all(c("V15c", "V15b") %in% names(input_data)) ) {
+
+    input_data$v_vaccine_barrier_appointment_location <- NA
+    input_data$v_vaccine_barrier_other <- NA
+  } else if ( all(c("V15c", "V15b") %in% names(input_data)) ) {
     # V15c introduced in Wave 12, replacing V15a with clarified wording.
     vaccine_barriers <- coalesce(input_data$V15c, input_data$V15b)
     vaccine_barriers <- ifelse(vaccine_barriers == "13", NA, vaccine_barriers)
@@ -713,6 +701,7 @@ code_vaccines <- function(input_data, wave) {
     input_data$v_vaccine_barrier_time <- NA
     input_data$v_vaccine_barrier_type <- NA
     input_data$v_vaccine_barrier_none <- NA
+
     input_data$v_vaccine_barrier_appointment_location <- NA
     input_data$v_vaccine_barrier_other <- NA
   }
@@ -733,22 +722,10 @@ code_vaccines <- function(input_data, wave) {
     input_data$v_vaccine_barrier_time_has <- is_selected(vaccine_barriers, "10")
     input_data$v_vaccine_barrier_type_has <- is_selected(vaccine_barriers, "12")
     input_data$v_vaccine_barrier_none_has <- is_selected(vaccine_barriers, "11")
-  } else {
-    input_data$v_vaccine_barrier_eligible_has <- NA
-    input_data$v_vaccine_barrier_no_appointments_has <- NA
-    input_data$v_vaccine_barrier_appointment_time_has <- NA
-    input_data$v_vaccine_barrier_technical_difficulties_has <- NA
-    input_data$v_vaccine_barrier_document_has <- NA
-    input_data$v_vaccine_barrier_technology_access_has <- NA
-    input_data$v_vaccine_barrier_travel_has <- NA
-    input_data$v_vaccine_barrier_language_has <- NA
-    input_data$v_vaccine_barrier_childcare_has <- NA
-    input_data$v_vaccine_barrier_time_has <- NA
-    input_data$v_vaccine_barrier_type_has <- NA
-    input_data$v_vaccine_barrier_none_has <- NA
-  }
-  
-  if ( "V15c" %in% names(input_data) ) {
+
+    input_data$v_vaccine_barrier_appointment_location_has <- NA
+    input_data$v_vaccine_barrier_other_has <- NA
+  } else if ( "V15c" %in% names(input_data) ) {
     # V15c introduced in Wave 12, replacing V15a with clarified wording.
     vaccine_barriers <- split_options(input_data$V15c)
     
@@ -779,6 +756,7 @@ code_vaccines <- function(input_data, wave) {
     input_data$v_vaccine_barrier_time_has <- NA
     input_data$v_vaccine_barrier_type_has <- NA
     input_data$v_vaccine_barrier_none_has <- NA
+
     input_data$v_vaccine_barrier_appointment_location_has <- NA
     input_data$v_vaccine_barrier_other_has <- NA
   }

--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -639,6 +639,12 @@ code_vaccines <- function(input_data, wave) {
     input_data$v_worried_vaccine_side_effects <- NA_real_
   }
 
+  
+  # Wave  V15a  V15b  V15c
+  # 11    Yes   Yes   No
+  # 12    No    Yes   Yes
+  #
+  # V15c replaces V15a as of Wave 12
   if ( all(c("V15a", "V15b") %in% names(input_data)) ) {
     # introduced in Wave 11
     vaccine_barriers <- coalesce(input_data$V15a, input_data$V15b)


### PR DESCRIPTION
### Description
Since items V15a and V15c won't be available at the same time for a given data file, combine their `if` blocks into one so that only one of the conditions is triggered per data file.

### Changelog
- `variables.R`: Change `if` blocks that depend on item V15c (`if ( all(c("V15c", "V15b") %in% names(input_data)) )` and `if ( "V15c" %in% names(input_data) )`) to `else if`.

### Fixes 
error introduced in #1303.

When item V15a exists, as in Wave 11 data, `vaccine_barrier_*` and `vaccine_barrier_*_has` fields were created in an initial `if` block. A second `if` block checked for the existence of item V15c (replacing V15a as of Wave 12) and if not found, overwrote those fields with `NA`. Since the existence of V15a and V15c were checked separately, the V15c `else` condition was always triggered, resulting in the `vaccine_barrier_*` and `vaccine_barrier_*_has` fields always being completely missing for pre-Wave 12 survey versions and the relevant indicators not being reported.

We'll need to reissue the `smoothed_wvaccine_barrier_*` and `smoothed_wvaccine_barrier_*_has` indicators back to Dec 12.