### PR TITLE
Add missing geos for claims_hosp

### DIFF
--- a/ansible/templates/claims_hosp-params-prod.json.j2
+++ b/ansible/templates/claims_hosp-params-prod.json.j2
@@ -13,7 +13,7 @@
     "write_se": false,
     "obfuscated_prefix": "foo_obfuscated",
     "parallel": false,
-    "geos": ["state", "msa", "hrr", "county"],
+    "geos": ["state", "msa", "hrr", "county", "nation", "hhs"],
     "weekday": [true, false],
     "ftp_credentials": {
       "host": "{{ claims_hosp_ftp_host }}",


### PR DESCRIPTION
### Description
Fix:

- Adds missing "nation" and "hhs" geos to indicator params template

### Changelog
- Updates claims_hosp production params