### PR TITLE
Add age signals to SirCal params templates

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -32,11 +32,14 @@
       "max_age":6,
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
       "retired-signals": [
-        "raw_pct_negative","smoothed_pct_negative","raw_tests_per_device","smoothed_tests_per_device",
-        ["covid_ag_raw_pct_positive_age_0_4", "hrr"], ["covid_ag_raw_pct_positive_age_0_4", "msa"],
-        ["covid_ag_raw_pct_positive_age_5_17", "hrr"], ["covid_ag_raw_pct_positive_age_5_17", "msa"],
-        ["covid_ag_raw_pct_positive_age_50_64", "hrr"], ["covid_ag_raw_pct_positive_age_50_64", "msa"],
-        ["covid_ag_raw_pct_positive_age_65plus", "hrr"], ["covid_ag_raw_pct_positive_age_65plus", "msa"]
+        "raw_pct_negative", "smoothed_pct_negative",
+        "raw_tests_per_device", "smoothed_tests_per_device",
+        "covid_ag_raw_pct_positive_age_0_4", "covid_ag_smoothed_pct_positive_age_0_4",
+        "covid_ag_raw_pct_positive_age_5_17", "covid_ag_smoothed_pct_positive_age_5_17",
+        "covid_ag_raw_pct_positive_age_18_49", "covid_ag_smoothed_pct_positive_age_18_49",
+        "covid_ag_raw_pct_positive_age_50_64", "covid_ag_smoothed_pct_positive_age_50_64",
+        "covid_ag_raw_pct_positive_age_65plus", "covid_ag_smoothed_pct_positive_age_65plus",
+        "covid_ag_raw_pct_positive_age_0_17", "covid_ag_smoothed_pct_positive_age_0_17"
       ]
     },
     "nchs-mortality": {

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -32,11 +32,14 @@
       "max_age":6,
       "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
       "retired-signals": [
-        "raw_pct_negative","smoothed_pct_negative","raw_tests_per_device","smoothed_tests_per_device",
-        ["covid_ag_raw_pct_positive_age_0_4", "hrr"], ["covid_ag_raw_pct_positive_age_0_4", "msa"],
-        ["covid_ag_raw_pct_positive_age_5_17", "hrr"], ["covid_ag_raw_pct_positive_age_5_17", "msa"],
-        ["covid_ag_raw_pct_positive_age_50_64", "hrr"], ["covid_ag_raw_pct_positive_age_50_64", "msa"],
-        ["covid_ag_raw_pct_positive_age_65plus", "hrr"], ["covid_ag_raw_pct_positive_age_65plus", "msa"]
+        "raw_pct_negative", "smoothed_pct_negative",
+        "raw_tests_per_device", "smoothed_tests_per_device",
+        "covid_ag_raw_pct_positive_age_0_4", "covid_ag_smoothed_pct_positive_age_0_4",
+        "covid_ag_raw_pct_positive_age_5_17", "covid_ag_smoothed_pct_positive_age_5_17",
+        "covid_ag_raw_pct_positive_age_18_49", "covid_ag_smoothed_pct_positive_age_18_49",
+        "covid_ag_raw_pct_positive_age_50_64", "covid_ag_smoothed_pct_positive_age_50_64",
+        "covid_ag_raw_pct_positive_age_65plus", "covid_ag_smoothed_pct_positive_age_65plus",
+        "covid_ag_raw_pct_positive_age_0_17", "covid_ag_smoothed_pct_positive_age_0_17"
       ]
     },
     "nchs-mortality": {


### PR DESCRIPTION
### Description
Add age signals to Sir ComplainsAlot's Quidel parameters section `retired-signals`. This should suppress the errors regarding the age-specific signals, but leave the `covid_ag_raw_pct_positive` and `covid_ag_smoothed_pct_positive` visible. 

It appears the actual Quidel outage started on 4/6, but before this a few age signals were experiencing known errors. This caused the actual outage to go under the radar for a couple days as it looked like a known issue.

One review topic: Should we change the name of `retired-signals` to something along the lines of `skipped-signals`? It appears there are legitimate retired signals in this section, but this section of parameters seems to just be suppressing these signals on the SirCal side.

### Changelog
- params.json.template (sircal)
- sir_complainsalot-params-prod.json.j2
    - added signals to "retired-signals" for both files.

### Fixes 
- Improves monitoring for Quidel signals
