### PR TITLE
Update claims_hosp SFTP and prod file output paths

### DIFF
--- a/ansible/templates/claims_hosp-params-prod.json.j2
+++ b/ansible/templates/claims_hosp-params-prod.json.j2
@@ -1,6 +1,6 @@
 {
   "common": {
-    "export_dir": "./receiving",
+    "export_dir": "/common/covidcast/receiving/hospital-admissions/",
     "log_exceptions": false
   },
   "indicator": {

--- a/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
+++ b/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
@@ -66,7 +66,7 @@ def download(ftp_credentials, out_path, logger):
                    password=ftp_credentials["pass"],
                    port=ftp_credentials["port"])
     sftp = client.open_sftp()
-    sftp.chdir('/hosp/receiving')
+    sftp.chdir('./receiving')
 
 
     # go through files in recieving dir


### PR DESCRIPTION
### Description

Fix:

There are two paths that need to be updated:

- The directory to access when obtaining new SFTP files
- The output directory to use in production

### Changelog

- download_claims_ftp_files.py
- claims_hosp-params-prod.json.j2