### PR TITLE
[NCHS] fix weekly arch if statement for Mondays

### DIFF
--- a/nchs_mortality/delphi_nchs_mortality/archive_diffs.py
+++ b/nchs_mortality/delphi_nchs_mortality/archive_diffs.py
@@ -33,7 +33,7 @@ def arch_diffs(params, daily_arch_diff, logger):
     # - Does not upload to S3, that is handled by daily run of archive utility
     # - Exports issues into receiving for the API
     n = 0
-    if datetime.today().weekday() == (0 or 3):
+    if datetime.today().weekday() in {0, 3}:
         # Copy todays raw output to receiving and log the number of published files
         for output_file in listdir(daily_export_dir):
             copy(


### PR DESCRIPTION
### Description
NCHS Mortality's weekly archive is not working on Mondays due to a issue with an if statement in `archive_diffs.py`. This means that the API upload is skipped for a week if the indicator fails on Thursday. This is also causing a lag discrepancy because data can only be uploaded to the API on Thursdays, but the source data updates on Mondays. The code `if datetime.today().weekday() == (0 or 3)` is only true when `datetime.today().weekday() = 3`, which is only on Thursdays.

### Changelog
- `archive_diffs.py` if statement changed to `if datetime.today().weekday() in {0, 3}`, which is true for both values.


### Fixes 
- Fixes #1678 
- Fixes PO-55 and PO-10
