### PR TITLE
[Backfill corrections] make CI workflow install faster

### DIFF
--- a/.github/workflows/backfill-corr-ci.yml
+++ b/.github/workflows/backfill-corr-ci.yml
@@ -32,6 +32,7 @@ jobs:
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r-version }}
+          use-public-rspm: true
       - name: Install linux dependencies
         run: |
             sudo apt-get install \

--- a/.github/workflows/backfill-corr-ci.yml
+++ b/.github/workflows/backfill-corr-ci.yml
@@ -52,23 +52,24 @@ jobs:
           key: ${{ runner.os }}-r-backfillcorr-${{ steps.get-date.outputs.date }}
           restore-keys: |
             ${{ runner.os }}-r-backfillcorr-
-      - name: Install R dependencies
+      - name: Install and cache dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: backfill_corrections/delphiBackfillCorrection
+          upgrade: 'TRUE'
+          extra-packages: |
+            any::rcmdcheck
+            any::devtools
+            any::remotes
+      - name: Update R dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ( !require("remotes") ) {
-            install.packages("remotes")
-          }
-          if ( !require("devtools") ) {
-            install.packages("devtools")
-          }
           remotes::update_packages(c("rcmdcheck", "remotes", "devtools"), upgrade="always")
           dependency_list <- remotes::dev_package_deps(dependencies=TRUE)
           remotes::update_packages(dependency_list$package, upgrade="always")
-
-          devtools::install_version("bettermc", version = "1.1.2")
-          devtools::install_github("cmu-delphi/covidcast", ref = "evalcast", subdir = "R-packages/evalcast")
-          devtools::install_github(repo="ryantibs/quantgen", subdir="quantgen")
         shell: Rscript {0}
       - name: Check
         run: |

--- a/.github/workflows/backfill-corr-ci.yml
+++ b/.github/workflows/backfill-corr-ci.yml
@@ -59,19 +59,9 @@ jobs:
         with:
           working-directory: backfill_corrections/delphiBackfillCorrection
           upgrade: 'TRUE'
-          extra-packages: |
-            any::rcmdcheck
-            any::devtools
-            any::remotes
-      - name: Update R dependencies
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          remotes::update_packages(c("rcmdcheck", "remotes", "devtools"), upgrade="always")
-          dependency_list <- remotes::dev_package_deps(dependencies=TRUE)
-          remotes::update_packages(dependency_list$package, upgrade="always")
-        shell: Rscript {0}
-      - name: Check
-        run: |
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--test-dir=unit-tests"), error_on = "error")
-        shell: Rscript {0}
+      - name: Check package
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          working-directory: backfill_corrections/delphiBackfillCorrection
+          args: 'c("--no-manual", "--test-dir=unit-tests")'
+          error-on: '"error"'

--- a/backfill_corrections/delphiBackfillCorrection/DESCRIPTION
+++ b/backfill_corrections/delphiBackfillCorrection/DESCRIPTION
@@ -35,5 +35,9 @@ Suggests:
     testthat (>= 1.0.1),
     covr (>= 2.2.2),
     mockr
+Remotes:
+    bettermc=github::gfkse/bettermc@v1.1.2,
+    evalcast=github::cmu-delphi/covidcast/R-packages/evalcast@evalcast,
+    quantgen=github::ryantibs/quantgen/quantgen
 RoxygenNote: 7.2.0
 Encoding: UTF-8


### PR DESCRIPTION
### Description
The backfill corrections CI takes ~1 hour to run when there's no cache, which makes it really inefficient to work with.

This PR switches to using the `r-lib` action to install dependencies for speed. `Remotes` in the `DESCRIPTION` file are specified for `bettermc`, `evalcast`, and `quantgen`, none of which are on CRAN, so that their installation can also be handled by `r-lib/actions/setup-r-dependencies@v2`.

We use another `r-lib` action to run the tests, and toggle on use of RSPM, to request binaries (faster to install) when possible.

Without a cache, this now takes ~6 min to run.

### Changelog
- `.github/workflows/backfill-corr-ci.yml`