### PR TITLE
[Draft] Create a common set of testing functions

### DIFF
--- a/_delphi_utils_python/delphi_utils/testing.py
+++ b/_delphi_utils_python/delphi_utils/testing.py
@@ -1,0 +1,21 @@
+from typing import Any, Dict
+import pandas as pd
+
+
+def check_valid_dtype(dtype):
+    try:
+        pd.api.types.pandas_dtype(dtype)
+    except TypeError:
+        raise ValueError(f"Invalid dtype {dtype}")
+
+
+def set_df_dtypes(df: pd.DataFrame, dtypes: Dict[str, Any]) -> pd.DataFrame:
+    """Set the dataframe column datatypes."""
+    [check_valid_dtype(d) for d in dtypes.values()]
+
+    df = df.copy()
+    for k, v in dtypes.items():
+        if k in df.columns:
+            df[k] = df[k].astype(v)
+    return df
+

--- a/_delphi_utils_python/tests/test_geomap.py
+++ b/_delphi_utils_python/tests/test_geomap.py
@@ -3,6 +3,7 @@ from delphi_utils.geomap import GeoMapper
 import pytest
 
 import pandas as pd
+from pandas.testing import assert_frame_equal
 import numpy as np
 
 
@@ -204,13 +205,7 @@ class TestGeoMapper:
                 "count": [8, 7, 3, 10021],
             }
         )
-        pd.testing.assert_frame_equal(new_data.set_index("megafips").sort_index(axis=1), expected_df.set_index("megafips").sort_index(axis=1))
-        # chng-fips should have the same behavior when converting to megacounties.
-        mega_county_groups = self.mega_data_3.copy()
-        mega_county_groups.fips.replace({1125:"01g01"}, inplace = True)
-        new_data = geomapper.fips_to_megacounty(self.mega_data_3, 4, 1)
-        pd.testing.assert_frame_equal(new_data.set_index("megafips").sort_index(axis=1), expected_df.set_index("megafips").sort_index(axis=1))
-
+        assert_frame_equal(new_data.set_index("megafips").sort_index(axis=1), expected_df.set_index("megafips").sort_index(axis=1))
         new_data = geomapper.fips_to_megacounty(self.mega_data_3, 4, 1, thr_col="count")
         expected_df = pd.DataFrame(
             {
@@ -220,12 +215,7 @@ class TestGeoMapper:
                 "count": [6, 5, 7, 10021],
             }
         )
-        pd.testing.assert_frame_equal(new_data.set_index("megafips").sort_index(axis=1), expected_df.set_index("megafips").sort_index(axis=1))
-        # chng-fips should have the same behavior when converting to megacounties.
-        mega_county_groups = self.mega_data_3.copy()
-        mega_county_groups.fips.replace({1123:"01g01"}, inplace = True)
-        new_data = geomapper.fips_to_megacounty(self.mega_data_3, 4, 1, thr_col="count")
-        pd.testing.assert_frame_equal(new_data.set_index("megafips").sort_index(axis=1), expected_df.set_index("megafips").sort_index(axis=1))
+        assert_frame_equal(new_data.set_index("megafips").sort_index(axis=1), expected_df.set_index("megafips").sort_index(axis=1))
 
     def test_add_population_column(self, geomapper):
         new_data = geomapper.add_population_column(self.fips_data_3, "fips")
@@ -269,7 +259,7 @@ class TestGeoMapper:
 
         # fips -> nation
         new_data = geomapper.replace_geocode(self.fips_data_5, "fips", "nation", new_col="NATION")
-        pd.testing.assert_frame_equal(
+        assert_frame_equal(
             new_data,
             pd.DataFrame().from_dict(
                 {
@@ -303,7 +293,7 @@ class TestGeoMapper:
 
         # zip -> nation
         new_data = geomapper.replace_geocode(self.zip_data, "zip", "nation")
-        pd.testing.assert_frame_equal(
+        assert_frame_equal(
             new_data,
             pd.DataFrame().from_dict(
                 {
@@ -329,7 +319,7 @@ class TestGeoMapper:
 
         # fips -> zip (date_col=None chech)
         new_data = geomapper.replace_geocode(self.fips_data_5.drop(columns=["timestamp"]), "fips", "hrr", date_col=None)
-        pd.testing.assert_frame_equal(
+        assert_frame_equal(
             new_data,
             pd.DataFrame().from_dict(
                 {
@@ -343,7 +333,7 @@ class TestGeoMapper:
         # fips -> hhs
         new_data = geomapper.replace_geocode(self.fips_data_3.drop(columns=["timestamp"]),
                                         "fips", "hhs", date_col=None)
-        pd.testing.assert_frame_equal(
+        assert_frame_equal(
             new_data,
             pd.DataFrame().from_dict(
                 {
@@ -357,7 +347,7 @@ class TestGeoMapper:
         # zip -> hhs
         new_data = geomapper.replace_geocode(self.zip_data, "zip", "hhs")
         new_data = new_data.round(10)  # get rid of a floating point error with 99.00000000000001
-        pd.testing.assert_frame_equal(
+        assert_frame_equal(
             new_data,
             pd.DataFrame().from_dict(
                 {

--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -1,15 +1,13 @@
 from collections import namedtuple
-from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from itertools import chain
-from typing import Any, Dict, List, Union
 import pandas as pd
-from pandas.testing import assert_frame_equal
 import numpy as np
 import pytest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from delphi_utils.geomap import GeoMapper
+from delphi_utils.testing import set_df_dtypes
 
 from delphi_dsew_community_profile.pull import (
     DatasetTimes, Dataset,
@@ -18,26 +16,7 @@ from delphi_dsew_community_profile.pull import (
     extend_listing_for_interp
 )
 
-
 example = namedtuple("example", "given expected")
-
-def _assert_frame_equal(df1, df2, index_cols: List[str] = None):
-    # Ensure same columns present.
-    assert set(df1.columns) == set(df2.columns)
-    # Ensure same column order.
-    df1 = df1[df1.columns]
-    df2 = df2[df1.columns]
-    # Ensure same row order by using a common index and sorting.
-    df1 = df1.set_index(index_cols).sort_index()
-    df2 = df2.set_index(index_cols).sort_index()
-    return assert_frame_equal(df1, df2)
-
-def _set_df_dtypes(df: pd.DataFrame, dtypes: Dict[str, Any]) -> pd.DataFrame:
-    df = df.copy()
-    for k, v in dtypes.items():
-        if k in df.columns:
-            df[k] = df[k].astype(v)
-    return df
 
 
 class TestPull:
@@ -170,7 +149,7 @@ class TestPull:
         ]
         for ex in examples:
             assert Dataset.retain_header(ex.given) == ex.expected, ex.given
-            
+
     def test_Dataset_parse_sheet(self):
         # TODO
         pass
@@ -515,7 +494,7 @@ class TestPull:
         DTYPES = {"geo_id": str, "timestamp": "datetime64[ns]", "val": float, "se": float, "sample_size": float, "publish_date": "datetime64[ns]"}
         line = lambda x: 3 * x + 5
 
-        sig1 = _set_df_dtypes(pd.DataFrame({
+        sig1 = set_df_dtypes(pd.DataFrame({
             "geo_id": "1",
             "timestamp": pd.date_range("2022-01-01", "2022-01-10"),
             "val": [line(i) for i in range(2, 12)],
@@ -531,7 +510,7 @@ class TestPull:
         # A linear signal missing everything but the end points, should be filled exactly by linear interpolation.
         missing_sig2 = sig2[(sig2.timestamp == "2022-01-01") | (sig2.timestamp == "2022-01-10")]
 
-        sig3 = _set_df_dtypes(pd.DataFrame({
+        sig3 = set_df_dtypes(pd.DataFrame({
             "geo_id": "3",
             "timestamp": pd.date_range("2022-01-01", "2022-01-10"),
             "val": None,
@@ -542,7 +521,7 @@ class TestPull:
         # A signal missing everything, should be dropped since it's all NAs.
         missing_sig3 = sig3[(sig3.timestamp <= "2022-01-05") | (sig3.timestamp >= "2022-01-08")]
 
-        sig4 = _set_df_dtypes(pd.DataFrame({
+        sig4 = set_df_dtypes(pd.DataFrame({
             "geo_id": "4",
             "timestamp": pd.date_range("2022-01-01", "2022-01-10"),
             "val": [None] * 9 + [10.0],
@@ -556,13 +535,13 @@ class TestPull:
         missing_dfs = [missing_sig1, missing_sig2, missing_sig3, missing_sig4]
         interpolated_dfs1 = interpolate_missing_values({("src", "sig", False): pd.concat(missing_dfs)})
         expected_dfs = pd.concat([sig1, sig2, sig4.loc[9:]])
-        _assert_frame_equal(interpolated_dfs1[("src", "sig", False)], expected_dfs, index_cols=["geo_id", "timestamp"])
+        pd.testing.assert_frame_equal(interpolated_dfs1[("src", "sig", False)], expected_dfs)
 
     def test_interpolation_object_type(self):
         DTYPES = {"geo_id": str, "timestamp": "datetime64[ns]", "val": float, "se": float, "sample_size": float, "publish_date": "datetime64[ns]"}
         line = lambda x: 3 * x + 5
 
-        sig1 = _set_df_dtypes(pd.DataFrame({
+        sig1 = set_df_dtypes(pd.DataFrame({
             "geo_id": "1",
             "timestamp": pd.date_range("2022-01-01", "2022-01-10"),
             "val": [line(i) for i in range(2, 12)],
@@ -573,11 +552,11 @@ class TestPull:
         # A linear signal missing two days which should be filled exactly by the linear interpolation.
         missing_sig1 = sig1[(sig1.timestamp <= "2022-01-05") | (sig1.timestamp >= "2022-01-08")]
         # set all columns to object type to simulate the miscast we sometimes see when combining dfs
-        missing_sig1 = _set_df_dtypes(missing_sig1, {key: object for key in DTYPES.keys()})
+        missing_sig1 = set_df_dtypes(missing_sig1, {key: object for key in DTYPES.keys()})
 
         interpolated_dfs1 = interpolate_missing_values({("src", "sig", False): missing_sig1})
         expected_dfs = pd.concat([sig1])
-        _assert_frame_equal(interpolated_dfs1[("src", "sig", False)], expected_dfs, index_cols=["geo_id", "timestamp"])
+        pd.testing.assert_frame_equal(interpolated_dfs1[("src", "sig", False)], expected_dfs)
 
     @patch("delphi_dsew_community_profile.pull.INTERP_LENGTH", 2)
     def test_extend_listing(self):


### PR DESCRIPTION
### Description
Noticed that I've been consistently rewriting the `_assert_frame_equal` and `_set_df_dtypes` functions in all the tests I write now, to help with testing. I pulled these out into `delphi_utils.testing` and refactored in a couple places. Considering refactoring them in other indicators, but I'm not sure if those tests were actually meant to depend on row order, so I don't want to make those tests less strict.

### Changelog
Create `delphi_utils.testing` and refactor a few recent tests.
