### PR TITLE
[CTIS] Codebook improvements

### DIFF
--- a/facebook/qsf-tools/generate-codebook.R
+++ b/facebook/qsf-tools/generate-codebook.R
@@ -350,7 +350,7 @@ add_qdf_to_codebook <- function(qdf,
   } else {
     codebook <- read_csv(path_to_codebook, col_types = cols(
       .default = col_character(),
-      wave = col_integer(),
+      wave = col_double(),
       variable = col_character(),
       replaces = col_character(),
       description = col_character(),

--- a/facebook/qsf-tools/generate-codebook.R
+++ b/facebook/qsf-tools/generate-codebook.R
@@ -399,7 +399,7 @@ add_static_fields <- function(codebook,
   codebook <- bind_rows(codebook, static_fields) %>% 
     filter(!(variable == "module" & wave < 11), # module field is only available for wave >= 11
            !(variable %in% c("wave", "UserLanguage", "fips") & wave < 4), # wave, UserLangauge, and fips fields are only available for wave >= 4
-           !(variable == "w12_treatment" & wave == 12.5), # experimental arm field is only available for wave == 12.5
+           !(variable == "w12_treatment" & wave != 12.5), # experimental arm field is only available for wave == 12.5
            variable != "Random_Number"
     )
 

--- a/facebook/qsf-tools/generate-codebook.R
+++ b/facebook/qsf-tools/generate-codebook.R
@@ -438,7 +438,7 @@ get_static_fields <- function(wave,
 add_qsf_to_codebook <- function(path_to_qsf, path_to_codebook) {
   qdf <- process_qsf(path_to_qsf)
   codebook <- add_qdf_to_codebook(qdf, path_to_codebook)
-  write_excel_csv(codebook, path_to_codebook)
+  write_excel_csv(codebook, path_to_codebook, quote="needed")
 }
 
 


### PR DESCRIPTION
### Description
Since experimental wave 12 is referred to as "12.5", reading it as an integer causes a parsing problem that corrupts the codebook.

Tell `readr::write_excel_csv` to use minimal quotes so Wave 12.5 -> Wave 12 codebook diff is smaller.

Fix logic error in filtering `w12_treatment` field so that `w12_treatment` is included for only experimental Wave 12 ("12.5").

### Changelog
- `generate-codebook.R`