### PR TITLE
Remove covid-act-now from sirCAL, CI, and Jenkins

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        packages: [_delphi_utils_python, changehc, claims_hosp, combo_cases_and_deaths, covid_act_now, doctor_visits, google_symptoms, hhs_hosp, hhs_facilities, jhu, nchs_mortality, nowcast, quidel, quidel_covidtest, safegraph_patterns, sir_complainsalot, usafacts]
+        packages: [_delphi_utils_python, changehc, claims_hosp, combo_cases_and_deaths, doctor_visits, google_symptoms, hhs_hosp, hhs_facilities, jhu, nchs_mortality, nowcast, quidel, quidel_covidtest, safegraph_patterns, sir_complainsalot, usafacts]
     defaults:
       run:
         working-directory: ${{ matrix.packages }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@
    - Keep in sync with '.github/workflows/python-ci.yml'.
    - TODO: #527 Get this list automatically from python-ci.yml at runtime.
  */
-def indicator_list = ["changehc", "claims_hosp", "covid_act_now", "facebook", "google_symptoms", "hhs_hosp", "jhu", "nchs_mortality", "quidel", "quidel_covidtest", "safegraph_patterns", "sir_complainsalot", "usafacts"]
+def indicator_list = ["changehc", "claims_hosp", "facebook", "google_symptoms", "hhs_hosp", "jhu", "nchs_mortality", "quidel", "quidel_covidtest", "safegraph_patterns", "sir_complainsalot", "usafacts"]
 def build_package = [:]
 def deploy_staging = [:]
 def deploy_production = [:]

--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -102,10 +102,6 @@
       "max_age":16,
       "maintainers": []
     },
-    "covid-act-now": {
-      "max_age":9,
-      "maintainers": []
-    },
     "hhs": {
       "max_age":8,
       "maintainers": []

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -101,10 +101,6 @@
       "max_age":16,
       "maintainers": []
     },
-    "covid-act-now": {
-      "max_age":9,
-      "maintainers": []
-    },
     "hhs": {
       "max_age":8,
       "maintainers": []


### PR DESCRIPTION
### Description
We're deactivating CAN; let's not check for it any more, anywhere.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- sirCAL prod and dev params
- python-ci
- Jenkinsfile

