### PR TITLE
Delete validation failures

### DIFF
--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -4,7 +4,7 @@ import importlib
 from typing import Any, Callable, Dict, Optional
 from .archive import ArchiveDiffer, archiver_from_params
 from .logger import get_structured_logger
-from .utils import read_params, transfer_files
+from .utils import read_params, transfer_files, delete_move_files
 from .validator.validate import Validator
 from .validator.run import validator_from_params
 
@@ -46,6 +46,9 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
     if validator:
         validation_report = validator.validate()
         validation_report.log(logger)
+        # Validators on dry-run always return success
+        if not validation_report.success():
+            delete_move_files()
     if (not validator or validation_report.success()):
         if archiver:
             archiver.run(logger)

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -101,7 +101,8 @@ def transfer_files():
 def delete_move_files():
     """Delete or move output files depending on dir settings provided in params.
 
-    1. Delete files in export-dir if delivery-dir is specified and is different from export_dir (aka only delete files produced by the most recent run)
+    1. Delete files in export-dir if delivery-dir is specified and is different
+       from export_dir (aka only delete files produced by the most recent run)
     2. If validation-failures-dir is specified, move failed files there instead
     """
     params = read_params()

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -96,4 +96,4 @@ def transfer_files():
     files_to_export = os.listdir(export_dir)
     for file_name in files_to_export:
         if file_name.endswith(".csv") or file_name.endswith(".CSV"):
-            move(os.path.join(export_dir, file_name), delivery_dir)
+            move(os.path.join(export_dir, file_name), os.path.join(delivery_dir, file_name))

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -116,6 +116,7 @@ def delete_move_files():
         for file_name in files_to_delete:
             if file_name.endswith(".csv") or file_name.endswith(".CSV"):
                 if validation_failure_dir is not None:
-                    move(os.path.join(export_dir, file_name), os.path.join(validation_failure_dir, file_name))
+                    move(os.path.join(export_dir, file_name),
+                        os.path.join(validation_failure_dir, file_name))
                 else:
                     os.remove(os.path.join(export_dir, file_name))

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -95,7 +95,7 @@ def transfer_files():
     delivery_dir = params["delivery"].get("delivery_dir", None)
     files_to_export = os.listdir(export_dir)
     for file_name in files_to_export:
-        if file_name.endswith(".csv") or file_name.endswith(".CSV"):
+        if file_name.lower().endswith(".csv"):
             move(os.path.join(export_dir, file_name), os.path.join(delivery_dir, file_name))
 
 def delete_move_files():

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -100,6 +100,7 @@ def transfer_files():
 
 def delete_move_files():
     """Delete csv files in export-dir under certain conditions.
+
     1. Delivery-dir is specified (aka we are only deleting files produced by the run
     2. If validation-failures-dir is specified, move failures there instead
     """

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -111,6 +111,8 @@ def delete_move_files():
     # Create validation_failure_dir if it doesn't exist
     if (validation_failure_dir is not None) and (not os.path.exists(validation_failure_dir)):
         os.mkdir(validation_failure_dir)
+    # Double-checking that export-dir is not delivery-dir
+    assert(export_dir is not None and export_dir != delivery_dir)
     files_to_delete = os.listdir(export_dir)
     if delivery_dir is not None:
         for file_name in files_to_delete:

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -97,3 +97,25 @@ def transfer_files():
     for file_name in files_to_export:
         if file_name.endswith(".csv") or file_name.endswith(".CSV"):
             move(os.path.join(export_dir, file_name), os.path.join(delivery_dir, file_name))
+
+def delete_move_files():
+    """Delete csv files in export-dir if:
+    1. Delivery-dir is specified (aka we are only deleting files produced by the run
+    2. If validation-failures-dir is specified, move failures there instead
+    """
+    params = read_params()
+    export_dir = params["common"].get("export_dir", None)
+    delivery_dir = params["delivery"].get("delivery_dir", None)
+    validation_failure_dir = params["validation"]["common"].get("validation_failure_dir", None)
+
+    # Create validation_failure_dir if it doesn't exist
+    if (validation_failure_dir is not None) and (not os.path.exists(validation_failure_dir)):
+        os.mkdir(validation_failure_dir)
+    files_to_delete = os.listdir(export_dir)
+    if delivery_dir is not None:
+        for file_name in files_to_delete:
+            if file_name.endswith(".csv") or file_name.endswith(".CSV"):
+                if validation_failure_dir is not None:
+                    move(os.path.join(export_dir, file_name), os.path.join(validation_failure_dir, file_name))
+                else:
+                    os.remove(os.path.join(export_dir, file_name))

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -108,6 +108,8 @@ def delete_move_files():
     params = read_params()
     export_dir = params["common"].get("export_dir", None)
     delivery_dir = params["delivery"].get("delivery_dir", None)
+    if delivery_dir is None:
+        return
     validation_failure_dir = params["validation"]["common"].get("validation_failure_dir", None)
 
     # Create validation_failure_dir if it doesn't exist
@@ -116,11 +118,10 @@ def delete_move_files():
     # Double-checking that export-dir is not delivery-dir
     assert(export_dir is not None and export_dir != delivery_dir)
     files_to_delete = os.listdir(export_dir)
-    if delivery_dir is not None:
-        for file_name in files_to_delete:
-            if file_name.endswith(".csv") or file_name.endswith(".CSV"):
-                if validation_failure_dir is not None:
-                    move(os.path.join(export_dir, file_name),
-                        os.path.join(validation_failure_dir, file_name))
-                else:
-                    os.remove(os.path.join(export_dir, file_name))
+    for file_name in files_to_delete:
+        if file_name.endswith(".csv") or file_name.endswith(".CSV"):
+            if validation_failure_dir is not None:
+                move(os.path.join(export_dir, file_name),
+                    os.path.join(validation_failure_dir, file_name))
+            else:
+                os.remove(os.path.join(export_dir, file_name))

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -104,19 +104,19 @@ def delete_move_files():
     1. Delete files in export-dir if delivery-dir is specified and is different
        from export_dir (aka only delete files produced by the most recent run)
     2. If validation-failures-dir is specified, move failed files there instead
+    If dry-run tag is True, then this function should not (and currently does not) get called
     """
     params = read_params()
     export_dir = params["common"].get("export_dir", None)
     delivery_dir = params["delivery"].get("delivery_dir", None)
-    if delivery_dir is None:
-        return
     validation_failure_dir = params["validation"]["common"].get("validation_failure_dir", None)
-
     # Create validation_failure_dir if it doesn't exist
     if (validation_failure_dir is not None) and (not os.path.exists(validation_failure_dir)):
         os.mkdir(validation_failure_dir)
     # Double-checking that export-dir is not delivery-dir
-    assert(export_dir is not None and export_dir != delivery_dir)
+    # Throw assertion error if delivery_dir or export_dir is unspecified
+    assert(delivery_dir is not None and export_dir is not None)
+    assert(export_dir != delivery_dir)
     files_to_delete = os.listdir(export_dir)
     for file_name in files_to_delete:
         if file_name.endswith(".csv") or file_name.endswith(".CSV"):

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -116,7 +116,7 @@ def delete_move_files():
     # Double-checking that export-dir is not delivery-dir
     # Throw assertion error if delivery_dir or export_dir is unspecified
     assert(delivery_dir is not None and export_dir is not None)
-    assert(export_dir != delivery_dir)
+    assert export_dir != delivery_dir
     files_to_delete = os.listdir(export_dir)
     for file_name in files_to_delete:
         if file_name.endswith(".csv") or file_name.endswith(".CSV"):

--- a/_delphi_utils_python/delphi_utils/utils.py
+++ b/_delphi_utils_python/delphi_utils/utils.py
@@ -99,7 +99,7 @@ def transfer_files():
             move(os.path.join(export_dir, file_name), os.path.join(delivery_dir, file_name))
 
 def delete_move_files():
-    """Delete csv files in export-dir if:
+    """Delete csv files in export-dir under certain conditions.
     1. Delivery-dir is specified (aka we are only deleting files produced by the run
     2. If validation-failures-dir is specified, move failures there instead
     """

--- a/_delphi_utils_python/delphi_utils/validator/README.md
+++ b/_delphi_utils_python/delphi_utils/validator/README.md
@@ -43,6 +43,27 @@ deactivate
 rm -r env
 ```
 
+### Using the runner
+
+The validator can also be called using the runner, which performs the entire pipeline:
+
+* Calling the indicator's `run` module
+* Running the validator on newly obtained CSV files, if validator is specified
+* If validation is unsuccessful, remove or transfer current files in the run
+* Archive files if archiver is specified and there are no validation failures
+* Transfer files to delivery directory if specified in params
+
+The following truth table describes behavior of the third bullet point:
+
+| case | dry_run | validation failure | export dir | delivery dir | v failure dir | action |
+| - | - | - | - | - | - | - |
+| 1 | true | never | * | * | * | no effect |
+| 2 | false | no | * | * | * | no effect |
+| 3 | false | yes | X | X | * | throw assertion exception |
+| 4 | false | yes | X | None | * | throw assertion exception |
+| 5 | false | yes | X | Y != X | None | delete CSV from X |
+| 6 | false | yes | X | Y != X | Z | move CSV from X to Z |
+
 ### Customization
 
 All of the user-changable parameters are stored in the `validation` field of the indicator's `params.json` file. If `params.json` does not already include a `validation` field, please copy that provided in this module's `params.json.template`.

--- a/_delphi_utils_python/delphi_utils/validator/README.md
+++ b/_delphi_utils_python/delphi_utils/validator/README.md
@@ -47,13 +47,13 @@ rm -r env
 
 The validator can also be called using the runner, which performs the entire pipeline:
 
-* Calling the indicator's `run` module
-* Running the validator on newly obtained CSV files, if validator is specified
-* If validation is unsuccessful, remove or transfer current files in the run
-* Archive files if archiver is specified and there are no validation failures
-* Transfer files to delivery directory if specified in params
+1. Calling the indicator's `run` module
+2. Running the validator on newly obtained CSV files, if validator is specified
+3. If validation is unsuccessful, remove or transfer current files in the run
+4. Archive files if archiver is specified and there are no validation failures
+5. Transfer files to delivery directory if specified in params
 
-The following truth table describes behavior of the third bullet point:
+The following truth table describes behavior of item (3):
 
 | case | dry_run | validation failure | export dir | delivery dir | v failure dir | action |
 | - | - | - | - | - | - | - |

--- a/_delphi_utils_python/tests/test_runner.py
+++ b/_delphi_utils_python/tests/test_runner.py
@@ -55,8 +55,9 @@ class TestRunIndicator:
         mock_validator_fn.return_value.validate.assert_called_once()
         mock_archiver_fn.return_value.run.assert_called_once()
 
+    @mock.patch("delphi_utils.runner.delete_move_files")
     @mock.patch("delphi_utils.runner.read_params")
-    def test_failed_validation(self, mock_read_params,
+    def test_failed_validation(self, mock_read_params, mock_delete_move_files,
                                mock_indicator_fn, mock_validator_fn, mock_archiver_fn):
         """Test that archiving is not called when validation fails."""
         mock_read_params.return_value = self.PARAMS
@@ -65,6 +66,7 @@ class TestRunIndicator:
 
         run_indicator_pipeline(mock_indicator_fn, mock_validator_fn, mock_archiver_fn)
 
+        mock_delete_move_files.assert_called_once()
         mock_indicator_fn.assert_called_once_with(self.PARAMS)
         mock_validator_fn.assert_called_once_with(self.PARAMS)
         mock_archiver_fn.assert_called_once_with(self.PARAMS)


### PR DESCRIPTION
### Description
During runner runs, upon validation failure for indicators with validator gating, switch to either deleting the csv files stored within `export-dir` (which should only contain files from the run) or moving them to another cache folder, `validation-failure-dir`.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- runner.py
- utils.py

More info in [Slack thread](https://delphi-org.slack.com/archives/C01LZ3A2UMU/p1643906335232629?thread_ts=1643620928.802429&cid=C01LZ3A2UMU) on system-monitoring
