### PR TITLE
Use GH API token in docker image-build workflow to increase rate limit

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -22,6 +22,8 @@ jobs:
           password: ${{ secrets.CMU_DELPHI_DEPLOY_MACHINE_PAT }}
 
       - name: Build, tag, and push image to Github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           baseRef="${GITHUB_REF#*/}"
           baseRef="${baseRef#*/}"


### PR DESCRIPTION
### Description
Use GH API token in docker image-build workflow to increase rate limit

### Changelog
- `backfill-corr-ci.yml`