### PR TITLE
Upgrade only to most recent working version of pip

### DIFF
--- a/jenkins/build-and-package.sh
+++ b/jenkins/build-and-package.sh
@@ -19,7 +19,7 @@ cd "${WORKSPACE}/${local_indicator}" || exit
 # Set up venv
 python -m venv env
 source env/bin/activate
-pip install --upgrade pip --retries 10 --timeout 20
+pip install pip==23.0.1 --retries 10 --timeout 20
 pip install numpy --retries 10 --timeout 20
 pip install ../_delphi_utils_python/. --retries 10 --timeout 20
 [ ! -f setup.py ] || pip install . --retries 10 --timeout 20


### PR DESCRIPTION
A recent change in `pip-23.1` is causing our indicator build process to fail. This is a quick fix that upgrades only to the most recent working version of `pip-23.0.1`.

### Description
QUICK FIX: Only upgrade to `pip-23.0.1` in our initial build script.

### Changelog
- jenkins/build-and-package.sh