### PR TITLE
Fix CPR data duplication and missing nation SE and n columns

### DIFF
--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -371,6 +371,7 @@ def fetch_new_reports(params, logger=None):
             lambda x: x[x["publish_date"] == x["publish_date"].max()]
         ).drop(
             "publish_date", axis=1
+        ).drop_duplicates(
         )
 
         if len(latest_sig_df.index) > 0:

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -377,15 +377,15 @@ def fetch_new_reports(params, logger=None):
         if len(latest_sig_df.index) > 0:
             latest_sig_df = latest_sig_df.reset_index(drop=True)
 
-        assert all(latest_sig_df.groupby(
-                ["timestamp", "geo_id"]
-            ).size(
-            ).reset_index(
-                drop=True
-            ) == 1), f"Duplicate rows in {sig} indicate that one or" \
-            + " more reports was published multiple times and the copies differ"
+            assert all(latest_sig_df.groupby(
+                    ["timestamp", "geo_id"]
+                ).size(
+                ).reset_index(
+                    drop=True
+                ) == 1), f"Duplicate rows in {sig} indicate that one or" \
+                + " more reports was published multiple times and the copies differ"
 
-        ret[sig] = latest_sig_df
+            ret[sig] = latest_sig_df
 
     # add nation from state
     geomapper = GeoMapper()

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -375,7 +375,17 @@ def fetch_new_reports(params, logger=None):
         )
 
         if len(latest_sig_df.index) > 0:
-            ret[sig] = latest_sig_df.reset_index(drop=True)
+            latest_sig_df = latest_sig_df.reset_index(drop=True)
+
+        assert all(latest_sig_df.groupby(
+                ["timestamp", "geo_id"]
+            ).size(
+            ).reset_index(
+                drop=True
+            ) == 1), f"Duplicate rows in {sig} indicate that one or" \
+            + " more reports was published multiple times and the copies differ"
+
+        ret[sig] = latest_sig_df
 
     # add nation from state
     geomapper = GeoMapper()

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -342,12 +342,16 @@ def nation_from_state(df, sig, geomapper):
         ).drop(
             "norm_denom", axis=1
         )
-    return geomapper.replace_geocode(
+    df = geomapper.replace_geocode(
         df,
         'state_id',
         'nation',
         new_col="geo_id"
     )
+    df["se"] = None
+    df["sample_size"] = None
+
+    return df
 
 def fetch_new_reports(params, logger=None):
     """Retrieve, compute, and collate all data we haven't seen yet."""

--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -171,7 +171,9 @@ class TestPull:
         test_df = pd.DataFrame({
                 'state_id': ['pa', 'wv'],
                 'timestamp': [datetime(year=2020, month=1, day=1)]*2,
-                'val': [15., 150.],})
+                'val': [15., 150.],
+                'se': [None, None],
+                'sample_size': [None, None],})
 
         pa_pop = int(state_pop.loc[state_pop.state_id == "pa", "pop"])
         wv_pop = int(state_pop.loc[state_pop.state_id == "wv", "pop"])
@@ -191,7 +193,9 @@ class TestPull:
             pd.DataFrame({
                 'geo_id': ['us'],
                 'timestamp': [datetime(year=2020, month=1, day=1)],
-                'val': [15. + 150.],}),
+                'val': [15. + 150.],
+                'se': [None],
+                'sample_size': [None],}),
             check_like=True
         )
 
@@ -204,6 +208,8 @@ class TestPull:
             pd.DataFrame({
                 'geo_id': ['us'],
                 'timestamp': [datetime(year=2020, month=1, day=1)],
-                'val': [15*pa_pop/tot_pop + 150*wv_pop/tot_pop],}),
+                'val': [15*pa_pop/tot_pop + 150*wv_pop/tot_pop],
+                'se': [None],
+                'sample_size': [None],}),
             check_like=True
         )


### PR DESCRIPTION
### Description
Fix
- State to nation aggregation drops sample size and standard error columns. Add them back explicitly.
- A small number of daily reports were published multiple times (with different asset ids), which causes overcounting for some signals. Deduplicate rows.

### Changelog
- `pull.py`
