### PR TITLE
If `setup.py` doesn't exist in an indicator dir don't attempt installation

### DIFF
--- a/jenkins/build-and-package.sh
+++ b/jenkins/build-and-package.sh
@@ -21,7 +21,7 @@ source env/bin/activate
 pip install --upgrade pip --retries 10 --timeout 20
 pip install numpy --retries 10 --timeout 20
 pip install ../_delphi_utils_python/. --retries 10 --timeout 20
-pip install . --retries 10 --timeout 20
+[ ! -f setup.py ] || pip install . --retries 10 --timeout 20
 
 #
 # Package


### PR DESCRIPTION
### Description
The existing Jenkins script assumes that all indicators are Python packages. The backfill corrections package is written in R and fails to build. Check for the existence of `setup.py` in the indicator dir to see if the package is installable via `pip`.

### Changelog
- `jenksin/build-and-package.sh`