### PR TITLE
Use full `sklearn` name in `setup.py`

### DIFF
--- a/doctor_visits/setup.py
+++ b/doctor_visits/setup.py
@@ -5,7 +5,7 @@ required = [
     "numpy",
     "pandas",
     "paramiko",
-    "sklearn",
+    "scikit-learn",
     "pytest",
     "pytest-cov",
     "pylint==2.8.3",


### PR DESCRIPTION
### Description
Linting and tests are failing for `doctor-visits` because the `sklearn` package can't be found. This is related to the [`sklearn` deprecation](https://pypi.org/project/sklearn/), so, as recommended, use the full package name in the setup file.

This is the only instance of `sklearn` in all `covidcast-indicators` packages.

### Changelog
- `setup.py`