### PR TITLE
[Backfill corrections] Restore original params if pipeline exits with an error

### DIFF
--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -75,10 +75,10 @@ run:
 		-v "`realpath $(USR_EXPORT_DIR)`:/backfill_corrections/${EXPORT_DIR}" \
 		-v "`realpath $(USR_INPUT_DIR)`:/backfill_corrections/${INPUT_DIR}" \
 		-v "`realpath $(USR_CACHE_DIR)`:/backfill_corrections/${CACHE_DIR}" \
-		-v "${PWD}"/params.json:/backfill_corrections/params.json \
+		-v "${PWD}"/params.json:/backfill_corrections/params.host.json \
 		--env GRB_LICENSE_FILE=$(GRB_LICENSE_FILE) \
 		-it "${DOCKER_IMAGE}:${DOCKER_TAG}" \
-		/bin/bash -c "make gurobi.lic && make run-local OPTIONS=\"${OPTIONS}\""
+		/bin/bash -c "cp params.host.json params.json; make gurobi.lic && make standardize-dirs && make run-local OPTIONS=\"${OPTIONS}\""
 
 publish:
 	aws configure set aws_access_key_id $(AWS_KEY_ID)
@@ -86,7 +86,7 @@ publish:
 	aws s3 cp $(USR_INPUT_DIR) $(S3_BUCKET)/ --recursive --exclude "*" --include "*.csv.gz" --acl public-read
 	echo "SUCCESS: published `ls -1 $(USR_EXPORT_DIR)/*.csv.gz | wc -l` files to the S3 bucket" >> $(LOG_FILE)
 
-pipeline: setup-dirs standardize-dirs run publish teardown clean
+pipeline: setup-dirs run publish clean
 
 # Make sure all user-specified dirs exist locally; create them if not.
 setup-dirs:
@@ -114,12 +114,6 @@ standardize-dirs:
 
 clean:
 	rm -f $(USR_EXPORT_DIR)/*.csv.gz
-
-# Restore dir names in params to user-provided values.
-teardown:
-	$(PYTHON) -m delphi_utils set input_dir $(USR_INPUT_DIR)
-	$(PYTHON) -m delphi_utils set cache_dir $(USR_CACHE_DIR)
-	$(PYTHON) -m delphi_utils set export_dir $(USR_EXPORT_DIR)
 
 coverage:
 	Rscript -e 'covr::package_coverage("delphiBackfillCorrection")'

--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -78,7 +78,7 @@ run:
 		-v "${PWD}"/params.json:/backfill_corrections/params.host.json \
 		--env GRB_LICENSE_FILE=$(GRB_LICENSE_FILE) \
 		-it "${DOCKER_IMAGE}:${DOCKER_TAG}" \
-		/bin/bash -c "cp params.host.json params.json; make gurobi.lic && make standardize-dirs && make run-local OPTIONS=\"${OPTIONS}\""
+		/bin/bash -c "cp params.host.json params.json && make gurobi.lic && make standardize-dirs && make run-local OPTIONS=\"${OPTIONS}\""
 
 publish:
 	aws configure set aws_access_key_id $(AWS_KEY_ID)


### PR DESCRIPTION
### Description
Modify params dirs ([for convenience of working with user-provided paths](https://github.com/cmu-delphi/covidcast-indicators/blob/6e7df3424e08ec2f29b196152c66f1d1aaa0e9e4/backfill_corrections/Makefile#L98-L113)) only inside the docker container so that the original user-provided params file is preserved regardless of pipeline exit status or other unintended behavior.

### Changelog
- Makefile

### Fixes 
Previously modifications to dir paths were performed on the original `params.json` outside the docker container. Restoring it to its original state relied on a [`teardown` step](https://github.com/cmu-delphi/covidcast-indicators/blob/6e7df3424e08ec2f29b196152c66f1d1aaa0e9e4/backfill_corrections/Makefile#L118-L122) that didn't run if the pipeline exited with an error.

Instead of solving this by capturing and rethrowing errors, it was easier to limit params modifications to a copy of the mounted `params.json` inside the docker container. The copy is not linked to any file on the host, so changes to it are not propagated back to the original `params.json`.

I can't find any built-in support for mounting a file from the host but NOT propagating in-container changes back to the host, so `params.json` is mounted under another name and then copied manually.