### PR TITLE
Add validation failures dir for google-symptoms

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -22,6 +22,7 @@
   "validation": {
     "common": {
       "data_source": "google-symptoms",
+      "validation_failure_dir": "./validation_failures",
       "span_length": 14,
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -12,6 +12,7 @@
   "validation": {
     "common": {
       "data_source": "google-symptoms",
+      "validation_failure_dir": "./validation_failures",
       "span_length": 14,
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},


### PR DESCRIPTION
### Description
#1514 activated a behavior whereby validation failures without dry-run delete the contents of the receiving directory unless a `validation_failure_dir` is specified in `params.validation.common`. This PR specifies that directory for google-symptoms, which is our only indicator without dry-run in validation.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- production & dev params for google-symptoms

### Fixes 
- Prerequisite for releasing #1514 
