### PR TITLE
DSEW - include new header logic for fully vaccinated signal

### DIFF
--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -298,6 +298,13 @@ class Dataset:
             # exclude "People who are fully vaccinated - 12-17" ...
             header.find("-") < 0,
         ]) or all([
+            # include "People with a completed primary series"
+            header.startswith("People with a completed primary series"),
+            # exclude "People with a completed primary series as % of adult population"
+            header.find("%") < 0,
+            # exclude "People with a completed primary series - ages 65+"
+            header.find("-") < 0,
+        ]) or all([
             # include "People with full course administered"
             header.startswith("People with full course"),
             # exclude "People with full course administered as % of adult population"
@@ -368,8 +375,14 @@ class Dataset:
             sig_select = [s for s in select if s[-1].find(sig) >= 0]
             # The name of the cumulative vaccination was changed after 03/09/2021
             # when J&J vaccines were added.
+            # 01/12/2023 - new name again
             if (sig == "fully vaccinated") and (len(sig_select) == 0):
-                sig_select = [s for s in select if s[-1].find("people with full course") >= 0]
+                other_sigs = [
+                    "people with a completed primary series",
+                    "people with full course"
+                    ]
+                sig_select = [s for s in select if s[-1] in other_sigs]
+
             # Since "doses administered" is a substring of another desired header,
             # "booster doses administered", we need to more strictly check if "doses administered"
             # occurs at the beginning of a header to find the correct match.

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -375,8 +375,9 @@ class Dataset:
             sig_select = [s for s in select if s[-1].find(sig) >= 0]
             # The name of the cumulative vaccination was changed after 03/09/2021
             # when J&J vaccines were added.
-            # 01/12/2023 - new name again
+            # fully vacinated signal was renamed again on 01/12/2023
             if (sig == "fully vaccinated") and (len(sig_select) == 0):
+                # Read these headers if "fully vaccinated" not found in source data
                 other_sigs = [
                     "people with a completed primary series",
                     "people with full course administered"

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -303,6 +303,8 @@ class Dataset:
             # exclude "People with a completed primary series as % of adult population"
             header.find("%") < 0,
             # exclude "People with a completed primary series - ages 65+"
+            header.find(" age") < 0,
+            # exclude "People with a completed primary series - 12-17" ...
             header.find("-") < 0,
         ]) or all([
             # include "People with full course administered"

--- a/dsew_community_profile/delphi_dsew_community_profile/pull.py
+++ b/dsew_community_profile/delphi_dsew_community_profile/pull.py
@@ -379,7 +379,7 @@ class Dataset:
             if (sig == "fully vaccinated") and (len(sig_select) == 0):
                 other_sigs = [
                     "people with a completed primary series",
-                    "people with full course"
+                    "people with full course administered"
                     ]
                 sig_select = [s for s in select if s[-1] in other_sigs]
 

--- a/dsew_community_profile/tests/test_pull.py
+++ b/dsew_community_profile/tests/test_pull.py
@@ -150,6 +150,22 @@ class TestPull:
             example("Confirmed COVID-19 admissions - last 7 days - age unknown",
                     False),
             example("Confirmed COVID-19 admissions per 100 inpatient beds - last 7 days",
+                    False),
+            example("People who are fully vaccinated",
+                    True),
+            example("People who are fully vaccinated - ages 5-11",
+                    False),
+            example("People who are fully vaccinated as % of total population",
+                    False),
+            example("People with a completed primary series",
+                    True),
+            example("People with a completed primary series - ages 5-11",
+                    False),
+            example("People with a completed primary series as % of total population",
+                    False),
+            example("People with full course",
+                    True),
+            example("People with full course as % of total population",
                     False)
         ]
         for ex in examples:


### PR DESCRIPTION
### Description
- Fix current DSEW CPR outage where the data drops on Fridays are not being picked up.
- On the 2023/01/12 report, the "People who are fully vaccinated..." headers were renamed to "People with a completed primary series...".
  -  Based on header descriptions, this looks to be the same data.
  -  The fully vaccinated signal was not finding data to process because the code would not pick up the new header.
- Looks similar to a past name change for this signal on 2021/03/09.
  - The code was updated to include "People with a full course".

### Changelog
delphi_dsew_community_profile_report.pull
- Updated retain_header function to include "People with a completed primary series...".
  - header is now placed in select list (list of headers).
- Updated sig_select code in  _parse_sheet function to include entries with new header name.
  - New header is now placed into sig_select for fully vaccinated signal.
  - Now len(sig_select) > 0 for fully vaccinated signal

### Fixes 
- PO-35
