### PR TITLE
Fix exception during flash phase of Runner

### DIFF
--- a/_delphi_utils_python/delphi_utils/runner.py
+++ b/_delphi_utils_python/delphi_utils/runner.py
@@ -66,14 +66,12 @@ def run_indicator_pipeline(indicator_fn:  Callable[[Params], None],
     validator = validator_fn(params)
     archiver = archiver_fn(params)
 
-    if flash_fn:
-        t = threading.Timer(timer, flash_fn(params))
-        t.start()
-        t.join(timer)
-        if t.is_alive():
-            t.cancel()
-            t.join()
-
+    t = threading.Timer(timer, flash_fn, args=[params])
+    t.start()
+    t.join(timer)
+    if t.is_alive():
+        t.cancel()
+        t.join()
 
     if validator:
         validation_report = validator.validate()


### PR DESCRIPTION

### Description
Type of change (bug fix, new feature, etc), brief description, and motivation for these changes.

Flash is crashing in currently-deployed code, though it does not prevent subsequent runner phases from executing. This PR fixes the exception.

### Changelog
Itemize code/test/documentation changes and files added/removed.

- runner.py - use `flash_fn`, not its result, as the input to Timer; remove superfluous check

### Fixes 
- Fixes nonblocking exception in prod
