### PR TITLE
Pin google-symptoms pandas to previous version

### DIFF
--- a/google_symptoms/setup.py
+++ b/google_symptoms/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 required = [
     "mock",
     "numpy",
-    "pandas",
+    "pandas==1.3.5",
     "pydocstyle",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
### Description
Pin pandas to 1.3.5. The recent update to 1.4.0 changes datetime handling, introducing a bug [on this line](https://github.com/cmu-delphi/covidcast-indicators/blob/c24d4f73ca9884fa98046ff435034c8e79f10f32/google_symptoms/delphi_google_symptoms/pull.py#L87-L88) that nulls out most of our data, causing us to produce csv files for no or a small number of seemingly random dates.

### Changelog
- `setup.py`