### PR TITLE
Suppress old `google-symptoms` signals in sirCAL settings

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -18,7 +18,15 @@
     },
     "google-symptoms": {
       "max_age": 6,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
+      "retired-signals": [
+        "ageusia_raw_search",
+        "ageusia_smoothed_search",
+        "anosmia_raw_search",
+        "anosmia_smoothed_search",
+        "sum_anosmia_ageusia_raw_search",
+        "sum_anosmia_ageusia_smoothed_search"
+      ]
     },
     "usa-facts": {
       "max_age": 5,

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -18,7 +18,15 @@
     },
     "google-symptoms": {
       "max_age": 6,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
+      "retired-signals": [
+        "ageusia_raw_search",
+        "ageusia_smoothed_search",
+        "anosmia_raw_search",
+        "anosmia_smoothed_search",
+        "sum_anosmia_ageusia_raw_search",
+        "sum_anosmia_ageusia_smoothed_search"
+      ]
     },
     "usa-facts": {
       "max_age": 5,


### PR DESCRIPTION
### Description
Keep sirCAL from alerting about deprecated GS signals (ageusia, anosmia, etc).

### Changelog
- ansible params
- local sirCAL params