### PR TITLE
Properly authenticate R install steps of docker builds

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -43,6 +43,6 @@ jobs:
           else
             cd ${{ github.workspace }}/${{ matrix.packages }}
             echo "using tag: --${imageTag}--"
-            docker build -t ghcr.io/${{ github.repository }}-${{ matrix.packages }}:$imageTag --file Dockerfile .
+            DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build --secret id=GITHUB_TOKEN -t ghcr.io/${{ github.repository }}-${{ matrix.packages }}:$imageTag --file Dockerfile .
             docker push ghcr.io/${{ github.repository }}-${{ matrix.packages }}:$imageTag
           fi

--- a/backfill_corrections/Dockerfile
+++ b/backfill_corrections/Dockerfile
@@ -25,7 +25,9 @@ RUN install2.r --error \
     Rglpk \
     argparser
 
-RUN R -e 'devtools::install_github("cmu-delphi/covidcast", ref = "evalcast", subdir = "R-packages/evalcast")' && \
+RUN --mount=type=secret,id=GITHUB_TOKEN \
+    export GITHUB_PAT="$(cat /run/secrets/GITHUB_TOKEN)" && \
+    R -e 'devtools::install_github("cmu-delphi/covidcast", ref = "evalcast", subdir = "R-packages/evalcast")' && \
     R -e 'devtools::install_github(repo="ryantibs/quantgen", subdir="quantgen")' && \
     R -e 'install.packages(list.files(path="/opt/gurobi/linux64/R/", pattern="^gurobi_.*[.]tar[.]gz$", full.names = TRUE), repos=NULL)'
 


### PR DESCRIPTION
 ### Description
By default, `devtools::install_github` in R looks for an environment variable called `GITHUB_PAT` containing a GH API Personal Access Token. We have a PAT available in the workflow as the environment variable `GITHUB_TOKEN`, but environment variables are not available in the Dockerfile unless explicitly passed to `docker build`.

To do so securely, use the `--secret` param. In the install step that requires authentication, mount the secret and convert to an environment variable so the R sessions can access it (environment variables created in a RUN step don't persist in that intermediate container after it is shutdown, and aren't accessible to other intermediate containers or the final container). Secrets are only supported when the Dockerfile is built with BuildKit.

Note: The new Dockerfile makes it a little more complicated to build locally. Use

```
DOCKER_BUILDKIT=1 BUILDKIT_PROGRESS=plain docker build -t <image name> --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN .
```

(recommended flags `--pull --no-cache=true --force-rm`). If the `GITHUB_TOKEN` environment variable is not available or is set to empty (""), the image will build without authentication (which does work most of the time).

### Changelog
- Dockerfile
- container build workflow, `build-container-images.yml`

### Fixes 
Backfill corrections docker build hitting the GH API rate limit.