### PR TITLE
Prevent CPR from processing entire report history every run

### DIFF
--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -407,7 +407,9 @@ def as_cached_filename(params, config):
 
 def fetch_listing(params):
     """Generate the list of report files to process."""
-    export_start_date = params['indicator'].get('export_start_date', datetime.datetime.fromtimestamp(0))
+    export_start_date = params['indicator'].get(
+        'export_start_date', datetime.datetime.fromtimestamp(0)
+    )
 
     listing = requests.get(DOWNLOAD_LISTING).json()['metadata']['attachments']
     # drop the pdf files
@@ -425,7 +427,10 @@ def fetch_listing(params):
 
     if params['indicator']['reports'] == 'new':
         # drop files we already have in the input cache
-        keep = [el for el in listing if not os.path.exists(el['cached_filename']) and check_valid_publish_date(el)]
+        keep = [
+            el for el in listing
+            if not os.path.exists(el['cached_filename']) and check_valid_publish_date(el)
+        ]
     elif params['indicator']['reports'].find("--") > 0:
         # drop files outside the specified publish-date range
         start_str, _, end_str = params['indicator']['reports'].partition("--")
@@ -440,7 +445,8 @@ def fetch_listing(params):
             el for el in listing if check_valid_publish_date(el)
         ]
     else:
-        raise ValueError(f"params['indicator']['reports'] is set to {params['indicator']['reports']}, which isn't 'new', 'all', or a date range.")
+        raise ValueError("params['indicator']['reports'] is set to" \
+            + f" {params['indicator']['reports']}, which isn't 'new', 'all', or a date range.")
 
     return extend_listing_for_interp(keep, listing)
 

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -422,6 +422,9 @@ def fetch_listing(params):
     if params['indicator']['reports'] == 'new':
         # drop files we already have in the input cache
         keep = [el for el in listing if not os.path.exists(el['cached_filename'])]
+        if not keep:
+            # No new listings, e.g. on the weekend.
+            return keep
     elif params['indicator']['reports'].find("--") > 0:
         # drop files outside the specified publish-date range
         start_str, _, end_str = params['indicator']['reports'].partition("--")

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -407,8 +407,9 @@ def as_cached_filename(params, config):
 
 def fetch_listing(params):
     """Generate the list of report files to process."""
-    listing = requests.get(DOWNLOAD_LISTING).json()['metadata']['attachments']
+    export_start_date = params['indicator'].get('export_start_date', datetime.datetime.fromtimestamp(0))
 
+    listing = requests.get(DOWNLOAD_LISTING).json()['metadata']['attachments']
     # drop the pdf files
     listing = [
         dict(
@@ -418,13 +419,13 @@ def fetch_listing(params):
         )
         for el in listing if el['filename'].endswith("xlsx")
     ]
-    keep = []
+
+    def check_valid_publish_date(x):
+        return x['publish_date'] >= export_start_date
+
     if params['indicator']['reports'] == 'new':
         # drop files we already have in the input cache
-        keep = [el for el in listing if not os.path.exists(el['cached_filename'])]
-        if not keep:
-            # No new listings, e.g. on the weekend.
-            return keep
+        keep = [el for el in listing if not os.path.exists(el['cached_filename']) and check_valid_publish_date(el)]
     elif params['indicator']['reports'].find("--") > 0:
         # drop files outside the specified publish-date range
         start_str, _, end_str = params['indicator']['reports'].partition("--")
@@ -432,22 +433,16 @@ def fetch_listing(params):
         end_date = datetime.datetime.strptime(end_str, "%Y-%m-%d").date()
         keep = [
             el for el in listing
-            if start_date <= el['publish_date'] <= end_date
+            if (start_date <= el['publish_date'] <= end_date) and check_valid_publish_date(el)
         ]
-
-    # reference date is guaranteed to be on or before publish date, so we can trim
-    # reports that are too early
-    if 'export_start_date' in params['indicator']:
+    elif params['indicator']['reports'] == 'all':
         keep = [
-            el for el in keep
-            if params['indicator']['export_start_date'] <= el['publish_date']
+            el for el in listing if check_valid_publish_date(el)
         ]
-    # can't do the same for export_end_date
+    else:
+        raise ValueError(f"params['indicator']['reports'] is set to {params['indicator']['reports']}, which isn't 'new', 'all', or a date range.")
 
-    # if we're only running on a subset, make sure we have enough data for interp
-    if keep:
-        keep = extend_listing_for_interp(keep, listing)
-    return keep if keep else listing
+    return extend_listing_for_interp(keep, listing)
 
 def extend_listing_for_interp(keep, listing):
     """Grab additional files from the full listing for interpolation if needed.

--- a/dsew_community_profile/delphi_dsew_community_profile/run.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/run.py
@@ -99,20 +99,20 @@ def run_module(params):
             params['indicator']['reports'] = 'all'
             params['indicator']['export_signals'] = {sensor_names[key] for key in new_signals}
 
-        dfs = fetch_new_reports(params, logger)
-        for key, df in dfs.items():
-            (geo, sig, is_prop) = key
-            if sig not in params["indicator"]["export_signals"]:
-                continue
-            dates = create_export_csv(
-                df,
-                params['common']['export_dir'],
-                geo,
-                make_signal_name(sig, is_prop),
-                **export_params
-            )
-            if len(dates)>0:
-                run_stats.append((max(dates), len(dates)))
+            dfs = fetch_new_reports(params, logger)
+            for key, df in dfs.items():
+                (geo, sig, is_prop) = key
+                if sig not in params["indicator"]["export_signals"]:
+                    continue
+                dates = create_export_csv(
+                    df,
+                    params['common']['export_dir'],
+                    geo,
+                    make_signal_name(sig, is_prop),
+                    **export_params
+                )
+                if len(dates)>0:
+                    run_stats.append((max(dates), len(dates)))
 
     ## log this indicator run
     elapsed_time_in_seconds = round(time.time() - start_time, 2)

--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -569,6 +569,11 @@ class TestPull:
                 [{"publish_date": date(2020, 1, 20)}, {"publish_date": date(2020, 1, 19)}],
                 [{"publish_date": date(2020, 1, 20)}, {"publish_date": date(2020, 1, 19)}, {"publish_date": date(2020, 1, 18)}]
             ),
+            # empty keep list
+            example(
+                [],
+                []
+            )
         ]
         for ex in examples:
             assert extend_listing_for_interp(ex.given, listing) == ex.expected, ex.given


### PR DESCRIPTION
### Description
#### Fix 1
The `if params['indicator']['reports'] == 'new':` chunk properly produces an empty `keep` list if no new reports are available in a run. But empty `keep` lists are always ignored in the return statement of the function, which returns `listing` (the full set of reports) instead. The result is that when no new reports are available (e.g. on the weekend or when the pipeline runs in quick succession) the pipeline process the entire report history. The intention of the was to process the entire report history when "all" reports were requested which is also assigned an empty `keep` list in `fetch_listing`.

To fix this, when only "new" reports are requested and the constructed `keep` list is empty (no new reports), return the empty `keep` list immediately.

#### Fix 2
Previously, [`fetch_new_reports` would run in the auto-backfill chunk](https://github.com/cmu-delphi/covidcast-indicators/blob/915198158678921ef3a552a5390f13f93fb08939/dsew_community_profile/delphi_dsew_community_profile/run.py#L96-L102) in `run.py` regardless of if COVIDCcast metadata was missing any signals. Because the auto-backfill run always follows the main run, which pulls any new reports, the auto-backfill run never sees new reports. Because of the above issue in `fetch_listing`, this causes the entire report history to be processed on every auto-backfill pipeline run.

To fix this, move the report processing so that it is within the [`new_signals` chunk](https://github.com/cmu-delphi/covidcast-indicators/blob/915198158678921ef3a552a5390f13f93fb08939/dsew_community_profile/delphi_dsew_community_profile/run.py#L96) and only triggered if any signals that we want are not found in metadata.

### Changelog
- `pull.py`
- `run.py`

### Fixes 
On weekdays, the CPR pipeline processes the whole history of reports. On weekends, the CPR pipeline processes the whole history of reports twice.
