### PR TITLE
Pin bettermc to last cran-approved version in workflow

### DIFF
--- a/.github/workflows/backfill-corr-ci.yml
+++ b/.github/workflows/backfill-corr-ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up R ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r-version }}
       - name: Install linux dependencies
@@ -66,6 +66,7 @@ jobs:
           dependency_list <- remotes::dev_package_deps(dependencies=TRUE)
           remotes::update_packages(dependency_list$package, upgrade="always")
 
+          devtools::install_version("bettermc", version = "1.1.2"
           devtools::install_github("cmu-delphi/covidcast", ref = "evalcast", subdir = "R-packages/evalcast")
           devtools::install_github(repo="ryantibs/quantgen", subdir="quantgen")
         shell: Rscript {0}


### PR DESCRIPTION
### Description
Make the same change as https://github.com/cmu-delphi/covidcast-indicators/pull/1828 in the backfill corrections workflow.

The bettermc package, required both for backfill corrections and as a dependency of evalcast, was recently [removed from CRAN](https://cran.rstudio.com/web/packages/bettermc/index.html). Pin to the last working version.

### Changelog
- `.github/workflows/backfill-corr-ci.yml`

### Fixes 
Backfill corrections CI is [failing](https://delphi-org.slack.com/archives/C013AH5N01E/p1682977732181189).
