### PR TITLE
DSEW-CPR: Extend files to be processed for interpolation

### DIFF
--- a/dsew_community_profile/delphi_dsew_community_profile/constants.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/constants.py
@@ -6,6 +6,8 @@ URL_PREFIX = "https://healthdata.gov/api/views/gqxm-d9w9"
 DOWNLOAD_ATTACHMENT = URL_PREFIX + "/files/{assetId}?download=true&filename={filename}"
 DOWNLOAD_LISTING = URL_PREFIX + ".json"
 
+INTERP_LENGTH = 5
+
 @dataclass
 class Transform:
     """Transformation filters for interpreting a particular sheet in the workbook."""

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -13,9 +13,12 @@ import requests
 
 from delphi_utils.geomap import GeoMapper
 
-from .constants import (TRANSFORMS, SIGNALS, COUNTS_7D_SIGNALS, NEWLINE,
+from .constants import (
+    TRANSFORMS, SIGNALS, COUNTS_7D_SIGNALS, NEWLINE,
     IS_PROP, NOT_PROP,
-    DOWNLOAD_ATTACHMENT, DOWNLOAD_LISTING)
+    DOWNLOAD_ATTACHMENT, DOWNLOAD_LISTING,
+    INTERP_LENGTH
+)
 
 DataDict = Dict[Tuple[str, str, bool], pd.DataFrame]
 
@@ -416,25 +419,35 @@ def fetch_listing(params):
     ]
     if params['indicator']['reports'] == 'new':
         # drop files we already have in the input cache
-        listing = [el for el in listing if not os.path.exists(el['cached_filename'])]
+        keep = [el for el in listing if not os.path.exists(el['cached_filename'])]
     elif params['indicator']['reports'].find("--") > 0:
         # drop files outside the specified publish-date range
         start_str, _, end_str = params['indicator']['reports'].partition("--")
         start_date = datetime.datetime.strptime(start_str, "%Y-%m-%d").date()
         end_date = datetime.datetime.strptime(end_str, "%Y-%m-%d").date()
-        listing = [
+        keep = [
             el for el in listing
             if start_date <= el['publish_date'] <= end_date
         ]
+
     # reference date is guaranteed to be on or before publish date, so we can trim
     # reports that are too early
     if 'export_start_date' in params['indicator']:
-        listing = [
-            el for el in listing
+        keep = [
+            el for el in keep
             if params['indicator']['export_start_date'] <= el['publish_date']
         ]
     # can't do the same for export_end_date
-    return listing
+    return extend_listing_for_interp(keep, listing)
+
+def extend_listing_for_interp(keep, listing):
+    publish_date_keeplist = set()
+    for el in keep:
+        # starts at 0 so includes keep publish_dates
+        for i in range(INTERP_LENGTH):
+            publish_date_keeplist.add(el['publish_date'] - datetime.timedelta(days=i))
+    keep = [el for el in listing if el['publish_date'] in publish_date_keeplist]
+    return keep
 
 def download_and_parse(listing, logger):
     """Convert a list of report files into Dataset instances."""

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -441,6 +441,18 @@ def fetch_listing(params):
     return extend_listing_for_interp(keep, listing)
 
 def extend_listing_for_interp(keep, listing):
+    """Grab additional files from the full listing for interpolation if needed.
+
+    Selects files based purely on publish_date, so may include duplicates where
+    multiple reports for a single publish_date are available.
+
+    Parameters:
+     - keep: list of reports desired in the final output
+     - listing: complete list of reports available from healthdata.gov
+
+    Returns: list of reports including keep and additional files needed for
+    interpolation.
+    """
     publish_date_keeplist = set()
     for el in keep:
         # starts at 0 so includes keep publish_dates


### PR DESCRIPTION
### Description
when filtering the file listing for what to process, extend the final list by (INTERP_LENGTH-1) days backward from each desired file, so that we have something to interpolate with.

Linting errors are extant in #1555 

### Changelog
Itemize code/test/documentation changes and files added/removed.
- constants: add INTERP_LENGTH
- pull: add extend_listing_for_interp
- test: check single range, ranges that don't overlap, and ranges that do overlap.

### Fixes 
- Fixes TODO in #1555 
