### PR TITLE
Add sort option to create_export_csv

### DIFF
--- a/_delphi_utils_python/delphi_utils/export.py
+++ b/_delphi_utils_python/delphi_utils/export.py
@@ -42,6 +42,7 @@ def create_export_csv(
     write_empty_days: Optional[bool] = False,
     logger: Optional[logging.Logger] = None,
     weekly_dates = False,
+    sort_geos: bool = False
 ):
     """Export data in the format expected by the Delphi API.
 
@@ -73,6 +74,9 @@ def create_export_csv(
     weekly_dates: Optional[bool]
         Whether the output data are weekly or not. If True, will prefix files with
         "weekly_YYYYWW" where WW is the epiweek instead of the usual YYYYMMDD for daily files.
+    sort_geos: bool
+        If True, the dataframe is sorted by geo before writing. Otherwise, the dataframe is
+        written as is.
 
     Returns
     ---------
@@ -122,5 +126,7 @@ def create_export_csv(
         if remove_null_samples:
             export_df = export_df[export_df["sample_size"].notnull()]
         export_df = export_df.round({"val": 7, "se": 7})
+        if sort_geos:
+            export_df = export_df.sort_values(by="geo_id")
         export_df.to_csv(export_file, index=False, na_rep="NA")
     return dates

--- a/_delphi_utils_python/tests/test_export.py
+++ b/_delphi_utils_python/tests/test_export.py
@@ -30,7 +30,9 @@ def _non_ignored_files_set(directory):
     return out
 
 def _set_df_dtypes(df: pd.DataFrame, dtypes: Dict[str, Any]) -> pd.DataFrame:
-    assert all(isinstance(e, type) for e in dtypes.values()), "Values must be types."
+    assert all(isinstance(e, type) or isinstance(e, str) for e in dtypes.values()), (
+        "Values must be types or Pandas string aliases for types."
+    )
 
     df = df.copy()
     for k, v in dtypes.items():

--- a/_delphi_utils_python/tests/test_export.py
+++ b/_delphi_utils_python/tests/test_export.py
@@ -30,6 +30,8 @@ def _non_ignored_files_set(directory):
     return out
 
 def _set_df_dtypes(df: pd.DataFrame, dtypes: Dict[str, Any]) -> pd.DataFrame:
+    assert all(isinstance(e, type) for e in dtypes.values()), "Values must be types."
+
     df = df.copy()
     for k, v in dtypes.items():
         if k in df.columns:
@@ -407,10 +409,8 @@ class TestExport:
             "se": [0.15, 0.22],
             "sample_size": [100, 100],
         })
-        assert_frame_equal(
-            _set_df_dtypes(pd.read_csv(join(self.TEST_DIR, "20200215_county_test.csv")), dtypes={"geo_id": str}),
-            expected_df
-        )
+        unsorted_csv = _set_df_dtypes(pd.read_csv(join(self.TEST_DIR, "20200215_county_test.csv")), dtypes={"geo_id": str})
+        assert_frame_equal(unsorted_csv, expected_df)
 
         _clean_directory(self.TEST_DIR)
         create_export_csv(
@@ -426,7 +426,5 @@ class TestExport:
             "se": [0.22, 0.15],
             "sample_size": [100, 100],
         })
-        assert_frame_equal(
-            _set_df_dtypes(pd.read_csv(join(self.TEST_DIR, "20200215_county_test.csv")), dtypes={"geo_id": str}),
-            expected_df
-        )
+        sorted_csv = _set_df_dtypes(pd.read_csv(join(self.TEST_DIR, "20200215_county_test.csv")), dtypes={"geo_id": str})
+        assert_frame_equal(sorted_csv,expected_df)

--- a/_delphi_utils_python/tests/test_export.py
+++ b/_delphi_utils_python/tests/test_export.py
@@ -401,9 +401,15 @@ class TestExport:
             geo_res="county",
             sensor="test"
         )
+        expected_df = pd.DataFrame({
+            "geo_id": ["51175", "51093"],
+            "val": [3.12345678910, 2.1],
+            "se": [0.15, 0.22],
+            "sample_size": [100, 100],
+        })
         assert_frame_equal(
             _set_df_dtypes(pd.read_csv(join(self.TEST_DIR, "20200215_county_test.csv")), dtypes={"geo_id": str}),
-            unsorted_df.query("timestamp == '2020-02-15'").drop(columns="timestamp").reset_index(drop=True)
+            expected_df
         )
 
         _clean_directory(self.TEST_DIR)
@@ -414,7 +420,13 @@ class TestExport:
             sensor="test",
             sort_geos=True
         )
+        expected_df = pd.DataFrame({
+            "geo_id": ["51093", "51175"],
+            "val": [2.1, 3.12345678910],
+            "se": [0.22, 0.15],
+            "sample_size": [100, 100],
+        })
         assert_frame_equal(
             _set_df_dtypes(pd.read_csv(join(self.TEST_DIR, "20200215_county_test.csv")), dtypes={"geo_id": str}),
-            unsorted_df.query("timestamp == '2020-02-15'").sort_values(by="geo_id").drop(columns="timestamp").reset_index(drop=True)
+            expected_df
         )

--- a/_delphi_utils_python/tests/test_export.py
+++ b/_delphi_utils_python/tests/test_export.py
@@ -2,10 +2,12 @@
 from datetime import datetime
 from os import listdir, remove
 from os.path import join
+from typing import Any, Dict, List
 
 import mock
 import numpy as np
 import pandas as pd
+from pandas.testing import assert_frame_equal
 
 from delphi_utils import create_export_csv, Nans
 
@@ -26,6 +28,13 @@ def _non_ignored_files_set(directory):
             continue
         out.add(fname)
     return out
+
+def _set_df_dtypes(df: pd.DataFrame, dtypes: Dict[str, Any]) -> pd.DataFrame:
+    df = df.copy()
+    for k, v in dtypes.items():
+        if k in df.columns:
+            df[k] = df[k].astype(v)
+    return df
 
 
 class TestExport:
@@ -136,7 +145,7 @@ class TestExport:
             geo_res="county",
             sensor="test",
         )
-        pd.testing.assert_frame_equal(
+        assert_frame_equal(
             pd.read_csv(join(self.TEST_DIR, "20200215_county_deaths_test.csv")),
             pd.DataFrame(
                 {
@@ -316,7 +325,7 @@ class TestExport:
                 "sample_size": [100, 100],
             }
         ).astype({"geo_id": str, "sample_size": int})
-        pd.testing.assert_frame_equal(df, expected_df)
+        assert_frame_equal(df, expected_df)
 
     def test_export_df_with_missingness(self):
         _clean_directory(self.TEST_DIR)
@@ -348,7 +357,7 @@ class TestExport:
                 "missing_sample_size": [Nans.NOT_MISSING] * 2,
             }
         ).astype({"geo_id": str, "sample_size": int})
-        pd.testing.assert_frame_equal(df, expected_df)
+        assert_frame_equal(df, expected_df)
 
     @mock.patch("delphi_utils.logger")
     def test_export_df_with_contradictory_missingness(self, mock_logger):
@@ -371,4 +380,41 @@ class TestExport:
         assert pd.read_csv(join(self.TEST_DIR, "20200315_state_test.csv")).size > 0
         mock_logger.info.assert_called_once_with(
             "Filtering contradictory missing code in test_None_2020-02-15."
+        )
+
+    def test_export_sort(self):
+        _clean_directory(self.TEST_DIR)
+
+        unsorted_df = pd.DataFrame({
+            "geo_id": ["51175", "51093", "51175", "51620"],
+            "timestamp": [
+                datetime.strptime(x, "%Y-%m-%d")
+                for x in ["2020-02-15", "2020-02-15", "2020-03-01", "2020-03-15"]
+            ],
+            "val": [3.12345678910, 2.1, 2.2, 2.6],
+            "se": [0.15, 0.22, 0.20, 0.34],
+            "sample_size": [100, 100, 101, 100],
+        })
+        create_export_csv(
+            unsorted_df,
+            export_dir=self.TEST_DIR,
+            geo_res="county",
+            sensor="test"
+        )
+        assert_frame_equal(
+            _set_df_dtypes(pd.read_csv(join(self.TEST_DIR, "20200215_county_test.csv")), dtypes={"geo_id": str}),
+            unsorted_df.query("timestamp == '2020-02-15'").drop(columns="timestamp").reset_index(drop=True)
+        )
+
+        _clean_directory(self.TEST_DIR)
+        create_export_csv(
+            unsorted_df,
+            export_dir=self.TEST_DIR,
+            geo_res="county",
+            sensor="test",
+            sort_geos=True
+        )
+        assert_frame_equal(
+            _set_df_dtypes(pd.read_csv(join(self.TEST_DIR, "20200215_county_test.csv")), dtypes={"geo_id": str}),
+            unsorted_df.query("timestamp == '2020-02-15'").sort_values(by="geo_id").drop(columns="timestamp").reset_index(drop=True)
         )


### PR DESCRIPTION
### Description
Adds the option to sort by geo before writing a csv.

### Changelog
- Test included.

### Fixes 
- Fixes #1588 
