### PR TITLE
Suppress validation errors from deprecated Google Symptoms signals

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -26,6 +26,12 @@
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
       "suppressed_errors": [
+        {"check_name": "check_missing_geo_sig_combo", "signal": "ageusia_raw_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "ageusia_smoothed_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "anosmia_raw_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "anosmia_smoothed_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "sum_anosmia_ageusia_raw_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "sum_anosmia_ageusia_smoothed_search"}
       ]
     },
     "static": {

--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -26,12 +26,12 @@
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
       "suppressed_errors": [
-        {"check_name": "check_missing_geo_sig_combo", "signal": "ageusia_raw_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "ageusia_smoothed_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "anosmia_raw_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "anosmia_smoothed_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "sum_anosmia_ageusia_raw_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "sum_anosmia_ageusia_smoothed_search"}
+        {"signal": "ageusia_raw_search"},
+        {"signal": "ageusia_smoothed_search"},
+        {"signal": "anosmia_raw_search"},
+        {"signal": "anosmia_smoothed_search"},
+        {"signal": "sum_anosmia_ageusia_raw_search"},
+        {"signal": "sum_anosmia_ageusia_smoothed_search"}
       ]
     },
     "static": {

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -16,12 +16,12 @@
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
       "suppressed_errors": [
-        {"check_name": "check_missing_geo_sig_combo", "signal": "ageusia_raw_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "ageusia_smoothed_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "anosmia_raw_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "anosmia_smoothed_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "sum_anosmia_ageusia_raw_search"},
-        {"check_name": "check_missing_geo_sig_combo", "signal": "sum_anosmia_ageusia_smoothed_search"}
+        {"signal": "ageusia_raw_search"},
+        {"signal": "ageusia_smoothed_search"},
+        {"signal": "anosmia_raw_search"},
+        {"signal": "anosmia_smoothed_search"},
+        {"signal": "sum_anosmia_ageusia_raw_search"},
+        {"signal": "sum_anosmia_ageusia_smoothed_search"}
       ]
     },
     "static": {

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -16,6 +16,12 @@
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
       "suppressed_errors": [
+        {"check_name": "check_missing_geo_sig_combo", "signal": "ageusia_raw_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "ageusia_smoothed_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "anosmia_raw_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "anosmia_smoothed_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "sum_anosmia_ageusia_raw_search"},
+        {"check_name": "check_missing_geo_sig_combo", "signal": "sum_anosmia_ageusia_smoothed_search"}
       ]
     },
     "static": {


### PR DESCRIPTION
### Description
The validator still expects the old GS signals (`ageusia_raw_search`, etc) to be produced. When it doesn't find them, it fails, so tell it to ignore those checks.

### Changelog
- Production params
- Local params