### PR TITLE
Update Quidel pull.py to ignore folder names when scanning bucket objects

### DIFF
--- a/quidel_covidtest/delphi_quidel_covidtest/pull.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/pull.py
@@ -35,7 +35,7 @@ def get_from_s3(start_date, end_date, bucket, logger):
     df = pd.DataFrame(columns=selected_columns)
     s3_files = {}
     for obj in bucket.objects.all():
-        if "-sars" in obj.key:
+        if "-sars" in obj.key and ".csv" in obj.key:
             date_string = obj.key.split("/")[1]
             try:
                 yy = int(date_string.split("_")[0])


### PR DESCRIPTION
### Description
Fix the problem described in #1595. 

We add a simple check to consider csv files only when scanning objects in the S3 bucket.

### Changelog
- ./delphi_quidel_covidtest/pull.py/get_from_s3

### Fixes 
- #1595 
