### PR TITLE
[CTIS] Change V17 name with new format

### DIFF
--- a/facebook/delphiFacebook/R/responses.R
+++ b/facebook/delphiFacebook/R/responses.R
@@ -648,7 +648,7 @@ create_complete_responses <- function(input_data, county_crosswalk, params)
     "I6_1", "I6_2", "I6_3", "I6_4", "I6_5", "I6_6", "I6_7", "I6_8",
     "I7", "K1", "K2", "V11a", "V12a", "V15a", "V15b", "V16", "V3a", # added in Wave 11
     "V1alt", "B13a", "V15c", "P1", "P2", "P3", "P4", "P5", "P6", # added in experimental Wave 12
-    "C17b", "V17_1", "V17_2", "V2b", "V2c", "V2d", # added in Wave 13
+    "C17b", "V17_month", "V17_year", "V2b", "V2c", "V2d", # added in Wave 13
     
     "raceethnicity", "token", "wave", "w12_treatment", "module", "UserLanguage",
     "zip5" # temporarily; we'll filter by this column later and then drop it before writing


### PR DESCRIPTION
### Description
V17 output field names were changed with the new format. Update microdata output names (V17 is not used anywhere else at the moment).

### Changelog
- `responses.R`