### PR TITLE
Increase fetch depth to 5 during checkout to publish release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           ssh-key: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_SSH }}
+          fetch-depth: 5
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
### Description
The v0.3.13 "publish release" workflow refused to go through, with error message
```
Run git push --tags
  git push --tags
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.12/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.12/x64/lib
To github.com:ORGANIZATION/PACKAGE.git
 ! [remote rejected] PACKAGE/v0.3.13 -> PACKAGE/v0.3.13 (shallow update not allowed)
error: failed to push some refs to 'github.com:ORGANIZATION/PACKAGE.git'
Error: Process completed with exit code 1.
```

I was able to reproduce the error manually in a fork. Increasing `fetch-depth` to 5 resolves the error.

No clue why this only just started breaking. It's possible the update to `ubuntu-latest` on May 5 caused it somehow, but shallow clone push behavior has always been undefined, so the old version really never should have worked 🤷‍♀️ 

### Changelog
Itemize code/test/documentation changes and files added/removed.
- publish-release.yml: increase fetch depth during checkout

### Fixes 
- Fixes stalled release of v0.3.13
