### PR TITLE
Drop CPR test positivity rows with missing `val` even if `sample_size` is not missing

### DIFF
--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -617,7 +617,8 @@ def interpolate_missing_values(dfs: DataDict) -> DataDict:
         # https://github.com/cmu-delphi/covidcast-indicators/issues/1576
         _, sig, _ = key
         if sig == "positivity":
-            interpolate_df[key] = df.set_index(["geo_id", "timestamp"]).sort_index().reset_index()
+            reindexed_group_df = df.set_index(["geo_id", "timestamp"]).sort_index().reset_index()
+            interpolate_df[key] = reindexed_group_df[~reindexed_group_df.val.isna()]
             continue
 
         geo_dfs = []


### PR DESCRIPTION
### Description
[Context in Slack](https://delphi-org.slack.com/archives/C013AH5N01E/p1651699160417189?thread_ts=1651600391.284619&cid=C013AH5N01E).

### Changelog
- `pull.py`