### PR TITLE
Fix CPR bugs associated with non-unique timestamps by publish date

### DIFF
--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -515,7 +515,7 @@ def fetch_new_reports(params, logger=None):
     for key, lst in datasets.items():
         (_, sig, _) = key
         latest_key_df = pd.concat(lst)
-        if sig == "total":
+        if sig in ("total", "positivity"):
             latest_key_df = pd.concat(apply_thres_change_date(
                 keep_latest_report,
                 latest_key_df,
@@ -534,7 +534,7 @@ def fetch_new_reports(params, logger=None):
         if state_key not in ret:
             continue
 
-        if sig == "total":
+        if sig in ("total", "positivity"):
             nation_df = pd.concat(apply_thres_change_date(
                 nation_from_state,
                 ret[state_key].rename(columns={"geo_id": "state_id"}),

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -626,6 +626,7 @@ def unify_testing_sigs(positivity_df, volume_df):
     https://docs.google.com/document/d/1MoIimdM_8OwG4SygoeQ9QEVZzIuDl339_a0xoYa6vuA/edit#
 
     """
+    # check that we have positivity *and* volume for each publishdate+geo
     pos_groups_df = positivity_df.drop(
         ["val", "se", "sample_size", "timestamp"],
         axis=1

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -461,12 +461,12 @@ def nation_from_state(df, sig, geomapper):
         ).drop(
             "norm_denom", axis=1
         )
-    # The filter in `fetch_new_reports` to keep most recent publish date gurantees
-    # that we'll only see one unique publish date per timestamp here.
+    # The filter in `fetch_new_reports` to keep most recent publish date
+    # gurantees that we'll only see one unique publish date per timestamp
+    # here, so just keep the first obs of each group.
     publish_date_by_ts = df.groupby(
         ["timestamp"]
-    )["publish_date"].apply(
-        lambda x: np.unique(x)[0]
+    )["publish_date"].first(
     ).reset_index(
     )
     df = geomapper.replace_geocode(
@@ -719,7 +719,7 @@ def add_max_ts_col(df):
     assert all(
         assert_df.num_obs <= 2
     ) and all(
-        assert_df[assert_df.num_obs == 2].num_unique_obs == 2
+        assert_df.num_obs == assert_df.num_unique_obs
     ), "Testing signals should have up to two timestamps per publish date-geo level " + \
         "combination. Each timestamp should be unique."
 
@@ -766,8 +766,9 @@ def apply_thres_change_date(apply_fn, df, *apply_fn_args):
     """
     Apply a function separately to data before and after the test volume change date.
 
-    The test volume change date is when test volume and test positivity started being
-    repported for different reference dates within the same report.
+    The test volume change date is when test volume and test positivity
+    started being reported for different reference dates within the same
+    report. This first occurred on 2021-03-17.
 
     Parameters
     ----------
@@ -791,7 +792,7 @@ def apply_thres_change_date(apply_fn, df, *apply_fn_args):
     list_of_dfs = [df[df.publish_date < change_date], df[df.publish_date >= change_date]]
 
     for arg_field in apply_fn_args:
-        assert len(list_of_dfs) == len(arg_field), "Extra arguments must be iterables with " + \
-            f"length {len(list_of_dfs)}, the same as the number of dfs to process"
+        assert len(arg_field) == 2, "Extra arguments must be iterables with " + \
+            "length 2, the same as the number of dfs to process"
 
     return map(apply_fn, list_of_dfs, *apply_fn_args)

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -362,7 +362,7 @@ class Dataset:
             sig_select = [s for s in select if s[-1].find(sig) >= 0]
             # The name of the cumulative vaccination was changed after 03/09/2021
             # when J&J vaccines were added.
-            if (sig == "fully vaccinated") and (len(sig_select)==0):
+            if (sig == "fully vaccinated") and (len(sig_select) == 0):
                 sig_select = [s for s in select if s[-1].find("people with full course") >= 0]
             # Since "doses administered" is a substring of another desired header,
             # "booster doses administered", we need to more strictly check if "doses administered"
@@ -491,7 +491,7 @@ def keep_latest_report(df, sig):
         ).drop_duplicates(
         )
 
-    if len(df.index) > 0:
+    if not df.empty:
         df = df.reset_index(drop=True)
         assert all(df.groupby(
                 ["timestamp", "geo_id"]
@@ -524,7 +524,7 @@ def fetch_new_reports(params, logger=None):
         else:
             latest_key_df = keep_latest_report(latest_key_df, sig)
 
-        if len(latest_key_df.index) > 0:
+        if not latest_key_df.empty:
             ret[key] = latest_key_df
 
     # add nation from state
@@ -753,6 +753,19 @@ def apply_thres_change_date(apply_fn, df, *apply_fn_args):
 
     The test volume change date is when test volume and test positivity started being
     repported for different reference dates within the same report.
+
+    Parameters
+    ----------
+    apply_fn: function
+        function to apply to data before and after the test volume change date
+    df: pd.DataFrame
+        Columns: val, sample_size, ...
+    apply_fn_args: tuple of lists
+        variable number of additional arguments to pass to the `apply_fn`.
+        Each additional argument should be a list of length 2. The first
+        element of each list will be passed to the `apply_fn` when processing
+        pre-change date data; the second element will be used for the
+        post-change date data.
 
     Returns
     -------

--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -359,7 +359,7 @@ class TestPull:
 
         with pytest.raises(AssertionError):
             # Inputs have different numbers of rows.
-            unify_testing_sigs(positivity_df, positivity_df.iloc[0])
+            unify_testing_sigs(positivity_df, positivity_df.head(n=1))
 
     def test_add_max_ts_col(self):
         input_df = pd.DataFrame({

--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -381,25 +381,57 @@ class TestPull:
             add_max_ts_col(
                 pd.DataFrame({
                     'geo_id': ["ca", "ca", "fl", "fl"],
-                    'timestamp': [datetime(2021, 10, 27)]*4,
+                    'timestamp': [datetime(2021, 10, 27)] * 4,
                     'val': [1, 2, 3, 4],
                     'se': [None] * 4,
                     'sample_size': [None] * 4,
-                    'publish_date': [datetime(2021, 10, 30)]*4,
+                    'publish_date': [datetime(2021, 10, 30)] * 4,
                 })
             )
         with pytest.raises(AssertionError):
-            # Input df has fewer than 2 timestamps per geo id-publish date combination.
+            # Input df has more than 2 timestamps per geo id-publish date combination.
+            add_max_ts_col(
+                pd.DataFrame({
+                    'geo_id': ["ca", "ca", "ca", "fl", "fl", "fl"],
+                    'timestamp': [datetime(2021, 10, 27)] * 6,
+                    'val': [1, 2, 3, 4, 5, 6],
+                    'se': [None] * 6,
+                    'sample_size': [None] * 6,
+                    'publish_date': [datetime(2021, 10, 30)] * 6,
+                })
+            )
+
+        try:
+            # Input df has fewer than 2 timestamps per geo id-publish date
+            # combination. This should not raise an exception.
             add_max_ts_col(
                 pd.DataFrame({
                     'geo_id': ["ca", "fl"],
-                    'timestamp': [datetime(2021, 10, 27)]*2,
+                    'timestamp': [datetime(2021, 10, 27)] * 2,
                     'val': [1, 2],
                     'se': [None] * 2,
                     'sample_size': [None] * 2,
-                    'publish_date': [datetime(2021, 10, 30)]*2,
+                    'publish_date': [datetime(2021, 10, 30)] * 2,
                 })
             )
+        except AssertionError as e:
+            assert False, f"'add_max_ts_col' raised exception: {e}"
+
+        try:
+            # Input df has 2 unique timestamps per geo id-publish date
+            # combination. This should not raise an exception.
+            add_max_ts_col(
+                pd.DataFrame({
+                    'geo_id': ["ca", "ca", "fl", "fl"],
+                    'timestamp': [datetime(2021, 10, 27), datetime(2021, 10, 20)] * 2,
+                    'val': [1, 2, 3, 4],
+                    'se': [None] * 4,
+                    'sample_size': [None] * 4,
+                    'publish_date': [datetime(2021, 10, 30)] * 4,
+                })
+            )
+        except AssertionError as e:
+            assert False, f"'add_max_ts_col' raised exception: {e}"
 
     def test_std_err(self):
         df = pd.DataFrame({


### PR DESCRIPTION
### Description
Fix two CPR bugs:

- Some asserts are too strict given earlier logic.
- On 2021-03-17, the reference dates for test volume and test positivity changed from being the same within a report to being different. This caused some timestamps to appear for multiple report dates, which the existing logic can't handle appropriately. Fix by splitting data into before/after that date and processing separately.

### Changelog
- `pull.py`
- tests

### Fixes 
Closes #1556.
