### PR TITLE
add hrr to quidel ignored regions for omicron 5_17

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -141,7 +141,7 @@
       "retired-signals": [
         "raw_pct_negative","smoothed_pct_negative","raw_tests_per_device","smoothed_tests_per_device",
         ["covid_ag_raw_pct_positive_age_0_4", "hrr"], ["covid_ag_raw_pct_positive_age_0_4", "msa"],
-        ["covid_ag_raw_pct_positive_age_5_17", "msa"],
+        ["covid_ag_raw_pct_positive_age_5_17", "hrr"], ["covid_ag_raw_pct_positive_age_5_17", "msa"],
         ["covid_ag_raw_pct_positive_age_50_64", "hrr"], ["covid_ag_raw_pct_positive_age_50_64", "msa"],
         ["covid_ag_raw_pct_positive_age_65plus", "hrr"], ["covid_ag_raw_pct_positive_age_65plus", "msa"]
       ]

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -140,7 +140,7 @@
       "retired-signals": [
         "raw_pct_negative","smoothed_pct_negative","raw_tests_per_device","smoothed_tests_per_device",
         ["covid_ag_raw_pct_positive_age_0_4", "hrr"], ["covid_ag_raw_pct_positive_age_0_4", "msa"],
-        ["covid_ag_raw_pct_positive_age_5_17", "msa"],
+        ["covid_ag_raw_pct_positive_age_5_17", "hrr"], ["covid_ag_raw_pct_positive_age_5_17", "msa"],
         ["covid_ag_raw_pct_positive_age_50_64", "hrr"], ["covid_ag_raw_pct_positive_age_50_64", "msa"],
         ["covid_ag_raw_pct_positive_age_65plus", "hrr"], ["covid_ag_raw_pct_positive_age_65plus", "msa"]
       ]


### PR DESCRIPTION
### Description
SirCAL complained about lag or gap for the quidel omicron signal for ages 5-17 in hrrs (it had not done so before). This is roughly as expected as similar lags/gaps in age group signals for small regions, so adding it to the ignore list.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- prod & dev sircal params

### Fixes 
- Fixes SirCAL false positive
