### PR TITLE
Make log file available to docker subcall so only one log is produced

### DIFF
--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -78,7 +78,7 @@ run:
 		-v "${PWD}"/params.json:/backfill_corrections/params.host.json \
 		--env GRB_LICENSE_FILE=$(GRB_LICENSE_FILE) \
 		-it "${DOCKER_IMAGE}:${DOCKER_TAG}" \
-		/bin/bash -c "cp params.host.json params.json && make gurobi.lic && make standardize-dirs && make run-local OPTIONS=\"${OPTIONS}\""
+		/bin/bash -c "cp params.host.json params.json && make gurobi.lic && make standardize-dirs && make run-local OPTIONS=\"${OPTIONS}\" LOG_FILE=${LOG_FILE}"
 
 publish:
 	if [ -f $(USR_EXPORT_DIR)/*.csv.gz ]; then \


### PR DESCRIPTION
### Description
Pass log file name from the `make` session on the host to the `make` session inside of docker so that all messages end up in a single log file instead of in two separate files.

### Changelog
- Makefile