### PR TITLE
Covidcast-indicators version logging and workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -58,7 +58,13 @@ jobs:
         id: indicators
         run: |
           echo -n "::set-output name=version::"
-          bump2version --list ${{ github.event.inputs.versionName }} | grep ^new_version | sed -r s,"^.*=",,       
+          bump2version --list ${{ github.event.inputs.versionName }} | grep ^new_version | sed -r s,"^.*=",,
+      - name: Copy version to indicator directory
+        run: |
+          indicator_list=("cdc_covidnet" "changehc" "claims_hosp" "combo_cases_and_deaths" "covid_act_now" "doctor_visits" "dsew_community_profile" "google_symptoms" "hhs_hosp" "hhs_facilities" "jhu" "nchs_mortality" "nowcast" "quidel" "quidel_covidtest" "safegraph_patterns" "sir_complainsalot" "usafacts")
+          for path in ${indicator_list[@]}; do
+            echo "current_version = ${{ steps.indicators.outputs.version }}" > $path/version.cfg
+          done
       - name: Create pull request into prod
         uses: peter-evans/create-pull-request@v3
         with:

--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -1,6 +1,7 @@
 """Indicator running utilities."""
 import argparse as ap
 import importlib
+import os
 from typing import Any, Callable, Dict, Optional
 from .archive import ArchiveDiffer, archiver_from_params
 from .logger import get_structured_logger
@@ -40,6 +41,28 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
         name=indicator_fn.__module__,
         filename=params["common"].get("log_filename", None),
         log_exceptions=params["common"].get("log_exceptions", True))
+        
+    #Get version and indicator name for startup
+    runner_dir = os.path.dirname(__file__)
+    ind_name = indicator_fn.__module__
+    ind_name = ind_name.replace(".run", "")
+    ind_name = ind_name.replace("delphi_", "")
+    #hhs_hosp subdir drops "hosp"
+    if ind_name == "hhs":
+        ind_name = "hhs_hosp"
+    #Check for version.cfg in indicator directory
+    ver_loc = runner_dir.replace("_delphi_utils_python/delphi_utils", f"{ind_name}/version.cfg")
+    if os.path.isfile(ver_loc) == True:
+        ver_file = open(ver_loc)
+        current_version = "not found"
+        for line in ver_file:
+            if "current_version" in line:
+                current_version = str.strip(line)
+                current_version = current_version.replace("current_version = ", "")
+    #Logging - Starting Indicator    
+        logger.info(f"Started {ind_name} with version {current_version}")
+    else: logger.info(f"Started {ind_name} without version.cfg")
+    
     indicator_fn(params)
     validator = validator_fn(params)
     archiver = archiver_fn(params)

--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -43,26 +43,19 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
         log_exceptions=params["common"].get("log_exceptions", True))
         
     #Get version and indicator name for startup
-    runner_dir = os.path.dirname(__file__)
-    ind_name = indicator_fn.__module__
-    ind_name = ind_name.replace(".run", "")
-    ind_name = ind_name.replace("delphi_", "")
-    #hhs_hosp subdir drops "hosp"
-    if ind_name == "hhs":
-        ind_name = "hhs_hosp"
+    ind_name = indicator_fn.__module__.replace(".run","")
     #Check for version.cfg in indicator directory
-    ver_loc = runner_dir.replace("_delphi_utils_python/delphi_utils", f"{ind_name}/version.cfg")
-    if os.path.isfile(ver_loc) == True:
-        ver_file = open(ver_loc)
+    if os.path.exists("version.cfg"):
+        ver_file = open("version.cfg")
         current_version = "not found"
         for line in ver_file:
             if "current_version" in line:
                 current_version = str.strip(line)
                 current_version = current_version.replace("current_version = ", "")
     #Logging - Starting Indicator    
-        logger.info(f"Started {ind_name} with version {current_version}")
+        logger.info(f"Started {ind_name} with covidcast-indicators version {current_version}")
     else: logger.info(f"Started {ind_name} without version.cfg")
-    
+
     indicator_fn(params)
     validator = validator_fn(params)
     archiver = archiver_fn(params)

--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -46,12 +46,12 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
     ind_name = indicator_fn.__module__.replace(".run", "")
     #Check for version.cfg in indicator directory
     if os.path.exists("version.cfg"):
-        ver_file = open("version.cfg")
-        current_version = "not found"
-        for line in ver_file:
-            if "current_version" in line:
-                current_version = str.strip(line)
-                current_version = current_version.replace("current_version = ", "")
+        with open("version.cfg") as ver_file:
+            current_version = "not found"
+            for line in ver_file:
+                if "current_version" in line:
+                    current_version = str.strip(line)
+                    current_version = current_version.replace("current_version = ", "")
     #Logging - Starting Indicator    
         logger.info(f"Started {ind_name} with covidcast-indicators version {current_version}")
     else: logger.info(f"Started {ind_name} without version.cfg")

--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -43,7 +43,7 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
         log_exceptions=params["common"].get("log_exceptions", True))
         
     #Get version and indicator name for startup
-    ind_name = indicator_fn.__module__.replace(".run","")
+    ind_name = indicator_fn.__module__.replace(".run", "")
     #Check for version.cfg in indicator directory
     if os.path.exists("version.cfg"):
         ver_file = open("version.cfg")

--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -41,7 +41,7 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
         name=indicator_fn.__module__,
         filename=params["common"].get("log_filename", None),
         log_exceptions=params["common"].get("log_exceptions", True))
-        
+
     #Get version and indicator name for startup
     ind_name = indicator_fn.__module__.replace(".run", "")
     #Check for version.cfg in indicator directory
@@ -52,7 +52,7 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
                 if "current_version" in line:
                     current_version = str.strip(line)
                     current_version = current_version.replace("current_version = ", "")
-    #Logging - Starting Indicator    
+    #Logging - Starting Indicator
         logger.info(f"Started {ind_name} with covidcast-indicators version {current_version}")
     else: logger.info(f"Started {ind_name} without version.cfg")
 


### PR DESCRIPTION
### Description
Adds logging for indicator name and covidcast-indicators repository version when started by delphi_utils.runner. Workflow populates version.cfg in indicator directories with current version (same as .bumpversion.cfg), and runner will check this file on individual indicator startup.
- Removed decommissioned indicators from the workflow 

### Changelog

create-release.yml
- copy covidcast-indicators version to indicator directories

runner.py
- check version.cfg for version info, output indicator name and version

### Fixes 
- Fixes #1702 
