### PR TITLE
Generalize BigQuery query to handle either NULL or empty string in `sub_region_2_code` correctly

### DIFF
--- a/google_symptoms/delphi_google_symptoms/pull.py
+++ b/google_symptoms/delphi_google_symptoms/pull.py
@@ -170,8 +170,8 @@ def produce_query(level, date_range):
     base_query = """
     select
         case
-            when sub_region_2_code is null then sub_region_1_code
-            when sub_region_2_code is not null then concat(sub_region_1_code, "-", sub_region_2_code)
+            when coalesce(sub_region_2_code, "") = "" then sub_region_1_code
+            when coalesce(sub_region_2_code, "") != "" then concat(sub_region_1_code, "-", sub_region_2_code)
         end as open_covid_region_code,
         date,
         {symptom_cols}


### PR DESCRIPTION
### Description
It appears that the underlying BigQuery table has changed the encoding for the `sub_region_2_code` field. For the US, this field is used to store county IDs; it is blank for states.

Although I can't find documentation of this, from our code, it appears that blanks in `sub_region_2_code` used to be coded as `NULL`. They are now empty strings (""). This causes the [`open_covid_region_code` field](https://github.com/cmu-delphi/covidcast-indicators/blob/4c03f4e5256a65b5eb6eacb9e907cb4aa2dfed26/google_symptoms/delphi_google_symptoms/pull.py#L172-L175) and later the [`geo_id` field](https://github.com/cmu-delphi/covidcast-indicators/blob/4c03f4e5256a65b5eb6eacb9e907cb4aa2dfed26/google_symptoms/delphi_google_symptoms/pull.py#L45-L46) to be created incorrectly at the state level. The result is that `geo_id`s are the same value (empty string) for all states, which the multiindex-er dislikes.

This PR changes our query so that it treats `NULL`s and empty strings in `sub_region_2_code` the same.

### Changelog
- `pull.py::produce_query`

### Fixes 
["ValueError: cannot handle a non-unique multi-index!"](https://delphi-org.slack.com/archives/C01LZ3A2UMU/p1649854869207719) raised during run.
