### PR TITLE
Safegraph patterns: spawn instead of fork threads

### DIFF
--- a/safegraph_patterns/delphi_safegraph_patterns/run.py
+++ b/safegraph_patterns/delphi_safegraph_patterns/run.py
@@ -17,6 +17,7 @@ from delphi_utils import get_structured_logger
 
 from .process import process
 
+mp.set_start_method("spawn")
 
 METRICS = [
         # signal_name, naics_code, wip
@@ -105,7 +106,7 @@ def run_module(params):
                                logger=logger,
                                )
 
-        with mp.Pool(n_core) as pool:
+        with mp.get_context("spawn").Pool(n_core) as pool:
             pool.map(process_file, files)
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)


### PR DESCRIPTION
### Description
Safegraph patterns unit tests started hanging recently. This appears to be a problem with the multiprocessing. Based on [this article](https://pythonspeed.com/articles/python-multiprocessing/) and the [docs](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods), it seems to be related to how the threads are created. I switched from default (forking) to spawning.

### Changelog
- `run.py`