### PR TITLE
[CTIS qsf tools] For changed matrix subquestions, the differ lists the particular items that changed

### DIFF
--- a/facebook/qsf-tools/qsf-differ.R
+++ b/facebook/qsf-tools/qsf-differ.R
@@ -210,8 +210,8 @@ create_diff_df <- function(questions, change_type=c("Added", "Removed",
     )    
     questions <- sort(questions)
 
-    if (!is.null(old_qsf, new_qsf {
-      old_qids <- sapply(questions, function(question) { old_qsf, new_qsfquestion]]$QuestionID })
+    if (!is.null(old_qsf)) {
+      old_qids <- sapply(questions, function(question) { old_qsf[[question]]$QuestionID })
     } else {
       old_qids <- NA
     }


### PR DESCRIPTION
### Description
The diff output now includes an `impacted_subquestions` column to indicate which particular matrix subquestion changed, if any. Subquestions are indicated with the full output name (carried forward from other questions and recoded with `ChoiceDataExportTags`, if provided). This will make it easier to join the annotated diff onto the codebook for the purpose of generating a changelog document.

### Changelog
- `qsf-differ.R`