### PR TITLE
include state FIPS codes in set of all FIPS geo values

### DIFF
--- a/_delphi_utils_python/delphi_utils/geomap.py
+++ b/_delphi_utils_python/delphi_utils/geomap.py
@@ -158,7 +158,7 @@ class GeoMapper:  # pylint: disable=too-many-public-methods
             to_code = from_code = "state"
         elif geo_type == "fips":
             from_code = "fips"
-            to_code = "pop"
+            to_code = "state"
         else:
             from_code = "fips"
             to_code = geo_type

--- a/_delphi_utils_python/delphi_utils/validator/static.py
+++ b/_delphi_utils_python/delphi_utils/validator/static.py
@@ -166,8 +166,6 @@ class StaticValidator:
         gmpr = GeoMapper()
         valid_geos = gmpr.get_geo_values(geomap_type)
         valid_geos |= set(self.params.additional_valid_geo_values.get(geo_type, []))
-        if geo_type == "county":
-            valid_geos |= set(x + "000" for x in gmpr.get_geo_values("state_code"))
         return valid_geos
 
     def check_bad_geo_id_value(self, df_to_test, filename, geo_type, report):

--- a/_delphi_utils_python/tests/test_geomap.py
+++ b/_delphi_utils_python/tests/test_geomap.py
@@ -373,13 +373,13 @@ class TestGeoMapper:
     def test_get_geos(self, geomapper):
         assert geomapper.get_geo_values("nation") == {"us"}
         assert geomapper.get_geo_values("hhs") == set(str(i) for i in range(1, 11))
-        assert len(geomapper.get_geo_values("fips")) == 3236
+        assert len(geomapper.get_geo_values("fips")) == 3293
         assert len(geomapper.get_geo_values("chng-fips")) == 2711
         assert len(geomapper.get_geo_values("state_id")) == 60
         assert len(geomapper.get_geo_values("zip")) == 32976
 
     def test_get_geos_2019(self, geomapper_2019):
-        assert len(geomapper_2019.get_geo_values("fips")) == 3235
+        assert len(geomapper_2019.get_geo_values("fips")) == 3292
         assert len(geomapper_2019.get_geo_values("chng-fips")) == 2710
 
     def test_get_geos_within(self, geomapper):


### PR DESCRIPTION
so that `delphi_utils.geomap.GeoMapper().get_geo_values('fips')` also includes (for example) "42000" representing all of Pennsylvania, in addition to FIPS codes in the 42001-42999 interval that represent individual counties.

see background discussion at https://github.com/cmu-delphi/delphi-epidata/pull/1134