### PR TITLE
[CTIS] Compress contingency tables

### DIFF
--- a/facebook/contingency-combine.R
+++ b/facebook/contingency-combine.R
@@ -26,11 +26,11 @@ suppressPackageStartupMessages({
 #'   create new ones, relative to the current working directory.
 #' @param pattern Regular expression indicating which files in that directory to
 #'   open. By default, selects all `.csv` files with standard table date prefix.
-run_rollup <- function(input_dir, output_dir, pattern = "^[0-9]{8}_[0-9]{8}.*[.]csv$") {
+run_rollup <- function(input_dir, output_dir, pattern = "^[0-9]{8}_[0-9]{8}.*[.]csv.gz$") {
   if (!dir.exists(output_dir)) { dir.create(output_dir) }
   
   files <- list.files(input_dir, pattern = pattern)
-  if (length(files) == 0) { stop("No matching data files.") }
+  if (length(files) == 0) { stop("No matching contingency files to combine.") }
 
   # Get df of input files and corresponding output files. Reformat as a list
   # such that input files with same grouping variables (and thus same output

--- a/facebook/delphiFacebook/R/contingency_write.R
+++ b/facebook/delphiFacebook/R/contingency_write.R
@@ -45,6 +45,7 @@ write_contingency_tables <- function(data, params, geo_type, groupby_vars)
     
     file_name <- get_file_name(params, geo_type, groupby_vars)
     msg_df(sprintf("saving contingency table data to %-35s", file_name), data)
+    # Automatically uses gzip compression based on output file name.
     write_csv(data, file.path(params$export_dir, file_name))
 
   } else {
@@ -169,7 +170,8 @@ get_file_name <- function(params, geo_type, groupby_vars) {
   if (!is.null(params$debug) && params$debug) {
     file_name <- paste0("DebugOn-DoNotShare_", file_name)
   }
-  file_name <- paste0(file_name, ".csv")
+  # Always use gzip compression.
+  file_name <- paste0(file_name, ".csv.gz")
   return(file_name)
 }
 

--- a/facebook/delphiFacebook/integration-tests/testthat/test-contingency-run.R
+++ b/facebook/delphiFacebook/integration-tests/testthat/test-contingency-run.R
@@ -67,10 +67,10 @@ test_that("small dataset produces no output", {
 ### This test relies on `setup-run.R` to run the full pipeline and tests basic
 ### properties of the output.
 test_that("full synthetic dataset produces expected output format", {
-  expected_files <- c("20200501_20200531_monthly_nation_gender.csv")
+  expected_files <- c("20200501_20200531_monthly_nation_gender.csv.gz")
   actual_files <- dir(test_path("receiving_contingency_full"))
   
-  out <- read.csv(file.path(params$export_dir, "20200501_20200531_monthly_nation_gender.csv"))
+  out <- read.csv(file.path(params$export_dir, "20200501_20200531_monthly_nation_gender.csv.gz"))
   
   expect_setequal(expected_files, actual_files)
   expect_equal(dir.exists(test_path("receiving_contingency_full")), TRUE)
@@ -101,7 +101,7 @@ test_that("simple equal-weight dataset produces correct percents", {
   run_contingency_tables_many_periods(params, base_aggs[2,])
 
   # Expected files
-  expect_setequal(!!dir(params$export_dir), c("20200501_20200531_monthly_nation_gender.csv"))
+  expect_setequal(!!dir(params$export_dir), c("20200501_20200531_monthly_nation_gender.csv.gz"))
 
   # Expected file contents
   raw_data <- read.csv(test_path("./input/simple_synthetic.csv"))
@@ -112,7 +112,7 @@ test_that("simple equal-weight dataset produces correct percents", {
     "us", "Female", fever_prop * 100, NA, 2000L, 100 * 2000
   ))
   
-  df <- read.csv(file.path(params$export_dir, "20200501_20200531_monthly_nation_gender.csv"))
+  df <- read.csv(file.path(params$export_dir, "20200501_20200531_monthly_nation_gender.csv.gz"))
   expect_equivalent(df, expected_output)
 })
 
@@ -148,7 +148,7 @@ test_that("testing run with multiple aggregations per group", {
     represented_pct_heartdisease = 100 * 2000,
   )
 
-  out <- read.csv(file.path(params$export_dir, "20200501_20200531_monthly_nation_gender.csv"))
+  out <- read.csv(file.path(params$export_dir, "20200501_20200531_monthly_nation_gender.csv.gz"))
   expect_equivalent(out, expected)
 })
 
@@ -198,7 +198,7 @@ test_that("simple weighted dataset produces correct percents", {
   run_contingency_tables_many_periods(params, base_aggs[2,])
 
   # Expected files
-  expect_equal(!!dir(params$export_dir), c("20200501_20200531_monthly_nation_gender.csv"))
+  expect_equal(!!dir(params$export_dir), c("20200501_20200531_monthly_nation_gender.csv.gz"))
 
   # Expected file contents
   raw_data <- read.csv(test_path("./input/simple_synthetic.csv"))
@@ -209,7 +209,7 @@ test_that("simple weighted dataset produces correct percents", {
     "us", "Female", fever_prop * 100, NA, 2000L, sum(rand_weights)
   ))
 
-  out <- read.csv(file.path(params$export_dir, "20200501_20200531_monthly_nation_gender.csv"))
+  out <- read.csv(file.path(params$export_dir, "20200501_20200531_monthly_nation_gender.csv.gz"))
   expect_equivalent(out, expected_output)
 })
 
@@ -228,7 +228,7 @@ test_that("production of historical CSVs for range of dates", {
 
   run_contingency_tables_many_periods(params, base_aggs[2,])
   # Expected files
-  expect_equal(!!dir(params$export_dir), c("20200503_20200509_weekly_nation_gender.csv", "20200510_20200516_weekly_nation_gender.csv"))
+  expect_equal(!!dir(params$export_dir), c("20200503_20200509_weekly_nation_gender.csv.gz", "20200510_20200516_weekly_nation_gender.csv.gz"))
 })
 
 

--- a/facebook/delphiFacebook/unit-tests/testthat/test-contingency-write.R
+++ b/facebook/delphiFacebook/unit-tests/testthat/test-contingency-write.R
@@ -45,9 +45,9 @@ test_that("testing write_contingency_tables command", {
                                          aggregate_range = "week"), 
                            "state", 
                            c("geo_id", "tested"))
-  expect_setequal(!!dir(tdir), c("20200510_20200516_weekly_state_tested.csv"))
+  expect_setequal(!!dir(tdir), c("20200510_20200516_weekly_state_tested.csv.gz"))
   
-  df <- read_csv(file.path(tdir, "20200510_20200516_weekly_state_tested.csv"))
+  df <- read_csv(file.path(tdir, "20200510_20200516_weekly_state_tested.csv.gz"))
   expect_equivalent(df, test_data)
 })
 
@@ -59,13 +59,13 @@ test_that("testing command to create output filenames", {
     end_date=as.Date("2021-01-02")
   )
   out <- get_file_name(params, "nation", c("gender"))
-  expected <- "DebugOn-DoNotShare_20210101_20210102_monthly_nation_gender.csv"
+  expected <- "DebugOn-DoNotShare_20210101_20210102_monthly_nation_gender.csv.gz"
   
   expect_equal(out, expected)
   
   params$debug <- FALSE
   out <- get_file_name(params, "nation", c("gender", "race", "ethnicity"))
-  expected <- "20210101_20210102_monthly_nation_ethnicity_gender_race.csv"
+  expected <- "20210101_20210102_monthly_nation_ethnicity_gender_race.csv.gz"
   
   expect_equal(out, expected)
 })


### PR DESCRIPTION
### Description
Compress contingency output using gzip. Update support code too.

### Changelog
- `contingency-combine.R`
- `contingency_write.R`
- contingency tests

### Fixes 
Individual/non-rollup weekly and monthly contingency tables take up a lot of space on the AWPS site. The size of our file collection seems to be causing problems with publishing changes to the AWPS site. The tables are very compressible (-75% using gzip) so this is an easy way to address the issue.