### PR TITLE
Backfill/chng

### DIFF
--- a/changehc/delphi_changehc/load_data.py
+++ b/changehc/delphi_changehc/load_data.py
@@ -4,14 +4,18 @@ Load CHC data.
 Author: Aaron Rumack
 Created: 2020-10-14
 """
-
+import glob
+import os
+from datetime import datetime
 # third party
 import pandas as pd
+
+from delphi_utils import GeoMapper
 
 # first party
 from .config import Config
 
-
+gmpr = GeoMapper()
 def load_chng_data(filepath, dropdate, base_geo,
                    col_names, col_types, counts_col):
     """Load in and set up daily count data from Change.
@@ -74,7 +78,8 @@ def load_chng_data(filepath, dropdate, base_geo,
     return data
 
 
-def load_combined_data(denom_filepath, covid_filepath, dropdate, base_geo):
+def load_combined_data(denom_filepath, covid_filepath, dropdate, base_geo,
+                       backfill_dir, geo, weekday, numtype, backfill_merge_day):
     """Load in denominator and covid data, and combine them.
 
     Args:
@@ -104,11 +109,16 @@ def load_combined_data(denom_filepath, covid_filepath, dropdate, base_geo):
     data["den"] = data[Config.DENOM_COL]
     data = data[["num", "den"]]
 
+    # Store for backfill
+    store_backfill_file(data, dropdate, backfill_dir, numtype, geo, weekday)
+    merge_backfill_file(backfill_dir, numtype, geo, weekday, backfill_merge_day,
+                        dropdate, test_mode=False, check_nd=25)
     return data
 
 
 def load_cli_data(denom_filepath, flu_filepath, mixed_filepath, flu_like_filepath,
-                  covid_like_filepath, dropdate, base_geo):
+                  covid_like_filepath, dropdate, base_geo,
+                  backfill_dir, geo, weekday, numtype, backfill_merge_day):
     """Load in denominator and covid-like data, and combine them.
 
     Args:
@@ -152,10 +162,16 @@ def load_cli_data(denom_filepath, flu_filepath, mixed_filepath, flu_like_filepat
     data["den"] = data[Config.DENOM_COL]
     data = data[["num", "den"]]
 
+    # Store for backfill
+    store_backfill_file(data, dropdate, backfill_dir, numtype, geo, weekday)
+    merge_backfill_file(backfill_dir, numtype, geo, weekday, backfill_merge_day,
+                        dropdate, test_mode=False, check_nd=25)
+
     return data
 
 
-def load_flu_data(denom_filepath, flu_filepath, dropdate, base_geo):
+def load_flu_data(denom_filepath, flu_filepath, dropdate, base_geo,
+                  backfill_dir, geo, weekday, numtype, backfill_merge_day):
     """Load in denominator and flu data, and combine them.
 
     Args:
@@ -185,4 +201,113 @@ def load_flu_data(denom_filepath, flu_filepath, dropdate, base_geo):
     data["den"] = data[Config.DENOM_COL]
     data = data[["num", "den"]]
 
+    # Store for backfill
+    store_backfill_file(data, dropdate, backfill_dir, numtype, geo, weekday)
+    merge_backfill_file(backfill_dir, numtype, geo, weekday, backfill_merge_day,
+                        dropdate, test_mode=False, check_nd=25)
     return data
+
+
+def store_backfill_file(df, _end_date, backfill_dir, numtype, geo, weekday):
+    """
+    Store county level backfill data into backfill_dir.
+
+    Parameter:
+        df: pd.DataFrame
+            Pre-process file at ZipCode level
+        _end_date: datetime
+            The most recent date when the raw data is received
+        backfill_dir: str
+            specified path to store backfill files.
+        numtype: str
+            indicate the type of the data
+        geo: str
+            geo level
+        weekday: bool
+    """
+    # We only need to run it once for a numtype
+    if geo != "county":
+        return
+    if weekday:
+        return
+
+    backfilldata = df.reset_index().copy()
+    backfilldata.rename({"timestamp": "time_value"}, axis=1, inplace=True)
+    #Store one year's backfill data
+    _start_date = _end_date.replace(year=_end_date.year-1)
+    selected_columns = ['time_value', 'fips',
+                        'num', 'den']
+    backfilldata = backfilldata.loc[backfilldata["time_value"] >= _start_date,
+                                    selected_columns]
+    path = backfill_dir + \
+        "/changehc_%s_as_of_%s.parquet"%(numtype, datetime.strftime(_end_date, "%Y%m%d"))
+    # Store intermediate file into the backfill folder
+    backfilldata.to_parquet(path)
+
+def merge_backfill_file(backfill_dir, numtype, geo, weekday, backfill_merge_day,
+                        today, test_mode=False, check_nd=25):
+    """
+    Merge ~4 weeks' backfill data into one file.
+
+    Usually this function should merge 28 days' data into a new file so as to
+    save the reading time when running the backfill pipelines. We
+    Parameters
+    ----------
+    today : datetime
+        The current dropdate
+    backfill_dir : str
+        specified path to store backfill files.
+    backfill_merge_day: int
+        The day of a week that we used to merge the backfill files. e.g. 0
+        is Monday.
+    test_mode: bool
+    check_nd: int
+        The criteria of the number of unmerged files. Ideally, we want the
+        number to be 28, but we use a looser criteria from practical
+        considerations
+    numtype: str
+            indicate the type of the data
+        geo: str
+            geo level
+        weekday: bool
+    """
+    # We only need to run it once for a numtype
+    if geo != "county":
+        return
+    if weekday:
+        return
+
+    new_files = glob.glob(backfill_dir + "/changehc_%s_as_of_*"%numtype)
+
+    def get_date(file_link):
+        # Keep the function here consistent with the backfill path in
+        # function `store_backfill_file`
+        fn = file_link.split("/")[-1].split(".parquet")[0].split("_")[-1]
+        return datetime.strptime(fn, "%Y%m%d")
+
+    date_list = list(map(get_date, new_files))
+    earliest_date = min(date_list)
+    latest_date = max(date_list)
+
+    # Check whether to merge
+    # Check the number of files that are not merged
+    if today.weekday() != backfill_merge_day or (today-earliest_date).days <= check_nd:
+        return
+
+    # Start to merge files
+    pdList = []
+    for fn in new_files:
+        df = pd.read_parquet(fn, engine='pyarrow')
+        pdList.append(df)
+    merged_file = pd.concat(pdList).sort_values(["time_value", "fips"])
+    path = backfill_dir + "/changehc_%s_from_%s_to_%s.parquet"%(
+        numtype,
+        datetime.strftime(earliest_date, "%Y%m%d"),
+        datetime.strftime(latest_date, "%Y%m%d"))
+    merged_file.to_parquet(path)
+
+    # Delete daily files once we have the merged one.
+    if not test_mode:
+        for fn in new_files:
+            os.remove(fn)
+    return

--- a/changehc/delphi_changehc/run.py
+++ b/changehc/delphi_changehc/run.py
@@ -15,7 +15,8 @@ from delphi_utils import get_structured_logger
 
 # first party
 from .download_ftp_files import download_counts
-from .load_data import load_combined_data, load_cli_data, load_flu_data
+from .load_data import (load_combined_data, load_cli_data, load_flu_data,
+                        store_backfill_file, merge_backfill_file)
 from .update_sensor import CHCSensorUpdater
 
 
@@ -133,6 +134,8 @@ def run_module(params: Dict[str, Dict[str, Any]]):
     # range of estimates to produce
     n_backfill_days = params["indicator"]["n_backfill_days"]  # produce estimates for n_backfill_days
     n_waiting_days = params["indicator"]["n_waiting_days"]  # most recent n_waiting_days won't be est
+    backfill_dir = params["indicator"]["backfill_dir"]
+    backfill_merge_day = params["indicator"]["backfill_merge_day"]
     enddate_dt = dropdate_dt - timedelta(days=n_waiting_days)
     startdate_dt = enddate_dt - timedelta(days=n_backfill_days)
     enddate = str(enddate_dt.date())
@@ -180,13 +183,17 @@ def run_module(params: Dict[str, Dict[str, Any]]):
                 )
                 if numtype == "covid":
                     data = load_combined_data(file_dict["denom"],
-                             file_dict["covid"],dropdate_dt,"fips")
+                             file_dict["covid"],dropdate_dt,"fips",
+                             backfill_dir, geo, weekday, numtype,
+                             backfill_merge_day)
                 elif numtype == "cli":
                     data = load_cli_data(file_dict["denom"],file_dict["flu"],file_dict["mixed"],
-                             file_dict["flu_like"],file_dict["covid_like"],dropdate_dt,"fips")
+                             file_dict["flu_like"],file_dict["covid_like"],dropdate_dt,"fips",
+                             backfill_dir, geo, weekday, numtype, backfill_merge_day)
                 elif numtype == "flu":
                     data = load_flu_data(file_dict["denom"],file_dict["flu"],
-                             dropdate_dt,"fips")
+                             dropdate_dt,"fips",backfill_dir, geo, weekday,
+                             numtype, backfill_merge_day)
                 more_stats = su_inst.update_sensor(
                     data,
                     params["common"]["export_dir"],

--- a/changehc/params.json.template
+++ b/changehc/params.json.template
@@ -17,6 +17,8 @@
     "start_date": null,
     "end_date": null,
     "drop_date": null,
+    "backfill_dir": "./backfill",
+    "backfill_merge_day": 0,
     "n_backfill_days": 60,
     "n_waiting_days": 3,
     "se": false,

--- a/changehc/setup.py
+++ b/changehc/setup.py
@@ -4,6 +4,7 @@ from setuptools import find_packages
 required = [
     "numpy",
     "pandas",
+    "pyarrow",
     "pydocstyle",
     "pytest",
     "pytest-cov",

--- a/changehc/tests/test_sensor.py
+++ b/changehc/tests/test_sensor.py
@@ -14,6 +14,7 @@ PARAMS = {
     "indicator": {
         "input_denom_file": "test_data/20200601_Counts_Products_Denom.dat.gz",
         "input_covid_file": "test_data/20200601_Counts_Products_Covid.dat.gz",
+        "backfill_dir": "./backfill",
         "drop_date": "2020-06-01"
     }
 }
@@ -22,9 +23,16 @@ DENOM_FILEPATH = PARAMS["indicator"]["input_denom_file"]
 DROP_DATE = pd.to_datetime(PARAMS["indicator"]["drop_date"])
 TEST_LOGGER = logging.getLogger()
 
+backfill_dir = PARAMS["indicator"]["backfill_dir"]
+
+geo = "county"
+weekday = True
+backfill_merge_day = 0
+
 class TestLoadData:
     combined_data = load_combined_data(DENOM_FILEPATH, COVID_FILEPATH, DROP_DATE,
-                                       "fips")
+                                       "fips", backfill_dir, geo, weekday, "covid",
+                                       backfill_merge_day)
 
     def test_backfill(self):
         num0 = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8], dtype=float).reshape(-1, 1)


### PR DESCRIPTION
### Description
Generate and store county level backfill file locally (On MIDAS) for CHNG. The newly added function will check the input file daily and store backfill file on a daily basis. Every 4 weeks, we will check the daily files and merge them into a combined file.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- `load_data.py`, `run.py` modify the current code, to save the county level intermediate file to `backfill_dir` before generating signals if there are new input raw files added by CHNG.
- `setup.py` add pyarrow as a necessary package so as to save the backfill file in the parquet format. 
- `tests/test_load_data.py`, `tests/test_sensor` update the unit tests for backfill related helper functions.
- `params.json.template` add `backfill_dir`, `backfill_merge_day`

