### PR TITLE
Patch validator for chng subdivision mapping change

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -111,8 +111,9 @@ def get_geo_signal_combos(data_source):
     Cross references based on combinations reported available by COVIDcast metadata.
     """
     # Maps data_source name with what's in the API, lists used in case of multiple names
+    # TODO: https://github.com/cmu-delphi/covidcast-indicators/issues/1457
+    # Extract this mapping from meta response instead of hard-coding
     source_signal_mappings = {
-        'chng': ['chng-cli', 'chng-covid'],
         'indicator-combination': ['indicator-combination-cases-deaths'],
         'quidel': ['quidel-covid-ag'],
         'safegraph': ['safegraph-weekly']

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -111,8 +111,9 @@ def get_geo_signal_combos(data_source):
     Cross references based on combinations reported available by COVIDcast metadata.
     """
     # Maps data_source name with what's in the API, lists used in case of multiple names
-    # TODO: https://github.com/cmu-delphi/covidcast-indicators/issues/1457
-    # Extract this mapping from meta response instead of hard-coding
+    # pylint: disable=fixme
+    # TODO: Extract this mapping from meta response instead of hard-coding
+    # https://github.com/cmu-delphi/covidcast-indicators/issues/1457
     source_signal_mappings = {
         'indicator-combination': ['indicator-combination-cases-deaths'],
         'quidel': ['quidel-covid-ag'],

--- a/_delphi_utils_python/tests/validator/test_datafetcher.py
+++ b/_delphi_utils_python/tests/validator/test_datafetcher.py
@@ -21,8 +21,9 @@ class TestDataFetcher:
         assert not date_filter(FILENAME_REGEX.match("20200620_a_b.csv"))
         assert not date_filter(FILENAME_REGEX.match("202006_a_b.csv"))
 
-    # TODO: https://github.com/cmu-delphi/covidcast-indicators/issues/1456
-    # mock out the advanced meta endpoint /covidcast/meta as well
+    # pylint: disable=fixme
+    # TODO: mock out the advanced meta endpoint /covidcast/meta as well
+    # https://github.com/cmu-delphi/covidcast-indicators/issues/1456
     @mock.patch("covidcast.metadata")
     def test_get_geo_signal_combos(self, mock_metadata):
         """Test that the geo signal combos are correctly pulled from the covidcast metadata."""

--- a/_delphi_utils_python/tests/validator/test_datafetcher.py
+++ b/_delphi_utils_python/tests/validator/test_datafetcher.py
@@ -21,6 +21,8 @@ class TestDataFetcher:
         assert not date_filter(FILENAME_REGEX.match("20200620_a_b.csv"))
         assert not date_filter(FILENAME_REGEX.match("202006_a_b.csv"))
 
+    # TODO: https://github.com/cmu-delphi/covidcast-indicators/issues/1456
+    # mock out the advanced meta endpoint /covidcast/meta as well
     @mock.patch("covidcast.metadata")
     def test_get_geo_signal_combos(self, mock_metadata):
         """Test that the geo signal combos are correctly pulled from the covidcast metadata."""


### PR DESCRIPTION
### Description
Tests are currently failing for validator after changing the source subdivision mapping for the changehc indicator. This PR installs a quick patch but does not solve the underlying problems, which are described in more detail in #1456 and #1457.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- test_datafetcher.py: Add todo
- datafetcher.py: Drop hardcoded mappings for `chng` source and add todo

### Fixes 
- Fixes failing builds
