### PR TITLE
Add hospital admissions to CPR indicator

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.event.pull_request.draft == false
     strategy:
       matrix:
-        packages: [_delphi_utils_python, changehc, claims_hosp, combo_cases_and_deaths, covid_act_now, doctor_visits, google_symptoms, hhs_hosp, hhs_facilities, jhu, nchs_mortality, nowcast, quidel, quidel_covidtest, safegraph_patterns, sir_complainsalot, usafacts]
+        packages: [_delphi_utils_python, changehc, claims_hosp, combo_cases_and_deaths, covid_act_now, doctor_visits, dsew_community_profile, google_symptoms, hhs_hosp, hhs_facilities, jhu, nchs_mortality, nowcast, quidel, quidel_covidtest, safegraph_patterns, sir_complainsalot, usafacts]
     defaults:
       run:
         working-directory: ${{ matrix.packages }}

--- a/ansible/templates/dsew_community_profile-prod.json.j2
+++ b/ansible/templates/dsew_community_profile-prod.json.j2
@@ -1,0 +1,32 @@
+{
+  "common": {
+    "export_dir": "./receiving",
+    "log_filename": "dsew_cpr.log"
+  },
+  "indicator": {
+    "input_cache": "./input_cache",
+    "reports": "new"
+  },
+  "validation": {
+    "common": {
+      "data_source": "dsew_cpr",
+      "span_length": 14,
+      "min_expected_lag": {"all": "5"},
+      "max_expected_lag": {"all": "9"},
+      "dry_run": true,
+      "suppressed_errors": []
+    },
+    "static": {
+      "minimum_sample_size": 0,
+      "missing_se_allowed": true,
+      "missing_sample_size_allowed": true
+    },
+    "dynamic": {
+      "ref_window_size": 7,
+      "smoothed_signals": [
+        "naats_total_7dav",
+        "naats_positivity_7dav"
+      ]
+    }
+  }
+}

--- a/dsew_community_profile/delphi_dsew_community_profile/constants.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/constants.py
@@ -46,14 +46,27 @@ TRANSFORMS = {
         )
     ]}
 
-# signal id : is_rate
+# signal id : is_rate, name to report in API
 SIGNALS = {
-    "total": False,
-    "positivity": True
+    "total": {
+        "is_rate" : False,
+        "api_name": "naats_total_7dav"
+    },
+    "positivity": {
+        "is_rate" : True,
+        "api_name": "naats_positivity_7dav"
+    },
+    "confirmed covid-19 admissions": {
+        "is_rate" : False,
+        "api_name": "confirmed_admissions_covid_1d_7dav",
+        "date_key": "hosp"
+    }
 }
+
+TOTAL_7D_SIGNALS = ("total", "confirmed covid-19 admissions")
 
 def make_signal_name(key):
     """Convert a signal key to the corresponding signal name for the API."""
-    return f"naats_{key}_7dav"
+    return SIGNALS[key]["api_name"]
 
 NEWLINE="\n"

--- a/dsew_community_profile/delphi_dsew_community_profile/constants.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/constants.py
@@ -58,12 +58,11 @@ SIGNALS = {
     },
     "confirmed covid-19 admissions": {
         "is_rate" : False,
-        "api_name": "confirmed_admissions_covid_1d_7dav",
-        "date_key": "hosp"
+        "api_name": "confirmed_admissions_covid_1d_7dav"
     }
 }
 
-TOTAL_7D_SIGNALS = ("total", "confirmed covid-19 admissions")
+COUNTS_7D_SIGNALS = {key for key, value in SIGNALS.items() if not value["is_rate"]}
 
 def make_signal_name(key):
     """Convert a signal key to the corresponding signal name for the API."""

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -323,7 +323,7 @@ def nation_from_state(df, sig, geomapper):
     if SIGNALS[sig]["is_rate"]: # true if sig is a rate
         df = geomapper.add_population_column(df, "state_id") \
                       .rename(columns={"population":"weight"})
-        df.weight = df.weight / df.weight.sum()
+        df.weight = df.weight / df.weight.sum() * len(df.timestamp.unique())
     return geomapper.replace_geocode(
         df,
         'state_id',

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -80,7 +80,8 @@ class DatasetTimes:
         else:
             raise ValueError(f"Couldn't find reference date in header '{header}'")
 
-        return DatasetTimes(column, positivity_reference_date, total_reference_date, hosp_reference_date)
+        return DatasetTimes(column, positivity_reference_date,
+            total_reference_date, hosp_reference_date)
     def __getitem__(self, key):
         """Use DatasetTimes like a dictionary."""
         if key.lower()=="positivity":
@@ -90,7 +91,8 @@ class DatasetTimes:
         if key.lower()=="confirmed covid-19 admissions":
             return self.hosp_reference_date
         raise ValueError(
-            f"Bad reference date type request '{key}'; need 'total', 'positivity', or 'confirmed covid-19 admissions'"
+            f"Bad reference date type request '{key}'; " + \
+            "need 'total', 'positivity', or 'confirmed covid-19 admissions'"
         )
     def __setitem__(self, key, newvalue):
         """Use DatasetTimes like a dictionary."""
@@ -102,7 +104,8 @@ class DatasetTimes:
             self.hosp_reference_date = newvalue
         else:
             raise ValueError(
-                f"Bad reference date type request '{key}'; need 'total', 'positivity', or 'confirmed covid-19 admissions'"
+                f"Bad reference date type request '{key}'; " + \
+                "need 'total', 'positivity', or 'confirmed covid-19 admissions'"
             )
     def __eq__(self, other):
         """Check equality by value."""

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -316,13 +316,13 @@ def download_and_parse(listing, logger):
 
 def nation_from_state(df, sig, geomapper):
     """Compute nation level from state df."""
-    if SIGNALS[sig]: # true if sig is a rate
-        df = geomapper.add_population_column(df, "state_code") \
+    if SIGNALS[sig]["is_rate"]: # true if sig is a rate
+        df = geomapper.add_population_column(df, "state_id") \
                       .rename(columns={"population":"weight"})
         df.weight = df.weight / df.weight.sum()
     return geomapper.replace_geocode(
         df,
-        'state_code',
+        'state_id',
         'nation',
         new_col="geo_id"
     )
@@ -343,7 +343,7 @@ def fetch_new_reports(params, logger=None):
     geomapper = GeoMapper()
     for sig in SIGNALS:
         ret[("nation", sig)] = nation_from_state(
-            ret[("state", sig)].rename(columns={"geo_id": "state_code"}),
+            ret[("state", sig)].rename(columns={"geo_id": "state_id"}),
             sig,
             geomapper
         )


### PR DESCRIPTION
### Description
Add hospital admissions (pediatric + adult) to the Community Profile Report indicator. Generalize some package logic. Add tests to CI.

### Changelog
- `constants.py` - add info for hosp admissions signal. Add more fields to `SIGNALS` subdicts.
- `pull.py`
    - Define regex for hosp header. Have `from_header` check if a match exists for each header regex.
    - Extend `retain_header` and `skip_overheader` to keep hosp header/overheader.
    - Allow changes to `DatasetTimes` attributes so can combine test and hosp `DatasetTimes` objects when necessary.
    - Switch `nation_from_state` to use `state_id` instead of `state_code`. CPR uses state appreviations not FIPS codes, so `state_code` was causing nation dfs to be empty.
- `test_pull.py`
- `.github/workflows/python-ci.yml`
- `ansible/templates/dsew_community_profile-prod.json.j2`

### Fixes
Partially addresses #1354.