### PR TITLE
[Validator] Cast timestamp to date in reference vs test data up-to-dateness comparison

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -404,7 +404,7 @@ class DynamicValidator:
         Returns:
             - None
         """
-        if df_to_test["time_value"].max() < df_to_reference["time_value"].max():
+        if df_to_test["time_value"].max() < df_to_reference["time_value"].max().date():
             report.add_raised_error(
                 ValidationFailure("check_max_date_vs_reference",
                                   checking_date,

--- a/_delphi_utils_python/tests/validator/test_dynamic.py
+++ b/_delphi_utils_python/tests/validator/test_dynamic.py
@@ -465,3 +465,38 @@ class TestDataOutlier:
 
         assert len(report.raised_warnings) == 2
         assert report.raised_warnings[0].check_name == "check_positive_negative_spikes"
+
+class TestDateComparison:
+    params = {
+        "common": {
+            "data_source": "",
+            "span_length": 1,
+            "end_date": "2020-09-02"
+        }
+    }
+
+    def test_date_comparison_by_type(self):
+        validator = DynamicValidator(self.params)
+        report = ValidationReport([])
+
+        ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,
+                   31.42857143, 31.71428571, 32, 32, 32.14285714,
+                   32.28571429, 32.42857143, 32.57142857, 32.71428571,
+                   32.85714286, 33, 33, 33, 33, 33, 33, 33, 33,
+                   33, 33, 33, 33.28571429, 33.57142857, 33.85714286, 34.14285714]
+        test_val = [100, 100, 100]
+
+        ref_data = pd.DataFrame({"val": ref_val, "se": [np.nan] * len(ref_val),
+                    "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
+                    # datetime64 type
+                    "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")})
+        test_data = pd.DataFrame({"val": test_val, "se": [np.nan] * len(test_val),
+                     "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
+                     # datetime.date type
+                     "time_value": datetime.strptime("2020-10-26", "%Y-%m-%d").date()})
+
+        try:
+            # This should run without raising any errors.
+            validator.check_max_date_vs_reference(test_data, ref_data, "date", "state", "signal", report)
+        except TypeError:
+            assert False

--- a/_delphi_utils_python/tests/validator/test_dynamic.py
+++ b/_delphi_utils_python/tests/validator/test_dynamic.py
@@ -1,5 +1,5 @@
 """Tests for dynamic validator."""
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 import numpy as np
 import pandas as pd
 
@@ -479,17 +479,14 @@ class TestDateComparison:
         validator = DynamicValidator(self.params)
         report = ValidationReport([])
 
-        ref_val = [30, 30.28571429, 30.57142857, 30.85714286, 31.14285714,
-                   31.42857143, 31.71428571, 32, 32, 32.14285714,
-                   32.28571429, 32.42857143, 32.57142857, 32.71428571,
-                   32.85714286, 33, 33, 33, 33, 33, 33, 33, 33,
-                   33, 33, 33, 33.28571429, 33.57142857, 33.85714286, 34.14285714]
+        ref_val = [30, 30, 30]
         test_val = [100, 100, 100]
 
+        START = datetime.strptime("2020-10-01", "%Y-%m-%d")
         ref_data = pd.DataFrame({"val": ref_val, "se": [np.nan] * len(ref_val),
                     "sample_size": [np.nan] * len(ref_val), "geo_id": ["1"] * len(ref_val),
                     # datetime64 type
-                    "time_value": pd.date_range(start="2020-09-24", end="2020-10-23")})
+                    "time_value": pd.date_range(start=START, end=START + timedelta(days=len(ref_val) - 1))})
         test_data = pd.DataFrame({"val": test_val, "se": [np.nan] * len(test_val),
                      "sample_size": [np.nan] * len(test_val), "geo_id": ["1"] * len(test_val),
                      # datetime.date type

--- a/_delphi_utils_python/tests/validator/test_dynamic.py
+++ b/_delphi_utils_python/tests/validator/test_dynamic.py
@@ -492,8 +492,5 @@ class TestDateComparison:
                      # datetime.date type
                      "time_value": datetime.strptime("2020-10-26", "%Y-%m-%d").date()})
 
-        try:
-            # This should run without raising any errors.
-            validator.check_max_date_vs_reference(test_data, ref_data, "date", "state", "signal", report)
-        except TypeError:
-            assert False
+        # This should run without raising any errors.
+        validator.check_max_date_vs_reference(test_data, ref_data, "date", "state", "signal", report)


### PR DESCRIPTION
### Description
Fix `TypeError` when comparing a `datetime.date` and a `datetime64` timestamp.

### Changelog
- `validator/dynamic.py`
- Validation tests

### Fixes
https://delphi-org.slack.com/archives/C01LZ3A2UMU/p1681391375854509