### PR TITLE
Fix CPR `fetch_listing` test + check empty `keep` list behavior

### DIFF
--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -197,7 +197,7 @@ class TestPull:
                 "publish_date": instance.publish
             }
         ex = example(
-            {'indicator':{'reports':'new'}},
+            {'indicator':{'reports':'new', 'input_cache':''}},
             [
                 as_listing(instance)
                 for i, instance in filter(lambda x: x[0]%2 == 0, enumerate(instances))

--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -163,8 +163,8 @@ class TestPull:
         inst = namedtuple("attachment", "assetId filename publish cache")
         instances = list(chain(*[
             [
-                inst(f"{i}", f"2021010{i}.xlsx", date(2021, 1, i), f"{i}---2021010{i}.xlsx"),
-                inst(f"p{i}", f"2021010{i}.pdf", date(2021, 1, i), f"p{i}---2021010{i}.pdf"),
+                inst(f"{i}", f"2021010{i}.xlsx", date(2021, 1, i), f"2021010{i}--{i}.xlsx"),
+                inst(f"p{i}", f"2021010{i}.pdf", date(2021, 1, i), f"2021010{i}--p{i}.pdf"),
             ]
             for i in [1, 2, 3, 4, 5]
         ]))


### PR DESCRIPTION
### Description
Get `fetch_listing` test to actually run. Add a couple fixes to the resulting broken tests. Add a new test to check that `fetch_listing` returns an empty list when there are no new reports.

### Changelog
- `tests/test_pull.py`

### Fixes 
Due to an issue with mocking, the existing `fetch_listing` tests weren't running. Here's a [test of that claim](https://github.com/cmu-delphi/covidcast-indicators/pull/1614).

Within `fetch_listing` as called by `test_fetch_listing`, the mocked `requests.get().json()` returns a Mock object, rather than the requested return value. Because Mock objects recursively create any requested methods or attributes as new Mock objects, `fetch_listing` completes without error but always returns an empty list `[]`.

The `zip` result is the same length as the shortest input list. The `[]` returned by `fetch_listing` has length 0, so the for loop doesn't run and `assert` is never called. The `test_fetch_listing` function appears to pass because test functions pass as long as no failure is reported.
