### PR TITLE
[Backfill corrections] Align daily and rollup file formats; make dates portable

### DIFF
--- a/changehc/tests/test_backfill.py
+++ b/changehc/tests/test_backfill.py
@@ -40,7 +40,7 @@ combined_data = load_combined_data(DENOM_FILEPATH, COVID_FILEPATH, DROP_DATE,
 class TestBackfill:
     
     def test_store_backfill_file(self):
-        
+
         fn = "changehc_covid_as_of_20200101.parquet"
         dropdate = datetime(2020, 1, 1)
         numtype = "covid"
@@ -69,7 +69,7 @@ class TestBackfill:
         backfill_df = pd.read_parquet(backfill_dir + "/"+ fn, engine='pyarrow')
         
         selected_columns = ['time_value', 'fips', 'state_id',
-                        'num', 'den']
+                        'num', 'den', 'lag', 'issue_date']
         assert set(selected_columns) == set(backfill_df.columns)  
         
         os.remove(backfill_dir + "/" + fn)
@@ -114,9 +114,6 @@ class TestBackfill:
             if "from" in file:
                 continue
             df = pd.read_parquet(file, engine='pyarrow')
-            issue_date = datetime.strptime(file[-16:-8], "%Y%m%d")
-            df["issue_date"] = issue_date
-            df["lag"] = [(issue_date - x).days for x in df["time_value"]]
             pdList.append(df)
             os.remove(file)
         new_files = glob.glob(backfill_dir + "/changehc_%s*.parquet"%numtype)

--- a/quidel_covidtest/delphi_quidel_covidtest/backfill.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/backfill.py
@@ -56,6 +56,17 @@ def store_backfill_file(df, _end_date, backfill_dir):
                         'num_age_0_17', 'den_age_0_17']
     backfilldata = backfilldata.loc[backfilldata["time_value"] >= _start_date,
                                     selected_columns]
+    backfilldata["lag"] = [(_end_date - x).days for x in backfilldata["time_value"]]
+    backfilldata["time_value"] = backfilldata.time_value.dt.strftime("%Y-%m-%d")
+    backfilldata["issue_date"] = datetime.strftime(_end_date, "%Y-%m-%d")
+
+    backfilldata = backfilldata.astype({
+        "time_value": "string",
+        "issue_date": "string",
+        "fips": "string",
+        "state_id": "string"
+    })
+
     path = backfill_dir + \
         "/quidel_covidtest_as_of_%s.parquet"%datetime.strftime(_end_date, "%Y%m%d")
     # Store intermediate file into the backfill folder
@@ -108,9 +119,6 @@ def merge_backfill_file(backfill_dir, backfill_merge_day, today,
     pdList = []
     for fn in new_files:
         df = pd.read_parquet(fn, engine='pyarrow')
-        issue_date = get_date(fn)
-        df["issue_date"] = issue_date
-        df["lag"] = [(issue_date - x).days for x in df["time_value"]]
         pdList.append(df)
     merged_file = pd.concat(pdList).sort_values(["time_value", "fips"])
     path = backfill_dir + "/quidel_covidtest_from_%s_to_%s.parquet"%(

--- a/quidel_covidtest/tests/test_backfill.py
+++ b/quidel_covidtest/tests/test_backfill.py
@@ -49,7 +49,8 @@ class TestBackfill:
                         'num_age_18_49', 'den_age_18_49',
                         'num_age_50_64', 'den_age_50_64',
                         'num_age_65plus', 'den_age_65plus',
-                        'num_age_0_17', 'den_age_0_17']
+                        'num_age_0_17', 'den_age_0_17',
+                        'lag', 'issue_date']
         assert set(selected_columns) == set(backfill_df.columns)  
         
         os.remove(backfill_dir + "/" + fn)
@@ -86,9 +87,6 @@ class TestBackfill:
             if "from" in file:
                 continue
             df = pd.read_parquet(file, engine='pyarrow')
-            issue_date = datetime.strptime(file[-16:-8], "%Y%m%d")
-            df["issue_date"] = issue_date
-            df["lag"] = [(issue_date - x).days for x in df["time_value"]]
             pdList.append(df)
             os.remove(file)
         new_files = glob.glob(backfill_dir + "/quidel_covidtest*.parquet")


### PR DESCRIPTION
### Description
Make sure `lag`  and `issue_date` fields are included in both daily and combined files. Store dates and location info as strings for better portability. These were previously `datetime64` (causing the timezone issue) and `object` types.

[`claims_hosp` backfill file generation](https://github.com/cmu-delphi/covidcast-indicators/pull/1675) was never merged, so changes to those functions are not included here.

### Changelog
- `quidel_covidtest`'s `backfill.py`
- `changehc`'s `backfill.py`

### Fixes
The original `time_value`s are meant to be plain dates ("2020-01-01") with no timestamp or timezone info.

The `parquet` format uses a schema with types. So if Python writes the `time_value`s as either pure dates (no timestamp info) or strings, R will read them in using the same types. The implicit timezone conversion (from no timezone, which R's `arrow::read_parquet` interprets as UTC, to the local timezone) only happens when the `time_value`s are saved into `parquet` form as `datetime64`s.

Python doesn't seem to have a "pure" date class (no time/timezone info). The `datetime64` type assumes the time is 00:00 even if none is given. To drop the time info, we can convert to a pure date but this [changes the type to `object`](https://stephenallwright.com/pandas-convert-datetime-to-date/). The `object` class can be a little dangerous to use. In this case, it's not clear what type `parquet` will assign to such a column or how R will read it in, and within Python `object`s can behave in unusual ways. Saving the dates to string is safer.

R will have to do an extra step to convert from string to a date, but it should avoid any weird time/timezone issues.