### PR TITLE
Fix requests.get mock

### DIFF
--- a/_delphi_utils_python/tests/validator/test_datafetcher.py
+++ b/_delphi_utils_python/tests/validator/test_datafetcher.py
@@ -31,7 +31,10 @@ class TestDataFetcher:
 
             def json(self):
                 return self.json_data
-        if kwargs["params"] == {'signal':'chng:inactive'}:
+        if len(kwargs) == 0:
+            return MockResponse([{'source': 'chng', 'db_source': 'chng'},
+                {'source': 'covid-act-now', 'db_source': 'covid-act-now'}], 200)
+        elif kwargs["params"] == {'signal': 'chng:inactive'}:
             return MockResponse([{"signals": [{"active": False}]}], 200)
         else:
             return MockResponse([{"signals": [{"active": True}]}], 200)


### PR DESCRIPTION
### Description
#1470 mocked out requests.get call, but #1471 uses another requests.get call that did not get mocked properly. We check which call this is and provide the appropriate mocked response.


### Changelog
Itemize code/test/documentation changes and files added/removed.
- test-datafetcher

### Fixes 
Should fix datafetcher test failures like in #1476.
