### PR TITLE
[CPR] Fix validation failure by setting min expected lag to 3

### DIFF
--- a/ansible/templates/dsew_community_profile-params-prod.json.j2
+++ b/ansible/templates/dsew_community_profile-params-prod.json.j2
@@ -12,7 +12,7 @@
     "common": {
       "data_source": "dsew-cpr",
       "span_length": 14,
-      "min_expected_lag": {"all": "5"},
+      "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "9"},
       "dry_run": true,
       "suppressed_errors": []

--- a/dsew_community_profile/params.json.template
+++ b/dsew_community_profile/params.json.template
@@ -18,7 +18,7 @@
     "common": {
       "data_source": "dsew_cpr",
       "span_length": 14,
-      "min_expected_lag": {"all": "5"},
+      "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "9"},
       "dry_run": true,
       "suppressed_errors": []


### PR DESCRIPTION
### Description
The CPR file named for 20220131 contains hospital admissions for 20220129, and is typically expected to be available from healthdata.gov on 20220201. This yields a 3-day `min_expected_lag`. 

We expect 5-day lag only on Mondays, since the CPR is not published on weekends. For example, on Monday 20220131, the most recent file available from healthdata.gov was named for 20220128, and contained hospital admissions for 20220126.

The CPR indicator only generates one reference date each day, and the validator only checks output files in a time range specified by `min_expected_lag` and `span_length`. With a 5-day `min_expected_lag`, validator will (1) ignore all files generated on Tuesdays through Fridays, and (2) crash because it can't concatenate an empty list of data frames.

This PR addresses (1), though hopefully QX can let me know if it will created unintended validation failures on Mondays.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- dev and prod params.json

### Fixes 
- Fixes [validator exception in #system-monitoring](https://delphi-org.slack.com/archives/C01LZ3A2UMU/p1643904192247609)
