### PR TITLE
Revert "Google-Symptoms suppress s05 low export errors"

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -32,19 +32,7 @@
         {"signal": "anosmia_raw_search"},
         {"signal": "anosmia_smoothed_search"},
         {"signal": "sum_anosmia_ageusia_raw_search"},
-        {"signal": "sum_anosmia_ageusia_smoothed_search"},
-        {"signal": "s05_raw_search",
-        "geo_type": "msa"},
-        {"signal": "s05_smoothed_search",
-        "geo_type": "msa"},
-        {"signal": "s05_raw_search",
-        "geo_type": "hrr"},
-        {"signal": "s05_smoothed_search",
-        "geo_type": "hrr"},
-        {"signal": "s05_raw_search",
-        "geo_type": "county"},
-        {"signal": "s05_smoothed_search",
-        "geo_type": "county"}
+        {"signal": "sum_anosmia_ageusia_smoothed_search"}
       ]
     },
     "static": {

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -22,19 +22,7 @@
         {"signal": "anosmia_raw_search"},
         {"signal": "anosmia_smoothed_search"},
         {"signal": "sum_anosmia_ageusia_raw_search"},
-        {"signal": "sum_anosmia_ageusia_smoothed_search"},
-        {"signal": "s05_raw_search",
-        "geo_type": "msa"},
-        {"signal": "s05_smoothed_search",
-        "geo_type": "msa"},
-        {"signal": "s05_raw_search",
-        "geo_type": "hrr"},
-        {"signal": "s05_smoothed_search",
-        "geo_type": "hrr"},
-        {"signal": "s05_raw_search",
-        "geo_type": "county"},
-        {"signal": "s05_smoothed_search",
-        "geo_type": "county"}
+        {"signal": "sum_anosmia_ageusia_smoothed_search"}
       ]
     },
     "static": {


### PR DESCRIPTION
Reverts cmu-delphi/covidcast-indicators#1805

Following the google symptoms outage, s05 signals are now behaving as expected for all geo_types. We should avoid suppressing these errors in case more issues arise.