### PR TITLE
Repair backfill corrections tests

### DIFF
--- a/backfill_corrections/delphiBackfillCorrection/R/io.R
+++ b/backfill_corrections/delphiBackfillCorrection/R/io.R
@@ -17,7 +17,6 @@ read_data <- function(input_dir) {
 #' @template indicator-template
 #' @template signal-template
 #' @template geo_level-template
-#' @template geo-template
 #' @template signal_suffix-template
 #' @template lambda-template
 #' @template value_type-template

--- a/backfill_corrections/delphiBackfillCorrection/man/export_test_result.Rd
+++ b/backfill_corrections/delphiBackfillCorrection/man/export_test_result.Rd
@@ -49,9 +49,6 @@ single input dataframe, as with `quidel`'s age buckets.}
 \item{value_type}{string describing signal type. Either "count" or "fraction".}
 
 \item{export_dir}{path to directory to save output to}
-
-\item{geo}{string specifying the name of the geo region (e.g. FIPS
-code for counties)}
 }
 \description{
 Export the result to customized directory

--- a/backfill_corrections/delphiBackfillCorrection/unit-tests/testthat/params-test.json.template
+++ b/backfill_corrections/delphiBackfillCorrection/unit-tests/testthat/params-test.json.template
@@ -1,3 +1,3 @@
 {
-  "input_dir": "./test.tempt"
+  "input_dir": "./test.temp"
 }

--- a/backfill_corrections/delphiBackfillCorrection/unit-tests/testthat/test-io.R
+++ b/backfill_corrections/delphiBackfillCorrection/unit-tests/testthat/test-io.R
@@ -85,20 +85,22 @@ test_that("testing the filtration of the files for training and predicting", {
   params <- read_params("params-run.json", "params-run.json.template")
   params$train_models <- TRUE
 
-  daily_files_list <- c(file.path(params$input_dir, str_interp("chng_outpatient_as_of_${format(TODAY-15, date_format)}.parquet")),
+  daily_files_list <- c(file.path(params$input_dir, "chng_outpatient_as_of_20200202.parquet"),
+                        file.path(params$input_dir, str_interp("chng_outpatient_as_of_${format(TODAY-15, date_format)}.parquet")),
                         file.path(params$input_dir, str_interp("chng_outpatient_as_of_${format(TODAY-5, date_format)}.parquet")),
                         file.path(params$input_dir, str_interp("chng_outpatient_as_of_${format(TODAY, date_format)}.parquet")))
   daily_valid_files <- subset_valid_files(daily_files_list, "daily", params)
-  expect_equal(daily_valid_files, daily_files_list[2])
+  expect_equal(daily_valid_files, daily_files_list[2:4])
   
   rollup_files_list <- c(file.path(params$input_dir, str_interp(
     "chng_outpatient_from_${format(TODAY-15, date_format)}_to_${format(TODAY-11, date_format)}.parquet")),
     file.path(params$input_dir, str_interp(
     "chng_outpatient_from_${format(TODAY-15, date_format)}_to_${format(TODAY, date_format)}.parquet")),
     file.path(params$input_dir, str_interp(
-      "chng_outpatient_from_${format(TODAY, date_format)}_to_${format(TODAY+3, date_format)}.parquet")))
+      "chng_outpatient_from_${format(TODAY, date_format)}_to_${format(TODAY+3, date_format)}.parquet")),
+    file.path(params$input_dir, "chng_outpatient_from_20200202_to_20210304.parquet"))
   rollup_valid_files <- subset_valid_files(rollup_files_list, "rollup", params)
-  expect_equal(rollup_valid_files, rollup_files_list[2])
+  expect_equal(rollup_valid_files, rollup_files_list[1:3])
 
   file.remove("params-run.json")
 })

--- a/backfill_corrections/delphiBackfillCorrection/unit-tests/testthat/test-model.R
+++ b/backfill_corrections/delphiBackfillCorrection/unit-tests/testthat/test-model.R
@@ -87,7 +87,6 @@ test_that("testing generating or loading the model", {
 })
 
 test_that("testing model training and testing", {
-  browser()
   result <- model_training_and_testing(train_data, test_data, taus=TAUS, covariates=covariates,
                                        lp_solver=LP_SOLVER, lambda=lambda, test_lag=test_lag,
                                        geo=geo, value_type=value_type, model_save_dir=model_save_dir,

--- a/backfill_corrections/delphiBackfillCorrection/unit-tests/testthat/test-utils.R
+++ b/backfill_corrections/delphiBackfillCorrection/unit-tests/testthat/test-utils.R
@@ -73,7 +73,7 @@ test_that("testing read parameters", {
   expect_true(!("test_dates" %in% names(params)))
   
   # Create input file
-  path = "test.tempt"
+  path = "test.temp"
   create_dir_not_exist(path)
   expect_silent(params <- read_params(path = "params-test.json",
                                       template_path = "params-test.json.template",
@@ -126,8 +126,8 @@ test_that("testing read parameters", {
   expect_true(params$training_days == TRAINING_DAYS)
   expect_true(params$ref_lag == REF_LAG)
   expect_true(params$testing_window == TESTING_WINDOW)
-  start_date <- TODAY - params$testing_window
-  end_date <- TODAY - 1
+  start_date <- TODAY - params$testing_window + 1
+  end_date <- TODAY
   expect_true(all(params$test_dates == seq(start_date, end_date, by="days")))
   
   expect_silent(file.remove("params-test.json"))


### PR DESCRIPTION
### Description
Change tests to reflect updated date-handling.

`subset_valid_files` tests` were failing because the function used to assume that `training_end_date` was always `today`. This was later changed to pull `training_end_date` from `params`, if provided.

The most recent `test_dates` was changed from `TODAY - 1` to `TODAY`, causing a `read_params` test to fail.

### Changelog
- `test-io.R`
- `test-model.R`
- `test-utils.R`

### Fixes 
Closes https://github.com/cmu-delphi/covidcast-indicators/issues/1737.