### PR TITLE
Use date portion of datetime when param not available

### DIFF
--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -408,7 +408,7 @@ def as_cached_filename(params, config):
 def fetch_listing(params):
     """Generate the list of report files to process."""
     export_start_date = params['indicator'].get(
-        'export_start_date', datetime.datetime.fromtimestamp(0)
+        'export_start_date', datetime.datetime.fromtimestamp(0).date()
     )
 
     listing = requests.get(DOWNLOAD_LISTING).json()['metadata']['attachments']


### PR DESCRIPTION
### Description
wee bug we missed in #1610 -- everything to do with listings is expressed in dates, not datetimes, and you can't compare datetimes with dates.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- pull.py:fetch_listing(): if export_start_date param not available, use date portion only of default datetime 

### Fixes 
- Fixes failing run in staging
