### PR TITLE
Cast CPR value columns to float before interpolating

### DIFF
--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -650,6 +650,7 @@ def interpolate_missing_values(dfs: DataDict) -> DataDict:
                 reindexed_group_df["publish_date"] = reindexed_group_df["publish_date"].fillna(
                     method="bfill"
                 )
+            reindexed_group_df = reindexed_group_df[~reindexed_group_df.val.isna()]
             geo_dfs.append(reindexed_group_df)
         interpolate_df[key] = (
             pd.concat(geo_dfs).reset_index().rename(columns={"index": "timestamp"})

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -630,14 +630,12 @@ def interpolate_missing_values(dfs: DataDict) -> DataDict:
                     reindexed_group_df["val"]
                     .astype(float)
                     .interpolate(method="linear", limit_area="inside")
-                    .astype(float)
                 )
             if "se" in reindexed_group_df.columns:
                 reindexed_group_df["se"] = (
                     reindexed_group_df["se"]
                     .astype(float)
                     .interpolate(method="linear", limit_area="inside")
-                    .astype(float)
                 )
             if (
                 "sample_size" in reindexed_group_df.columns
@@ -647,7 +645,6 @@ def interpolate_missing_values(dfs: DataDict) -> DataDict:
                     reindexed_group_df["sample_size"]
                     .astype(float)
                     .interpolate(method="linear", limit_area="inside")
-                    .astype(float)
                 )
             if "publish_date" in reindexed_group_df.columns:
                 reindexed_group_df["publish_date"] = reindexed_group_df["publish_date"].fillna(

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -628,12 +628,14 @@ def interpolate_missing_values(dfs: DataDict) -> DataDict:
             if "val" in reindexed_group_df.columns and not reindexed_group_df["val"].isna().all():
                 reindexed_group_df["val"] = (
                     reindexed_group_df["val"]
+                    .astype(float)
                     .interpolate(method="linear", limit_area="inside")
                     .astype(float)
                 )
             if "se" in reindexed_group_df.columns:
                 reindexed_group_df["se"] = (
                     reindexed_group_df["se"]
+                    .astype(float)
                     .interpolate(method="linear", limit_area="inside")
                     .astype(float)
                 )
@@ -643,6 +645,7 @@ def interpolate_missing_values(dfs: DataDict) -> DataDict:
             ):
                 reindexed_group_df["sample_size"] = (
                     reindexed_group_df["sample_size"]
+                    .astype(float)
                     .interpolate(method="linear", limit_area="inside")
                     .astype(float)
                 )

--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -539,6 +539,7 @@ class TestPull:
         }), dtypes=DTYPES)
         # A linear signal missing two days which should be filled exactly by the linear interpolation.
         missing_sig1 = sig1[(sig1.timestamp <= "2022-01-05") | (sig1.timestamp >= "2022-01-08")]
+        # set all columns to object type to simulate the miscast we sometimes see when combining dfs
         missing_sig1 = _set_df_dtypes(missing_sig1, {key: object for key in DTYPES.keys()})
 
         interpolated_dfs1 = interpolate_missing_values({("src", "sig", False): missing_sig1})


### PR DESCRIPTION
### Description
Explicitly cast `val`, `se`, and `sample_size` fields to `float` right before performing interpolation. Add a test to check if interpolation works correctly when the input df has value columns of type `object`.

Drop obs where `val` is missing.

Bonus: update `assert_frame_equal` import to silence deprecation warning.

### Changelog
- `pull.py`
- `test_pull.py`

### Fixes 
In some cases, interpolation doesn't work correctly, reporting all `NA`s for a geo type-signal-date combination that should have been interpolatable.

[Combining dfs across reports](https://github.com/cmu-delphi/covidcast-indicators/blob/939501ba577fc8990a3a5e7cab2a52e90eeb7088/dsew_community_profile/delphi_dsew_community_profile/pull.py#L550) sometimes implicitly converts an int or float `val` column to an `object` type.

This happens when the `val` field is different types in different subdfs (the per-signal per-report dfs).

When a date range includes at least one report for which a signal is not available, we produce an [empty dataframe with the correct column names but all of `object` type](https://github.com/cmu-delphi/covidcast-indicators/blob/939501ba577fc8990a3a5e7cab2a52e90eeb7088/dsew_community_profile/delphi_dsew_community_profile/pull.py#L362-L365), the default type. On the other hand, when a signal is available in a given report, we read in that data with `val` as a numeric.

Since a standard df column can't hold multiple types, when we combine the empty subdfs with the correctly-typed subdfs, the resulting columns are auto-converted to `object` types, which can hold mixed types. (`object` fields are also used to hold strings.)

The `interpolate` function [doesn't perform linear interpolation for `object`-typed columns](https://note.nkmk.me/en/python-pandas-interpolate/), because it thinks those columns are either strings or mixed types that can't be manipulated mathematically in a uniform fashion. (Although in our case, we have an `object` field that actually only contains a single type of element.) As a result, `interpolate` doesn't overwrite the `NaN`s that `reindex` inserts.

So limited-scope, recent time periods (e.g. 2022-04-01 through 2022-04-07) interpolate correctly, since all geo types have all signals available in every report, but older/longer time periods won't interpolate correctly. Specifically, they won't work for any signal not included in one or more reports and _included_ in one or more reports.

Incidentally also closes https://github.com/cmu-delphi/covidcast-indicators/issues/1593.