### PR TITLE
Use underscore instead of dash for variable names

### DIFF
--- a/ansible/ansible-deploy-staging.yaml
+++ b/ansible/ansible-deploy-staging.yaml
@@ -29,7 +29,7 @@
 
     - name: Check to see if we have a secrets template to send.
       local_action: stat path="templates/{{ indicator }}-secrets-prod.py.j2"
-      register: template-secrets
+      register: template_secrets
 
     - name: Set production params file.
       copy:
@@ -53,4 +53,4 @@
         dest: "{{ indicators_runtime_dir }}/{{ indicator }}/secrets.py"
         owner: "{{ runtime_user }}"
         group: "{{ runtime_user }}"
-      when: template-secrets.stat.exists
+      when: template_secrets.stat.exists

--- a/ansible/ansible-deploy.yaml
+++ b/ansible/ansible-deploy.yaml
@@ -29,7 +29,7 @@
 
     - name: Check to see if we have a secrets template to send.
       local_action: stat path="templates/{{ indicator }}-secrets-prod.py.j2"
-      register: template-secrets
+      register: template_secrets
 
     - name: Set production params file.
       copy:
@@ -53,4 +53,4 @@
         dest: "{{ indicators_runtime_dir }}/{{ indicator }}/secrets.py"
         owner: "{{ runtime_user }}"
         group: "{{ runtime_user }}"
-      when: template-secrets.stat.exists
+      when: template_secrets.stat.exists


### PR DESCRIPTION
### Description
Fix:

Update a variable name to use an underscore instead of a dash.

### Changelog
- Updates multiple occurences of `template-secrets` to `template_secrets`