### PR TITLE
Change illegal empty array to empty string

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        packages: [ ]
+        packages: ""
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
### Description
Apparently empty arrays aren't allowed in GitHub Action workflows, but empty strings are?

### Changelog
Itemize code/test/documentation changes and files added/removed.
- build-container-images.yml: change from empty array `[ ]` to empty string `""`

### Fixes 
- Fixes [failing build](https://github.com/cmu-delphi/covidcast-indicators/actions/runs/3265501961)
