### PR TITLE
[quidel] Activate archivediffer in prod params

### DIFF
--- a/ansible/templates/quidel_covidtest-params-prod.json.j2
+++ b/ansible/templates/quidel_covidtest-params-prod.json.j2
@@ -48,6 +48,15 @@
       ]
     }
   },
+  "archive": {
+    "aws_credentials": {
+      "aws_access_key_id": "{{ delphi_aws_access_key_id }}",
+      "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"
+    },
+    "bucket_name": "delphi-covidcast-indicator-output",
+    "cache_dir": "./archivediffer_cache",
+    "indicator_prefix": "quidel"
+  },
   "delivery": {
     "delivery_dir": "/common/covidcast/receiving/quidel"
   }


### PR DESCRIPTION
### Description
Left out of #1457

### Changelog
Itemize code/test/documentation changes and files added/removed.
- prod params for quidel_covidtest: configure archivediffer

