### PR TITLE
Remove sorcerer's apprentice from raceeth tidy

### DIFF
--- a/facebook/Makefile
+++ b/facebook/Makefile
@@ -57,8 +57,9 @@ scratch:
 tidy%: receiving
 	rm -rf tidy$*/$(RECEIVING)
 	rm -rf tidy$*/$(INDIVIDUAL)
+	rm -rf tidy$*/$(INDIVIDUAL_RACEETH)
 	rm -f tidy$*/params.json
-	mkdir -p tidy$* tidy$*/$(RECEIVING) tidy$*/$(INDIVIDUAL)
+	mkdir -p tidy$* tidy$*/$(RECEIVING) tidy$*/$(INDIVIDUAL) tidy$*/$(INDIVIDUAL_RACEETH)
 	cp params.json tidy$*/
 	mv $(RECEIVING)/*.csv tidy$*/$(RECEIVING)
 	mv $(INDIVIDUAL)/*.csv* tidy$*/$(INDIVIDUAL)


### PR DESCRIPTION
### Description
Clear out old raceeth data from tidy directories before tidying today's run.

While reviewing https://github.com/cmu-delphi/covidcast-indicators/pull/1572 I noticed we weren't ever creating the tidy raceeth directory even though we were copying files into it, and it turns out we were never deleting it either, and I checked the server and we've just been straight-up tarballing an ever-growing collection of raceeth data in the tidy files. 😭 


### Changelog
Itemize code/test/documentation changes and files added/removed.
- Makefile, tidy target: delete old raceeth data; ensure raceeth folder exists.

### Fixes


```
[indicators@bigchunk-dev-02 facebook]$ du -sh tidy/individual tidy/individual_raceeth/ tidy/receiving/
4.5M    tidy/individual
1.1G    tidy/individual_raceeth/
28M     tidy/receiving/
```