### PR TITLE
[CTIS utils] Correctly handle static display logic in QSFs

### DIFF
--- a/facebook/qsf-tools/generate-codebook.R
+++ b/facebook/qsf-tools/generate-codebook.R
@@ -192,6 +192,23 @@ process_qsf <- function(path_to_qsf,
     map(~ gsubfn("(QID[0-9]+)", function(qid) {items[qids == qid]}, .x)) %>% 
     # Collapse logic into a single string.
     map(~ paste(.x, collapse=" "))
+  
+  # Handle questions that use a fixed condition ("If False", "If True")
+  ii_boolean_displaylogic <- (displayed_questions %>% 
+                                map(~ .x$Payload$DisplayLogic) %>% 
+                                map(~ .x$`0`) %>% 
+                                map(~ map(.x, "LogicType") %>% unlist()) == "BooleanValue") %>% 
+    which()
+  
+  display_logic[ii_boolean_displaylogic] <- displayed_questions[ii_boolean_displaylogic] %>% 
+    map(~ .x$Payload$DisplayLogic) %>% 
+    map(~ .x$`0`) %>% 
+    map(~ paste(
+      map(.x, "Value")
+    )) %>%
+    map(~ gsub(" ?NULL ?", "", .x)) %>% 
+    # Collapse logic into a single string.
+    map(~ paste(.x, collapse=""))
     
   logic_type <- displayed_questions %>% 
     map(~ .x$Payload$DisplayLogic) %>% 


### PR DESCRIPTION
### Description
Output summarized version of survey item display logic when it is fixed and doesn't depend on a previous question.

### Changelog
- `generate-codebook.R`

### Fixes 
Closes #1500.