### PR TITLE
[CTIS] Add a few missing indicators and wave-specific handling for multi-selects

### DIFF
--- a/facebook/delphiFacebook/R/contingency_indicators.R
+++ b/facebook/delphiFacebook/R/contingency_indicators.R
@@ -170,6 +170,13 @@ THEME_GROUPS <- list(
     "pct_hesitant_dontneed_reason_not_serious",
     "pct_hesitant_dontneed_reason_other",
     "pct_hesitant_dontneed_reason_precautions",
+    "pct_barrier_reason_dontneed_had_covid",
+    "pct_barrier_reason_dontneed_dont_spend_time",
+    "pct_barrier_reason_dontneed_not_high_risk",
+    "pct_barrier_reason_dontneed_precautions",
+    "pct_barrier_reason_dontneed_not_serious",
+    "pct_barrier_reason_dontneed_not_beneficial",
+    "pct_barrier_reason_dontneed_other",
     "pct_hesitant_trust_covid_info_cdc",
     "pct_hesitant_trust_covid_info_doctors",
     "pct_hesitant_trust_covid_info_experts",
@@ -388,8 +395,8 @@ THEME_GROUPS <- list(
     "pct_unusual_symptom_sleep_changes",
     "pct_unusual_symptom_stuffy_nose",
     "pct_unusual_symptom_other",
-    "pct_unusual_symptom_hospital",
-    "pct_unusual_symptom_hospital_tried",
+    "pct_symptom_hospital",
+    "pct_symptom_hospital_tried",
     "pct_unusual_symptom_medical_care_called_doctor",
     "pct_unusual_symptom_medical_care_telemedicine",
     "pct_unusual_symptom_medical_care_visited_doctor",
@@ -397,6 +404,7 @@ THEME_GROUPS <- list(
     "pct_unusual_symptom_medical_care_er",
     "pct_unusual_symptom_medical_care_hospital",
     "pct_unusual_symptom_medical_care_tried",
+    "pct_unusual_symptom_medical_care_none",
     "pct_unusual_symptom_tested",
     "pct_unusual_symptom_tested_positive"
   ),
@@ -720,6 +728,19 @@ get_aggs <- function() {
     "pct_unusual_symptom_stuffy_nose", "symp_stuffy_nose_unusual", compute_binary, jeffreys_binary,
     "pct_unusual_symptom_other", "symp_other_unusual", compute_binary, jeffreys_binary,
 
+    # symptom followup medical care
+    "pct_symptom_hospital", "t_symptom_hospital", compute_binary, jeffreys_binary,
+    "pct_symptom_hospital_tried", "t_symptom_hospital_tried", compute_binary, jeffreys_binary,
+
+    "pct_unusual_symptom_medical_care_called_doctor", "unusual_symptom_medical_care_called_doctor", compute_binary, jeffreys_binary,
+    "pct_unusual_symptom_medical_care_telemedicine", "unusual_symptom_medical_care_telemedicine", compute_binary, jeffreys_binary,
+    "pct_unusual_symptom_medical_care_visited_doctor", "unusual_symptom_medical_care_visited_doctor", compute_binary, jeffreys_binary,
+    "pct_unusual_symptom_medical_care_urgent_care", "unusual_symptom_medical_care_urgent_care", compute_binary, jeffreys_binary,
+    "pct_unusual_symptom_medical_care_er", "unusual_symptom_medical_care_er", compute_binary, jeffreys_binary,
+    "pct_unusual_symptom_medical_care_hospital", "unusual_symptom_medical_care_hospital", compute_binary, jeffreys_binary,
+    "pct_unusual_symptom_medical_care_tried", "unusual_symptom_medical_care_tried", compute_binary, jeffreys_binary,
+    "pct_unusual_symptom_medical_care_none", "unusual_symptom_medical_care_none", compute_binary, jeffreys_binary,
+
     # vaccines
     "pct_vaccinated", "v_covid_vaccinated", compute_binary, jeffreys_binary,
     "pct_received_2_vaccine_doses", "v_received_2_vaccine_doses", compute_binary, jeffreys_binary,
@@ -846,6 +867,14 @@ get_aggs <- function() {
     "pct_hesitant_dontneed_reason_not_serious", "v_hesitant_dontneed_reason_not_serious", compute_binary, jeffreys_binary,
     "pct_hesitant_dontneed_reason_not_beneficial", "v_hesitant_dontneed_reason_not_beneficial", compute_binary, jeffreys_binary,
     "pct_hesitant_dontneed_reason_other", "v_hesitant_dontneed_reason_other", compute_binary, jeffreys_binary,
+
+    "pct_barrier_reason_dontneed_had_covid", "v_dontneed_reason_had_covid", compute_binary, jeffreys_binary,
+    "pct_barrier_reason_dontneed_dont_spend_time", "v_dontneed_reason_dont_spend_time", compute_binary, jeffreys_binary,
+    "pct_barrier_reason_dontneed_not_high_risk", "v_dontneed_reason_not_high_risk", compute_binary, jeffreys_binary,
+    "pct_barrier_reason_dontneed_precautions", "v_dontneed_reason_precautions", compute_binary, jeffreys_binary,
+    "pct_barrier_reason_dontneed_not_serious", "v_dontneed_reason_not_serious", compute_binary, jeffreys_binary,
+    "pct_barrier_reason_dontneed_not_beneficial", "v_dontneed_reason_not_beneficial", compute_binary, jeffreys_binary,
+    "pct_barrier_reason_dontneed_other", "v_dontneed_reason_other", compute_binary, jeffreys_binary,
 
     "pct_barrier_sideeffects", "v_hesitancy_reason_sideeffects", compute_binary, jeffreys_binary,
     "pct_barrier_allergic", "v_hesitancy_reason_allergic", compute_binary, jeffreys_binary,
@@ -1001,16 +1030,6 @@ get_aggs <- function() {
 
     "pct_unusual_symptom_tested", "t_unusual_symptom_tested", compute_binary, jeffreys_binary,
     "pct_unusual_symptom_tested_positive", "t_unusual_symptom_tested_positive", compute_binary, jeffreys_binary,
-    "pct_unusual_symptom_hospital", "t_unusual_symptom_hospital", compute_binary, jeffreys_binary,
-    "pct_unusual_symptom_hospital_tried", "t_unusual_symptom_hospital_tried", compute_binary, jeffreys_binary,
-
-    "pct_unusual_symptom_medical_care_called_doctor", "unusual_symptom_medical_care_called_doctor", compute_binary, jeffreys_binary,
-    "pct_unusual_symptom_medical_care_telemedicine", "unusual_symptom_medical_care_telemedicine", compute_binary, jeffreys_binary,
-    "pct_unusual_symptom_medical_care_visited_doctor", "unusual_symptom_medical_care_visited_doctor", compute_binary, jeffreys_binary,
-    "pct_unusual_symptom_medical_care_urgent_care", "unusual_symptom_medical_care_urgent_care", compute_binary, jeffreys_binary,
-    "pct_unusual_symptom_medical_care_er", "unusual_symptom_medical_care_er", compute_binary, jeffreys_binary,
-    "pct_unusual_symptom_medical_care_hospital", "unusual_symptom_medical_care_hospital", compute_binary, jeffreys_binary,
-    "pct_unusual_symptom_medical_care_tried", "unusual_symptom_medical_care_tried", compute_binary, jeffreys_binary,
 
     "pct_reason_not_tested_tried", "t_reason_not_tested_tried", compute_binary, jeffreys_binary,
     "pct_reason_not_tested_appointment", "t_reason_not_tested_appointment", compute_binary, jeffreys_binary,

--- a/facebook/delphiFacebook/R/contingency_variables.R
+++ b/facebook/delphiFacebook/R/contingency_variables.R
@@ -1658,7 +1658,7 @@ code_addl_demographic <- function(input_data, wave) {
     input_data$language_home_chinese <- input_data$D12 == 3
     input_data$language_home_vietnamese <- input_data$D12 == 4
     input_data$language_home_french <- input_data$D12 == 5
-    input_data$language_home_portugese <- input_data$D12 == 6
+    input_data$language_home_portuguese <- input_data$D12 == 6
     input_data$language_home_other <- input_data$D12 == 7
   } else {
     input_data$language_home_english <- NA
@@ -1666,7 +1666,7 @@ code_addl_demographic <- function(input_data, wave) {
     input_data$language_home_chinese <- NA
     input_data$language_home_vietnamese <- NA
     input_data$language_home_french <- NA
-    input_data$language_home_portugese <- NA
+    input_data$language_home_portuguese <- NA
     input_data$language_home_other <- NA
   }
 

--- a/facebook/delphiFacebook/R/contingency_variables.R
+++ b/facebook/delphiFacebook/R/contingency_variables.R
@@ -367,11 +367,11 @@ code_addl_vaccines <- function(input_data, wave) {
   }
 
   if ("B6" %in% names(input_data)) {
-    input_data$t_unusual_symptom_hospital <- input_data$B6 == 1
-    input_data$t_unusual_symptom_hospital_tried <- input_data$B6 == 1 | input_data$B6 == 3
+    input_data$t_symptom_hospital <- input_data$B6 == 1
+    input_data$t_symptom_hospital_tried <- input_data$B6 == 1 | input_data$B6 == 3
   } else {
-    input_data$t_unusual_symptom_hospital <- NA
-    input_data$t_unusual_symptom_hospital_tried <- NA
+    input_data$t_symptom_hospital <- NA
+    input_data$t_symptom_hospital_tried <- NA
   }
 
   if ("B7" %in% names(input_data) && wave != 10) {
@@ -392,6 +392,7 @@ code_addl_vaccines <- function(input_data, wave) {
     input_data$unusual_symptom_medical_care_er <- is_selected(unusual_symptoms_care, "5")
     input_data$unusual_symptom_medical_care_hospital <- is_selected(unusual_symptoms_care, "6")
     input_data$unusual_symptom_medical_care_tried <- is_selected(unusual_symptoms_care, "7")
+    input_data$unusual_symptom_medical_care_none <- is_selected(unusual_symptoms_care, "8")
   } else {
     input_data$unusual_symptom_medical_care_called_doctor <- NA
     input_data$unusual_symptom_medical_care_telemedicine <- NA
@@ -400,6 +401,7 @@ code_addl_vaccines <- function(input_data, wave) {
     input_data$unusual_symptom_medical_care_er <- NA
     input_data$unusual_symptom_medical_care_hospital <- NA
     input_data$unusual_symptom_medical_care_tried <- NA
+    input_data$unusual_symptom_medical_care_none <- NA
   }
 
   if ( "B12a" %in% names(input_data) ) {

--- a/facebook/delphiFacebook/R/contingency_variables.R
+++ b/facebook/delphiFacebook/R/contingency_variables.R
@@ -165,6 +165,19 @@ code_health <- function(input_data, wave) {
     input_data$comorbidobese <- is_selected(comorbidities, "13")
     input_data$comorbid_none <- is_selected(comorbidities, "9")
 
+    if (wave < 4) {
+      # Added in Wave 4
+      input_data$comorbidimmuno <- NA
+    }
+    if (wave < 8) {
+      # Added in Wave 8
+      input_data$comorbidobese <- NA
+    }
+    if (wave >= 11) {
+      # Removed in Wave 11
+      input_data$comorbid_autoimmune <- NA
+    }
+
     # Combo vaccine-eligibility
     input_data$eligible <- 
       input_data$comorbidheartdisease |
@@ -1156,6 +1169,32 @@ code_addl_symptoms <- function(input_data, wave) {
     input_data$symp_headache <- is_selected(symptoms, "18")
     input_data$symp_sleep_changes <- is_selected(symptoms, "19")
     input_data$symp_stuffy_nose <- is_selected(symptoms, "20")
+
+    if (wave < 3) {
+      # Added in Wave 3
+      input_data$symp_eye_pain <- NA
+    }
+    if (wave < 4) {
+      # Added in Wave 4
+      input_data$symp_chills <- NA
+    }
+    if (wave < 5) {
+      # Added in Wave 5
+      input_data$symp_headache <- NA
+      input_data$symp_sleep_changes <- NA
+    }
+    if (wave < 11) {
+      # Added in Wave 11
+      input_data$symp_stuffy_nose <- NA
+    }
+    if (wave >= 11) {
+      # All removed in Wave 11
+      input_data$symp_nasal_congestion <- NA
+      input_data$symp_runny_nose <- NA
+      input_data$symp_eye_pain <- NA
+      input_data$symp_sleep_changes <- NA
+    }
+
   } else {
     input_data$symp_fever <- NA
     input_data$symp_cough <- NA
@@ -1267,6 +1306,33 @@ code_addl_symptoms <- function(input_data, wave) {
     input_data$symp_unusual_given_stuffy_nose <- calc_unusual_given_symptom(
       input_data$symp_stuffy_nose, is_selected(symptoms, "20")
     )
+
+    if (wave < 5) {
+      # Added in Wave 5
+      input_data$symp_headache_unusual <- NA
+      input_data$symp_sleep_changes_unusual <- NA
+
+      input_data$symp_unusual_given_headache <- NA
+      input_data$symp_unusual_given_sleep_changes <- NA
+    }
+    if (wave < 11) {
+      # Added in Wave 11
+      input_data$symp_stuffy_nose_unusual <- NA
+
+      input_data$symp_unusual_given_stuffy_nose <- NA
+    }
+    if (wave >= 11) {
+      # All removed in Wave 11
+      input_data$symp_nasal_congestion_unusual <- NA
+      input_data$symp_runny_nose_unusual <- NA
+      input_data$symp_eye_pain_unusual <- NA
+      input_data$symp_sleep_changes_unusual <- NA
+
+      input_data$symp_unusual_given_nasal_congestion <- NA
+      input_data$symp_unusual_given_runny_nose <- NA
+      input_data$symp_unusual_given_eye_pain <- NA
+      input_data$symp_unusual_given_sleep_changes <- NA
+    }
   } else {
     input_data$symp_unusual_given_fever <- NA
     input_data$symp_unusual_given_cough <- NA

--- a/facebook/delphiFacebook/R/variables.R
+++ b/facebook/delphiFacebook/R/variables.R
@@ -428,6 +428,11 @@ code_testing <- function(input_data, wave) {
     input_data$t_tested_reason_other <- is_selected(testing_reasons, "8")
     input_data$t_tested_reason_travel <- is_selected(testing_reasons, "9")
     
+
+    if (wave < 11) {
+      # Added in Wave 11
+      input_data$t_tested_reason_travel <- NA
+    }
     if (wave >= 11) {
       input_data$t_tested_reason_large_event <- NA
       input_data$t_tested_reason_crowd <- NA


### PR DESCRIPTION
### Description
Add a few missing indicators that FB docs are expecting. Fix a couple spelling/naming issues. Add wave-specific handling, [e.g.](https://github.com/cmu-delphi/covidcast-indicators/blob/e97bbb923b17864477755db4dfe4377715631147/facebook/delphiFacebook/R/variables.R#L431-L434), for some multi-select responses that didn't exist the entire time the question was fielded. This only impacts contingency signals.

### Changelog
- `contingency_indicators.R`
- `contingency_variables.R`