### PR TITLE
Pin pandas below v2

### DIFF
--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -14,7 +14,7 @@ required = [
     "mock",
     "moto",
     "numpy",
-    "pandas>=1.1.0",
+    "pandas>=1.1.0,<2",
     "pydocstyle",
     "pylint==2.8.3",
     "pytest",

--- a/_delphi_utils_python/tests/test_geomap.py
+++ b/_delphi_utils_python/tests/test_geomap.py
@@ -275,6 +275,10 @@ class TestGeoMapper:
         new_data = geomapper.add_geocode(self.zip_data, "zip", "state_code")
         new_data2 = geomapper.add_geocode(new_data, "state_code", "nation")
         assert new_data2["nation"].unique()[0] == "us"
+        new_data = geomapper.replace_geocode(self.zip_data, "zip", "state_code")
+        new_data2 = geomapper.add_geocode(new_data, "state_code", "state_id", new_col="state")
+        new_data3 = geomapper.replace_geocode(new_data2, "state_code", "nation", new_col="geo_id")
+        assert "state" not in new_data3.columns
 
         # state_code -> hhs
         new_data = geomapper.add_geocode(self.zip_data, "zip", "state_code")


### PR DESCRIPTION
### Description
Temporary fix while we wait for #1820.

Pandas v2 was release on April 3 and includes breaking changes. This PR pins the version under v2.


### Changelog
Itemize code/test/documentation changes and files added/removed.

- pin pandas version in delphi-utils (which is imported by everybody, so will be transitive in all new builds)
- add a test which fails in pandas v2. this was added while chasing down the problem, but will create a good place to start on #1820.

### Fixes

Fixes failing build in `main`
