### PR TITLE
Fix errors when get timestamps from the file name

### DIFF
--- a/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
+++ b/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
@@ -25,13 +25,21 @@ def print_callback(filename, logger, bytes_so_far, bytes_total):
     if (rough_percent_transferred % 25) == 0:
         logger.info("Transfer in progress", filename=filename, percent=rough_percent_transferred)
 
-FILENAME_TIMESTAMP = re.compile(r".*EDI_AGG_INPATIENT_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
+OLD_FILENAME_TIMESTAMP = re.compile(
+    r".*EDI_AGG_INPATIENT_[0-9]_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
+NEW_FILENAME_TIMESTAMP = re.compile(r".*EDI_AGG_INPATIENT_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
 def get_timestamp(name):
     """Get the reference date in datetime format."""
-    m = FILENAME_TIMESTAMP.match(name)
+    if len(name.split("_")) > 5:
+        m = OLD_FILENAME_TIMESTAMP.match(name)
+    else:
+        m = NEW_FILENAME_TIMESTAMP.match(name)
     if not m:
         return datetime.datetime(1900, 1, 1)
-    return datetime.datetime.strptime(''.join(m.groups()), "%Y%m%d%H%M")
+    try:
+        return datetime.datetime.strptime(''.join(m.groups()), "%Y%m%d%H%M")
+    except ValueError:
+        return datetime.datetime.strptime(''.join(m.groups()), "%m%d%Y%H%M")
 
 def change_date_format(name):
     """Flip date from YYYYMMDD to MMDDYYYY."""

--- a/claims_hosp/tests/test_download_claims_ftp_files.py
+++ b/claims_hosp/tests/test_download_claims_ftp_files.py
@@ -1,5 +1,6 @@
 # standard
 import datetime
+import re
 
 # third party
 import numpy as np
@@ -8,6 +9,9 @@ import numpy as np
 from delphi_claims_hosp.download_claims_ftp_files import (change_date_format,
                                                           get_timestamp)
 
+OLD_FILENAME_TIMESTAMP = re.compile(
+    r".*EDI_AGG_INPATIENT_[0-9]_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
+NEW_FILENAME_TIMESTAMP = re.compile(r".*EDI_AGG_INPATIENT_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
 
 class TestDownloadClaimsFtpFiles:
     
@@ -19,3 +23,9 @@ class TestDownloadClaimsFtpFiles:
     def test_get_timestamp(self):
         name = "SYNEDI_AGG_INPATIENT_20200611_1451CDT"
         assert(get_timestamp(name).date() == datetime.date(2020, 6, 11))
+        
+        name = "EDI_AGG_INPATIENT_08272021_0251CDT.csv.gz.filepart"
+        assert(get_timestamp(name).date() == datetime.date(2021, 8, 27))
+        
+        name = "EDI_AGG_INPATIENT_1_05302020_0352CDT.csv.gz"
+        assert(get_timestamp(name).date() == datetime.date(2020, 5, 30))


### PR DESCRIPTION
### Description
Notice that we would run into errors when there are some file name that are partially match the re-format that we set previously.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- `download_claims_ftp_files.py`: update the `get_timestamp` function to fix this error.
- `tests/test_download_claims_ftp_files.py`: add more tests

### Fix
Fix #1667 