### PR TITLE
[Quidel] Suppress checks of omicron signals in small geos

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -138,7 +138,13 @@
     "quidel": {
       "max_age":6,
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
-      "retired-signals": ["raw_pct_negative","smoothed_pct_negative","raw_tests_per_device","smoothed_tests_per_device"]
+      "retired-signals": [
+        "raw_pct_negative","smoothed_pct_negative","raw_tests_per_device","smoothed_tests_per_device",
+        ["covid_ag_raw_pct_positive_age_0_4", "hrr"], ["covid_ag_raw_pct_positive_age_0_4", "msa"],
+        ["covid_ag_raw_pct_positive_age_5_17", "msa"],
+        ["covid_ag_raw_pct_positive_age_50_64", "hrr"], ["covid_ag_raw_pct_positive_age_50_64", "msa"],
+        ["covid_ag_raw_pct_positive_age_65plus", "hrr"], ["covid_ag_raw_pct_positive_age_65plus", "msa"]
+      ]
     },
     "nchs-mortality": {
       "max_age":16,

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -137,7 +137,13 @@
     "quidel": {
       "max_age":6,
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
-      "retired-signals": ["raw_pct_negative","smoothed_pct_negative","raw_tests_per_device","smoothed_tests_per_device"]
+      "retired-signals": [
+        "raw_pct_negative","smoothed_pct_negative","raw_tests_per_device","smoothed_tests_per_device",
+        ["covid_ag_raw_pct_positive_age_0_4", "hrr"], ["covid_ag_raw_pct_positive_age_0_4", "msa"],
+        ["covid_ag_raw_pct_positive_age_5_17", "msa"],
+        ["covid_ag_raw_pct_positive_age_50_64", "hrr"], ["covid_ag_raw_pct_positive_age_50_64", "msa"],
+        ["covid_ag_raw_pct_positive_age_65plus", "hrr"], ["covid_ag_raw_pct_positive_age_65plus", "msa"]
+      ]
     },
     "nchs-mortality": {
       "max_age":16,


### PR DESCRIPTION
### Description
SirCAL complains about some of the Quidel omicron signals for small geo levels that don't often meet minimum sample size thresholds. We expect availability of these signals to be spotty at these geo levels, so this PR suppresses those checks.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- dev and prod sircal params

### Fixes 
- Fixes #1529
