### PR TITLE
[CTIS contingency] prevent implicit conversion of df -> vector in `rowSums` filtering of theme tables when the df has a single column

### DIFF
--- a/facebook/delphiFacebook/R/contingency_aggregate.R
+++ b/facebook/delphiFacebook/R/contingency_aggregate.R
@@ -107,7 +107,7 @@ produce_aggregates <- function(df, aggregations, cw_list, params) {
         # Drop any rows that are completely `NA`. Grouping variables are always
         # defined, so need to ignore those.
         cols_check_na <- setdiff(names(theme_out), agg_group)
-        theme_out <- theme_out[rowSums(is.na(theme_out[, cols_check_na])) != length(cols_check_na),]
+        theme_out <- theme_out[rowSums(is.na(theme_out[, cols_check_na])) != length(cols_check_na),, drop=FALSE]
         
         if ( nrow(theme_out) != 0 && ncol(theme_out) != 0 ) {
           write_contingency_tables(theme_out, params, geo_level, agg_group, theme)  


### PR DESCRIPTION
### Description
Handle edge case where themed subset of contingency aggregates is implicitly converted to a vector during `rowSums` handling.

### Changelog
- `contingency_aggregate` theme handling

### Fixes 
When generating contingency table for the "norms_information_beliefs" theme, with no grouping variables ("overall", grouped by "geo_id" only) for the week spanning 20200405-20200411, we get

```
Error in if (nrow(theme_out) != 0 && ncol(theme_out) != 0) { :                                                                                                              
  missing value where TRUE/FALSE needed
```

This early in the survey, no norms/belief items are available so `theme_out` only contains grouping variables [when we create it](https://github.com/cmu-delphi/covidcast-indicators/blob/34c0d100537990a43d088cb37d375055cf798d85/facebook/delphiFacebook/R/contingency_aggregate.R#L106).  Because we only have one grouping variable, the dataframe has a single column.

Filtering by the `rowSums` result produces a vector because, by default bracket filtering converts single-dimension results into a vector (`drop=TRUE` removes unneeded dimensions). Turn off `drop` so that we keep `theme_out` in dataframe format.