### PR TITLE
Suppress sirCAL alerts for for `smoothed_vaccine_barrier_other_tried` and `smoothed_vaccine_barrier_appointment_location_tried`

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -132,7 +132,9 @@
         "smoothed_vaccine_barrier_type_has", "smoothed_wvaccine_barrier_type_has",
         "smoothed_vaccine_barrier_none_has", "smoothed_wvaccine_barrier_none_has",
         "smoothed_vaccine_barrier_appointment_location_has", "smoothed_wvaccine_barrier_appointment_location_has",
-        "smoothed_vaccine_barrier_other_has", "smoothed_wvaccine_barrier_other_has"
+        "smoothed_vaccine_barrier_other_has", "smoothed_wvaccine_barrier_other_has",
+        ["smoothed_vaccine_barrier_appointment_location_tried", "county", "state"],
+        ["smoothed_vaccine_barrier_other_tried", "county", "state"]
       ]
     },
     "quidel": {

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -132,7 +132,9 @@
         "smoothed_vaccine_barrier_type_has", "smoothed_wvaccine_barrier_type_has",
         "smoothed_vaccine_barrier_none_has", "smoothed_wvaccine_barrier_none_has",
         "smoothed_vaccine_barrier_appointment_location_has", "smoothed_wvaccine_barrier_appointment_location_has",
-        "smoothed_vaccine_barrier_other_has", "smoothed_wvaccine_barrier_other_has"
+        "smoothed_vaccine_barrier_other_has", "smoothed_wvaccine_barrier_other_has",
+        ["smoothed_vaccine_barrier_appointment_location_tried", "county", "state"],
+        ["smoothed_vaccine_barrier_other_tried", "county", "state"]
       ]
     },
     "quidel": {


### PR DESCRIPTION
### Description
Suppress sirCAL alerts for for `smoothed_vaccine_barrier_other_tried` and `smoothed_vaccine_barrier_appointment_location_tried`. Sample sizes have dropped too low to report.

### Changelog
- Ansible template params and sirCAL package template params.
