### PR TITLE
[Test] CPR tests should fail

### DIFF
--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -201,6 +201,7 @@ class TestPull:
 
         for actual, expected in zip(fetch_listing(ex.given), ex.expected):
             assert actual == expected
+            assert False
 
     def test_nation_from_state(self):
         geomapper = GeoMapper()


### PR DESCRIPTION
### Description
Added `assert False` to the `fetch_listing` test. If that test runs correctly (wrt mocking), the CPR test suite should fail... but it doesn't!

### Changelog
Itemize code/test/documentation changes and files added/removed.
- change1
- change2

### Fixes 
- Fixes #(issue)
