### PR TITLE
Produce CPR positivity in production

### DIFF
--- a/ansible/templates/dsew_community_profile-params-prod.json.j2
+++ b/ansible/templates/dsew_community_profile-params-prod.json.j2
@@ -11,7 +11,8 @@
       "doses administered",
       "booster doses administered",
       "fully vaccinated",
-      "booster dose since"
+      "booster dose since",
+      "positivity"
     ]
   },
   "validation": {
@@ -31,7 +32,6 @@
     "dynamic": {
       "ref_window_size": 7,
       "smoothed_signals": [
-        "naats_total_7dav",
         "naats_positivity_7dav",
         "confirmed_admissions_covid_1d_prop_7dav",
         "confirmed_admissions_covid_1d_7dav",

--- a/dsew_community_profile/params.json.template
+++ b/dsew_community_profile/params.json.template
@@ -10,7 +10,6 @@
     "export_end_date": null,
     "export_signals": [
       "confirmed covid-19 admissions",
-      "total",
       "positivity",
       "doses administered",
       "booster doses administered",
@@ -35,7 +34,6 @@
     "dynamic": {
       "ref_window_size": 7,
       "smoothed_signals": [
-        "naats_total_7dav",
         "naats_positivity_7dav",
         "confirmed_admissions_covid_1d_prop_7dav",
         "confirmed_admissions_covid_1d_7dav",


### PR DESCRIPTION
### Description
Update CPR production params so that test positivity is output.

Also remove total tests signal from params; it is reported as the sample size for test positivity, not as a separate signal.

### Changelog
- Ansible template params
- Indicator local params

Note: before releasing this, we need to verify in staging that test positivity files are produced, but values are not interpolated. This looks correct in local testing.