### PR TITLE
[CTIS qsf tools] Grab bag of fixes and improvements

### DIFF
--- a/facebook/qsf-tools/generate-changelog.R
+++ b/facebook/qsf-tools/generate-changelog.R
@@ -189,19 +189,15 @@ generate_changelog <- function(path_to_codebook,
 }
 
 
-# args <- commandArgs(TRUE)
-# 
-# if (length(args) != 4) {
-#   stop("Usage: Rscript generate-changelog.R [UMD/CMU] path/to/codebook path/to/annotated/diff path/to/changelog")
-# }
-# 
-# survey_version <- args[1]
-# path_to_codebook <- args[2]
-# path_to_diff <- args[3]
-# path_to_changelog <- args[4]
-path_to_codebook <- "codebook.csv"
-path_to_diff <- "diff_10-11.csv"
-path_to_changelog <- "changelog_test_10v11.csv"
-survey_version <- "CMU"
+args <- commandArgs(TRUE)
+
+if (length(args) != 4) {
+  stop("Usage: Rscript generate-changelog.R [UMD/CMU] path/to/codebook path/to/annotated/diff path/to/changelog")
+}
+
+survey_version <- args[1]
+path_to_codebook <- args[2]
+path_to_diff <- args[3]
+path_to_changelog <- args[4]
 
 invisible(generate_changelog(path_to_codebook, path_to_diff, path_to_changelog, survey_version))

--- a/facebook/qsf-tools/generate-codebook.R
+++ b/facebook/qsf-tools/generate-codebook.R
@@ -182,7 +182,7 @@ process_qsf <- function(path_to_qsf,
       raw_scale_reversal == TRUE ~ "scale reversal",
       TRUE ~ "none"
     )
-  
+
   # format display logic
   # Not all questions have display logic; if NULL, shown to all respondents within section.
   display_logic <- displayed_questions %>% 
@@ -357,7 +357,7 @@ process_qsf <- function(path_to_qsf,
   qdf <- qdf %>%
     mutate(replaces = ifelse(variable %in% rownames(replaces_map), 
                              replaces_map[variable, "old_item"], 
-                             NA_character_),
+                             "none"),
            wave = wave
     ) %>% 
     select(wave,
@@ -382,9 +382,9 @@ process_qsf <- function(path_to_qsf,
   # add free text response options
   other_text_items <- qdf %>%
     filter(variable %in% names(other_text_items)) %>%
+    # "Other text" items should borrow most fields from base question.
     mutate(variable = other_text_items[variable],
            question_type = "Text",
-           response_option_randomization = NA,
            description = paste0(description, " other text")
     )
   qdf <- rbind(qdf, other_text_items)

--- a/facebook/qsf-tools/qsf-differ.R
+++ b/facebook/qsf-tools/qsf-differ.R
@@ -59,6 +59,7 @@ get_qsf_file <- function(path, survey_version,
                                         "QuestionText", "QuestionType",
                                         "Choices", "Answers", "DisplayLogic")
 ) {
+  wave <- get_wave(path)
   # Read file as json.
   qsf <- read_json(path)
   ## Block
@@ -157,6 +158,14 @@ get_qsf_file <- function(path, survey_version,
         question$DataExportTag == "B12b" & question$QuestionID == "QID257" ~ "B12b_profile",
         TRUE ~ question$DataExportTag
       )
+    } else if (survey_version == "CMU") {
+      if (wave == 10) {
+        question$DataExportTag <- case_when(
+          question$DataExportTag == "C6" ~ "C6a",
+          question$DataExportTag == "C8" ~ "C8a",
+          TRUE ~ question$DataExportTag
+        )
+      }
     }
     
     questions_out <- safe_insert_question(questions_out, question)

--- a/facebook/qsf-tools/qsf-differ.R
+++ b/facebook/qsf-tools/qsf-differ.R
@@ -165,9 +165,13 @@ get_qsf_file <- function(path, survey_version,
           question$DataExportTag == "C8" ~ "C8a",
           TRUE ~ question$DataExportTag
         )
+      } else if (wave == 11) {
+        if (question$DataExportTag == "E1") {
+          names(question$Subquestions) <- c("E1_1", "E1_2", "E1_3", "E1_4")
+        }
       }
     }
-    
+      
     questions_out <- safe_insert_question(questions_out, question)
     qid_item_map[[question$QuestionID]] <- question$DataExportTag
   }
@@ -258,7 +262,7 @@ diff_question <- function(names, change_type=c("Choices", "QuestionText",
             names(new_qsf[[question]][[change_type]])
           )
         )
-        
+
         for (code in subquestion_codes) {
           if ( !identical(old_qsf[[question]][[change_type]][[code]], new_qsf[[question]][[change_type]][[code]]) ) {
             changed_subquestions <- append(changed_subquestions, code)


### PR DESCRIPTION
### Description
- In CMU Wave 10, manually rename C6 -> C6a and C8 -> C8a to match [bodge function](https://github.com/cmu-delphi/covidcast-indicators/blob/6dba43d13ebe5a092249c9af23930d09e60badc3/facebook/delphiFacebook/R/responses.R#L474) and intended naming.
- In CMU Wave 11, manually rename E1 subquestions to match [bodge function](https://github.com/cmu-delphi/covidcast-indicators/blob/6dba43d13ebe5a092249c9af23930d09e60badc3/facebook/delphiFacebook/R/responses.R#L547).
- Standardize meaning of "none" and "NA" in the codebook. `NA` means that that particular field isn't valid for the item listed. For example, the `module` field isn't a survey item so `display_logic` can't be defined for it. For survey items with no display logic, `display_logic` is `none` because it could be defined for a survey item, it's just not in this case. `none` is the opposite of `all`.
- Fix how matrix items are created when joining the codebook onto the diff. The diff contains one observation per matrix item. The codebook contains one observation per matrix subquestion (so 3+ per matrix question).

### Changelog
- `qsf-tools/generate-changelog.R`
- `qsf-tools/generate-codebook.R`
- `qsf-tools/qsf-differ.R`