### PR TITLE
[Backfill corrections] Allocate enough shared memory for parallel prediction generation

### DIFF
--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -67,6 +67,8 @@ run-local: setup-dirs
 	grep "backfill correction completed successfully" $(LOG_FILE)
 	grep "scheduled core" $(LOG_FILE) ; \
 	[ "$$?" -eq 1 ]
+	grep "SIGBUS" $(LOG_FILE) ; \
+	[ "$$?" -eq 1 ]
 
 gurobi.lic:
 	@echo WLSACCESSID=$(GRB_WLSACCESSID) >> $(GRB_LICENSE_FILE)

--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -124,7 +124,7 @@ standardize-dirs:
 	$(PYTHON) -m delphi_utils set export_dir $(EXPORT_DIR)
 
 clean:
-	rm -f $(USR_EXPORT_DIR)/*.csv.gz
+	rm -rf $(USR_EXPORT_DIR)/*
 
 coverage:
 	Rscript -e 'covr::package_coverage("delphiBackfillCorrection")'

--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -81,6 +81,7 @@ run:
 		-v "`realpath $(USR_CACHE_DIR)`:/backfill_corrections/${CACHE_DIR}" \
 		-v "${PWD}"/params.json:/backfill_corrections/params.host.json \
 		--env GRB_LICENSE_FILE=$(GRB_LICENSE_FILE) \
+		--shm-size=5gb \
 		-it "${DOCKER_IMAGE}:${DOCKER_TAG}" \
 		/bin/bash -c "cp params.host.json params.json && make gurobi.lic && make standardize-dirs && make run-local OPTIONS=\"${OPTIONS}\" LOG_FILE=${LOG_FILE}"
 

--- a/backfill_corrections/delphiBackfillCorrection/R/main.R
+++ b/backfill_corrections/delphiBackfillCorrection/R/main.R
@@ -60,6 +60,7 @@ run_backfill <- function(df, params,
     msg_ts("Splitting data into geo groups")
     group_dfs <- group_split(df, geo_value)
 
+    msg_ts("Beginning training and/or testing...")
     # Build model for each location
     apply_fn <- ifelse(params$parallel, mclapply, lapply)
     result <- apply_fn(group_dfs, function(subdf) {


### PR DESCRIPTION
### Description
Main change here is to make sure the docker container has enough shared memory to generate predictions.

Smaller changes:
- Logging
- Make sure `receiving` directory is cleared after a run
- Check for "SIGBUS" message in log file

### Changelog
- Makefile
- `main.R`

### Fixes 
Generating predictions in parallel (even with 2 cores) resulted in the error `'memcpy' resulted in a SIGBUS (no shared memory left)`. Docker containers have 64 MB shared memory by default, which is apparently sufficient for modeling training in parallel but not generating predictions. This change assigns 5 GB of shared memory, which is enough for generating predictions in parallel with up to 5 cores.
