### PR TITLE
[Backfill corrections] check if any files exist in receiving before trying to publish

### DIFF
--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -81,10 +81,14 @@ run:
 		/bin/bash -c "cp params.host.json params.json && make gurobi.lic && make standardize-dirs && make run-local OPTIONS=\"${OPTIONS}\""
 
 publish:
-	aws configure set aws_access_key_id $(AWS_KEY_ID)
-	aws configure set aws_secret_access_key $(AWS_SECRET_KEY)
-	aws s3 cp $(USR_INPUT_DIR) $(S3_BUCKET)/ --recursive --exclude "*" --include "*.csv.gz" --acl public-read
-	echo "SUCCESS: published `ls -1 $(USR_EXPORT_DIR)/*.csv.gz | wc -l` files to the S3 bucket" >> $(LOG_FILE)
+	if [ -f $(USR_INPUT_DIR)/*.csv.gz ]; then \
+		aws configure set aws_access_key_id $(AWS_KEY_ID); \
+		aws configure set aws_secret_access_key $(AWS_SECRET_KEY); \
+		aws s3 cp $(USR_INPUT_DIR) $(S3_BUCKET)/ --recursive --exclude "*" --include "*.csv.gz" --acl public-read; \
+		echo "SUCCESS: published `ls -1 $(USR_EXPORT_DIR)/*.csv.gz | wc -l` files to the S3 bucket" >> $(LOG_FILE); \
+	else \
+		echo "No files in $(USR_EXPORT_DIR) to publish" >> $(LOG_FILE); \
+	fi
 
 pipeline: setup-dirs run publish clean
 


### PR DESCRIPTION
### Description
Don't bother with connecting to AWS or trying to publish if we haven't actually generated any files, such as when doing model training.

### Changelog
- Makefile