### PR TITLE
[Backfill corrections] Pin `bettermc` to last cran-approved version

### DIFF
--- a/backfill_corrections/Dockerfile
+++ b/backfill_corrections/Dockerfile
@@ -26,6 +26,7 @@ RUN install2.r --error \
 
 RUN --mount=type=secret,id=GITHUB_TOKEN \
     export GITHUB_PAT="$(cat /run/secrets/GITHUB_TOKEN)" && \
+    R -e 'devtools::install_version("bettermc", version = "1.1.2")' && \
     R -e 'devtools::install_github("cmu-delphi/covidcast", ref = "evalcast", subdir = "R-packages/evalcast")' && \
     R -e 'devtools::install_github(repo="ryantibs/quantgen", subdir="quantgen")' && \
     R -e 'install.packages(list.files(path="/opt/gurobi/linux64/R/", pattern="^gurobi_.*[.]tar[.]gz$", full.names = TRUE), repos=NULL)'


### PR DESCRIPTION
### Description
The `bettermc` package, required both for backfill corrections and as a dependency of `evalcast`, was recently [removed from CRAN](https://cran.rstudio.com/web/packages/bettermc/index.html). Pin to the last working version.

### Changelog
- Dockerfile