### PR TITLE
Add archive params to prod dsew-cpr configuration

### DIFF
--- a/ansible/templates/dsew_community_profile-params-prod.json.j2
+++ b/ansible/templates/dsew_community_profile-params-prod.json.j2
@@ -39,5 +39,14 @@
         "booster_doses_admin_7dav"
       ]
     }
+  },
+  "archive": {
+    "aws_credentials": {
+      "aws_access_key_id": "{{ delphi_aws_access_key_id }}",
+      "aws_secret_access_key": "{{ delphi_aws_secret_access_key }}"
+    },
+    "bucket_name": "delphi-covidcast-indicator-output",
+    "cache_dir": "./cache",
+    "indicator_prefix": "delphi_dsew_community_profile"
   }
 }


### PR DESCRIPTION
### Description
Archive-differ is required for interpolation. Destination prefix is already set up with output through 2022-04-18. Once this is merged, we'll do a release; once the release is merged; interpolation will be activated in prod.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- Production params for dsew-cpr

### Fixes 
- Release mechanism for interpolation
