### PR TITLE
Temporarily remove testing signals from CPR indicator

### DIFF
--- a/ansible/templates/dsew_community_profile-params-prod.json.j2
+++ b/ansible/templates/dsew_community_profile-params-prod.json.j2
@@ -5,7 +5,8 @@
   },
   "indicator": {
     "input_cache": "./input_cache",
-    "reports": "new"
+    "reports": "new",
+    "export_signals": ["confirmed covid-19 admissions"]
   },
   "validation": {
     "common": {

--- a/dsew_community_profile/README.md
+++ b/dsew_community_profile/README.md
@@ -23,6 +23,8 @@ Indicator-specific parameters:
   and exported.
 * `export_start_date`: a YYYY-mm-dd string indicating the first date to export.
 * `export_end_date`: a YYYY-mm-dd string indicating the final date to export.
+* `export_signals`: list of string keys from constants.SIGNALS indicating which
+  signals to export
 
 ## Running the Indicator
 

--- a/dsew_community_profile/delphi_dsew_community_profile/run.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/run.py
@@ -38,9 +38,12 @@ def run_module(params):
         __name__, filename=params["common"].get("log_filename"),
         log_exceptions=params["common"].get("log_exceptions", True))
     def replace_date_param(p):
-        if p in params["indicator"] and params["indicator"][p] is not None:
-            date_param = datetime.strptime(params["indicator"][p], "%Y-%m-%d").date()
-            params["indicator"][p] = date_param
+        if p in params["indicator"]:
+            if params["indicator"][p] is None:
+                del params["indicator"][p]
+            else:
+                date_param = datetime.strptime(params["indicator"][p], "%Y-%m-%d").date()
+                params["indicator"][p] = date_param
     replace_date_param("export_start_date")
     replace_date_param("export_end_date")
     export_params = {

--- a/dsew_community_profile/delphi_dsew_community_profile/run.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/run.py
@@ -59,6 +59,8 @@ def run_module(params):
     dfs = fetch_new_reports(params, logger)
     for key, df in dfs.items():
         (geo, sig) = key
+        if sig not in params["indicator"]["export_signals"]:
+            continue
         dates = create_export_csv(
             df,
             params['common']['export_dir'],

--- a/dsew_community_profile/params.json.template
+++ b/dsew_community_profile/params.json.template
@@ -7,7 +7,12 @@
     "input_cache": "./input_cache",
     "reports": "new",
     "export_start_date": null,
-    "export_end_date": null
+    "export_end_date": null,
+    "export_signals": [
+      "confirmed covid-19 admissions",
+      "total",
+      "positivity"
+    ]
   },
   "validation": {
     "common": {


### PR DESCRIPTION
### Description
Testing signals look weird under visual review, so we're shutting them off while we work on it. This permits the hospital admissions signal to go through to production without delay.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- dev and prod params: add `export_signals` for selecting what to output
- run.py: machinery for signal selection/suppression, plus a bugfix in export date processing

