### PR TITLE
Fix archiver bug ignoring deletions when comparing two files with no missing columns

### DIFF
--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -107,6 +107,17 @@ def diff_export_csv(
     deleted_df[["val", "se", "sample_size"]] = np.nan
     if "missing_val" in after_df_cmn.columns:
         deleted_df[["missing_val", "missing_se", "missing_sample_size"]] = Nans.DELETED
+    
+    # Remove deleted entries that were already present
+    if deleted_idx.size > 0:
+        deleted_same_mask = deleted_df == before_df.loc[deleted_idx, :]
+        deleted_same_mask |= pd.isna(deleted_df) & pd.isna(before_df.loc[deleted_idx, :])
+        deleted_df = deleted_df.loc[~(deleted_same_mask.all(axis=1)), :]
+
+    # If the new file has no missing columns, then we should remove them from
+    # the deletions too
+    if "missing_val" not in after_df_cmn.columns:
+        deleted_df = deleted_df[["val", "se", "sample_size"]]
 
     return (
         deleted_df,

--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -107,7 +107,7 @@ def diff_export_csv(
     deleted_df[["val", "se", "sample_size"]] = np.nan
     if "missing_val" in after_df_cmn.columns:
         deleted_df[["missing_val", "missing_se", "missing_sample_size"]] = Nans.DELETED
-    
+
     # Remove deleted entries that were already present
     if deleted_idx.size > 0:
         deleted_same_mask = deleted_df == before_df.loc[deleted_idx, :]

--- a/_delphi_utils_python/delphi_utils/archive.py
+++ b/_delphi_utils_python/delphi_utils/archive.py
@@ -49,6 +49,10 @@ from .nancodes import Nans
 Files = List[str]
 FileDiffMap = Dict[str, Optional[str]]
 
+EXPORT_CSV_DTYPES = {
+    "geo_id": str, "val": float, "se": float, "sample_size": float,
+    "missing_val": "Int64", "missing_se": "Int64", "missing_sample_size": "Int64"
+}
 
 def diff_export_csv(
     before_csv: str,
@@ -75,15 +79,10 @@ def diff_export_csv(
         changed_df is the pd.DataFrame of common rows from after_csv with changed values.
         added_df is the pd.DataFrame of added rows from after_csv.
     """
-    export_csv_dtypes = {
-        "geo_id": str, "val": float, "se": float, "sample_size": float,
-        "missing_val": int, "missing_se": int, "missing_sample_size": int
-    }
-
-    before_df = pd.read_csv(before_csv, dtype=export_csv_dtypes)
+    before_df = pd.read_csv(before_csv, dtype=EXPORT_CSV_DTYPES)
     before_df.set_index("geo_id", inplace=True)
     before_df = before_df.round({"val": 7, "se": 7})
-    after_df = pd.read_csv(after_csv, dtype=export_csv_dtypes)
+    after_df = pd.read_csv(after_csv, dtype=EXPORT_CSV_DTYPES)
     after_df.set_index("geo_id", inplace=True)
     after_df = after_df.round({"val": 7, "se": 7})
     deleted_idx = before_df.index.difference(after_df.index)
@@ -93,8 +92,8 @@ def diff_export_csv(
     before_df_cmn = before_df.reindex(common_idx)
     after_df_cmn = after_df.reindex(common_idx)
 
-    # If CSVs have different columns (no missingness), mark all values as new
-    if ("missing_val" in before_df_cmn.columns) ^ ("missing_val" in after_df_cmn.columns):
+    # If new CSV has missingness columns, but old doesn't, mark all values as new
+    if ("missing_val" not in before_df_cmn.columns) & ("missing_val" in after_df_cmn.columns):
         same_mask = after_df_cmn.copy()
         same_mask.loc[:] = False
     else:
@@ -102,22 +101,12 @@ def diff_export_csv(
         same_mask = before_df_cmn == after_df_cmn
         same_mask |= pd.isna(before_df_cmn) & pd.isna(after_df_cmn)
 
-    # Code deleted entries as nans with the deleted missing code
+    # Any deleted entries become rows with nans and the deleted missing code
     deleted_df = before_df.loc[deleted_idx, :].copy()
     deleted_df[["val", "se", "sample_size"]] = np.nan
-    if "missing_val" in after_df_cmn.columns:
-        deleted_df[["missing_val", "missing_se", "missing_sample_size"]] = Nans.DELETED
-
-    # Remove deleted entries that were already present
-    if deleted_idx.size > 0:
-        deleted_same_mask = deleted_df == before_df.loc[deleted_idx, :]
-        deleted_same_mask |= pd.isna(deleted_df) & pd.isna(before_df.loc[deleted_idx, :])
-        deleted_df = deleted_df.loc[~(deleted_same_mask.all(axis=1)), :]
-
-    # If the new file has no missing columns, then we should remove them from
-    # the deletions too
-    if "missing_val" not in after_df_cmn.columns:
-        deleted_df = deleted_df[["val", "se", "sample_size"]]
+    # If the new file doesn't have missing columsn, then when the deleted, changed, and added
+    # rows are concatenated (in diff_exports), they will default to NA
+    deleted_df[["missing_val", "missing_se", "missing_sample_size"]] = Nans.DELETED
 
     return (
         deleted_df,


### PR DESCRIPTION
### Description
A partial fix of the issues in #1520. 

### Changelog
Previously, the archiver did not code deletions between two old-style CSVs (old-style meaning no missing columns). This changes it to always write deletions with DELETED missing columns and NAs in the missing columns for the rest of the non-missing rows. The validation and repair for the NA missing columns is then handled by the [acquisition](https://github.com/cmu-delphi/delphi-epidata/blob/dev/src/acquisition/covidcast/csv_importer.py#L224-L253).

To be merged after https://github.com/cmu-delphi/delphi-epidata/pull/862.

### Fixes 
- partial fix #1520
