### PR TITLE
Keep sirCAL from complaining about `try_vaccinate_1m` at the MSA level

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -92,6 +92,7 @@
         ["smoothed_vaccine_barrier_travel_tried", "msa"], ["smoothed_wvaccine_barrier_travel_tried", "msa"],
         ["smoothed_vaccine_barrier_type_tried", "msa"], ["smoothed_wvaccine_barrier_type_tried", "msa"],
         ["smoothed_try_vaccinate_1m", "hrr"], ["smoothed_wtry_vaccinate_1m", "hrr"],
+        ["smoothed_try_vaccinate_1m", "msa"], ["smoothed_wtry_vaccinate_1m", "msa"],
         ["smoothed_dontneed_reason_dont_spend_time", "hrr"], ["smoothed_wdontneed_reason_dont_spend_time", "hrr"],
         ["smoothed_dontneed_reason_had_covid", "hrr"], ["smoothed_wdontneed_reason_had_covid", "hrr"],
         ["smoothed_dontneed_reason_not_beneficial", "hrr"], ["smoothed_wdontneed_reason_not_beneficial", "hrr"],

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -92,6 +92,7 @@
         ["smoothed_vaccine_barrier_travel_tried", "msa"], ["smoothed_wvaccine_barrier_travel_tried", "msa"],
         ["smoothed_vaccine_barrier_type_tried", "msa"], ["smoothed_wvaccine_barrier_type_tried", "msa"],
         ["smoothed_try_vaccinate_1m", "hrr"], ["smoothed_wtry_vaccinate_1m", "hrr"],
+        ["smoothed_try_vaccinate_1m", "msa"], ["smoothed_wtry_vaccinate_1m", "msa"],
         ["smoothed_dontneed_reason_had_covid", "hrr"], ["smoothed_wdontneed_reason_had_covid", "hrr"],
         ["smoothed_dontneed_reason_not_beneficial", "hrr"], ["smoothed_wdontneed_reason_not_beneficial", "hrr"],
         ["smoothed_dontneed_reason_not_high_risk", "hrr"], ["smoothed_wdontneed_reason_not_high_risk", "hrr"],


### PR DESCRIPTION
### Description
Due to decreasing sample size, the weighted version of `try_vaccinate_1m` is no longer available. The unweighted version only has one MSA region available, so it will be missing soon too. Keep sirCAL from complaining about either.

### Changelog
- Local and ansible `params`