### PR TITLE
Google-Symptoms suppress s05 low export errors

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -32,7 +32,7 @@
         {"signal": "anosmia_raw_search"},
         {"signal": "anosmia_smoothed_search"},
         {"signal": "sum_anosmia_ageusia_raw_search"},
-        {"signal": "sum_anosmia_ageusia_smoothed_search"}
+        {"signal": "sum_anosmia_ageusia_smoothed_search"},
         {"signal": "s05_raw_search",
         "geo_type": "msa"},
         {"signal": "s05_smoothed_search",

--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -33,6 +33,18 @@
         {"signal": "anosmia_smoothed_search"},
         {"signal": "sum_anosmia_ageusia_raw_search"},
         {"signal": "sum_anosmia_ageusia_smoothed_search"}
+        {"signal": "s05_raw_search",
+        "geo_type": "msa"},
+        {"signal": "s05_smoothed_search",
+        "geo_type": "msa"},
+        {"signal": "s05_raw_search",
+        "geo_type": "hrr"},
+        {"signal": "s05_smoothed_search",
+        "geo_type": "hrr"},
+        {"signal": "s05_raw_search",
+        "geo_type": "county"},
+        {"signal": "s05_smoothed_search",
+        "geo_type": "county"}
       ]
     },
     "static": {

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -22,7 +22,19 @@
         {"signal": "anosmia_raw_search"},
         {"signal": "anosmia_smoothed_search"},
         {"signal": "sum_anosmia_ageusia_raw_search"},
-        {"signal": "sum_anosmia_ageusia_smoothed_search"}
+        {"signal": "sum_anosmia_ageusia_smoothed_search"},
+        {"signal": "s05_raw_search",
+        "geo_type": "msa"},
+        {"signal": "s05_smoothed_search",
+        "geo_type": "msa"},
+        {"signal": "s05_raw_search",
+        "geo_type": "hrr"},
+        {"signal": "s05_smoothed_search",
+        "geo_type": "hrr"},
+        {"signal": "s05_raw_search",
+        "geo_type": "county"},
+        {"signal": "s05_smoothed_search",
+        "geo_type": "county"}
       ]
     },
     "static": {


### PR DESCRIPTION
### Description
The google-symptoms indicator has been exporting minimal data for the s05 signals, which is causing validation failures and blocking acquisition. Specifically, the s05_raw and s05_smoothed signals for the MSA, HRR, and county geo levels are causing the validation failures. They are receiving critical errors for the check_missing_geo_sig_date_combo, empty_reference_data and check_min_max_date validation checks. 

Params files and templates have been updated for google symptoms to suppress errors for these geo-signal pairs. The indicator should now run even with no export from these particular geo-signal pairs.

### Changelog
Add geo-signal pairs to the suppressed errors section
- ansible/templates/google_symptoms-params-prod.json.j2
- google_symptoms/params.json.template 

### Fixes 
- PO-30 (Google-Symptoms Outage)
