### PR TITLE
[Backfill corrections] Fetch user-provided paths only at setup + increase pip timeout

### DIFF
--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -5,9 +5,9 @@ SHELL:=/bin/bash
 OPTIONS=
 
 PYTHON:=env/bin/python
-USR_INPUT_DIR=$(shell $(PYTHON) -m delphi_utils get input_dir)
-USR_CACHE_DIR=$(shell $(PYTHON) -m delphi_utils get cache_dir)
-USR_EXPORT_DIR=$(shell $(PYTHON) -m delphi_utils get export_dir)
+USR_INPUT_DIR:=$(shell $(PYTHON) -m delphi_utils get input_dir)
+USR_CACHE_DIR:=$(shell $(PYTHON) -m delphi_utils get cache_dir)
+USR_EXPORT_DIR:=$(shell $(PYTHON) -m delphi_utils get export_dir)
 
 # Gurobi license
 GRB_LICENSE_FILE=./gurobi.lic

--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -53,7 +53,7 @@ install-python:
 	python3 -m venv env
 	source env/bin/activate && \
 	pip install wheel && \
-	pip install delphi_utils
+	pip install --timeout 1000 delphi_utils
 
 lib:
 	R -e 'roxygen2::roxygenise("delphiBackfillCorrection")'


### PR DESCRIPTION
### Description
Make sure that user-provided paths are saved permanently (evaluated only once) by using `make`'s `:=` assignment operator.

Previously, these variables were assigned with `=` which re-evaluates the expression every time the variable is used. Since we [change the contents of `params.json`](https://github.com/cmu-delphi/covidcast-indicators/blob/7d2614391341f201890d332cb1cbf794c2d167bc/backfill_corrections/Makefile#L110-L113), at some points in the `Makefile`, the supposedly user-provided path variables actually contain the fixed dir names intended for use inside of the docker container.

Bonus: increase `pip install` timeout from the default of 15 s. When building the docker container, installing `delphi-utils` and dependencies exceeds this, causing an error.

### Changelog
- Makefile

### Fixes 
Pipeline complained about not finding any relevant files in input dir, despite dir and files existing.
