### PR TITLE
Suppress sirCAL alerts for weighted `smoothed_vaccine_barrier_*`

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -133,8 +133,8 @@
         "smoothed_vaccine_barrier_none_has", "smoothed_wvaccine_barrier_none_has",
         "smoothed_vaccine_barrier_appointment_location_has", "smoothed_wvaccine_barrier_appointment_location_has",
         "smoothed_vaccine_barrier_other_has", "smoothed_wvaccine_barrier_other_has",
-        ["smoothed_vaccine_barrier_appointment_location_tried", "county", "state"],
-        ["smoothed_vaccine_barrier_other_tried", "county", "state"]
+        ["smoothed_vaccine_barrier_appointment_location_tried", "county", "state"], ["smoothed_wvaccine_barrier_appointment_location_tried", "county", "state"],
+        ["smoothed_vaccine_barrier_other_tried", "county", "state"], ["smoothed_wvaccine_barrier_other_tried", "county", "state"]
       ]
     },
     "quidel": {

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -133,8 +133,8 @@
         "smoothed_vaccine_barrier_none_has", "smoothed_wvaccine_barrier_none_has",
         "smoothed_vaccine_barrier_appointment_location_has", "smoothed_wvaccine_barrier_appointment_location_has",
         "smoothed_vaccine_barrier_other_has", "smoothed_wvaccine_barrier_other_has",
-        ["smoothed_vaccine_barrier_appointment_location_tried", "county", "state"],
-        ["smoothed_vaccine_barrier_other_tried", "county", "state"]
+        ["smoothed_vaccine_barrier_appointment_location_tried", "county", "state"], ["smoothed_wvaccine_barrier_appointment_location_tried", "county", "state"],
+        ["smoothed_vaccine_barrier_other_tried", "county", "state"], ["smoothed_wvaccine_barrier_other_tried", "county", "state"]
       ]
     },
     "quidel": {


### PR DESCRIPTION
### Description
Like https://github.com/cmu-delphi/covidcast-indicators/pull/1604 but for weighted versions of the signals.

### Changelog
- Ansible template params and sirCAL package template params.
