### PR TITLE
[cpr] Flip order of filename and asset id

### DIFF
--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -276,9 +276,13 @@ class Dataset:
 
 def as_cached_filename(params, config):
     """Formulate a filename to uniquely identify this report in the input cache."""
+    # eg "Community Profile Report 20220128.xlsx"
+    # but delimiters vary; don't get tripped up if they do something wacky like
+    # Community.Profile.Report.20220128.xlsx
+    name, _, ext = config['filename'].rpartition(".")
     return os.path.join(
         params['indicator']['input_cache'],
-        f"{config['assetId']}--{config['filename']}"
+        f"{name}--{config['assetId']}.{ext}"
     )
 
 def fetch_listing(params):


### PR DESCRIPTION


### Description
Type of change (bug fix, new feature, etc), brief description, and motivation for these changes.

Make it easier for a human to browse the input_cache folder. Asset IDs are essentially hash strings, and aren't meant to be ordered. Filenames (modulo some irregularities in the choice of delimiter) _are_ orderable, so we should put them first. That way, input_cache will list in roughly date order, making it easier to see what the most recent file is, and whether the file named for a particular date is present.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- pull.py:`as_cached_filename()` - flip the order of filename and assetid, plus some string manipulation to make sure the file extension goes in the right place.

### Fixes 
- Fixes likely future debugging headaches
