### PR TITLE
Remove explicit check for unique days = n_days

### DIFF
--- a/usafacts/delphi_usafacts/pull.py
+++ b/usafacts/delphi_usafacts/pull.py
@@ -166,14 +166,6 @@ def pull_usafacts_data(base_url: str, metric: str, logger: Logger, cache: str=No
     # each FIPS has same number of rows
     if (len(days_by_fips) > 1) or (days_by_fips[0] != len(unique_days)):
         raise ValueError("Differing number of days by fips")
-    min_timestamp = min(unique_days)
-    max_timestamp = max(unique_days)
-    n_days = (max_timestamp - min_timestamp) / np.timedelta64(1, "D") + 1
-    if n_days != len(unique_days):
-        raise ValueError(
-            f"Not every day between {min_timestamp} and "
-            "{max_timestamp} is represented."
-        )
     return df.loc[
         df["timestamp"] >= min_ts,
         [  # Reorder

--- a/usafacts/tests/test_pull.py
+++ b/usafacts/tests/test_pull.py
@@ -34,14 +34,6 @@ class TestPullUSAFacts:
         # sort since rows order doesn't matter
         pd.testing.assert_frame_equal(df.sort_index(), expected_df.sort_index())
 
-    def test_missing_days(self):
-
-        metric = "confirmed"
-        with pytest.raises(ValueError):
-            pull_usafacts_data(
-                BASE_URL_BAD["missing_days"], metric, TEST_LOGGER
-            )
-
     def test_missing_cols(self):
 
         metric = "confirmed"


### PR DESCRIPTION
### Description
Removing explicit check to let validator handle missing dates 

### Fixes 
- USA-facts will start working again
