### PR TITLE
Request rcmdcheck to be installed with dependencies in backfill corrections CI

### DIFF
--- a/.github/workflows/backfill-corr-ci.yml
+++ b/.github/workflows/backfill-corr-ci.yml
@@ -58,6 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          extra-packages: any::rcmdcheck
           working-directory: backfill_corrections/delphiBackfillCorrection
           upgrade: 'TRUE'
       - name: Check package


### PR DESCRIPTION
### Description
Install `rcmdcheck`.

### Changelog
backfill corrections ci workflow file

### Fixes 
```
Run r-lib/actions/check-r-package@v2
Run ## --------------------------------------------------------------------
Error: Error in loadNamespace(x) : there is no package called ‘rcmdcheck’
Calls: loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
Execution halted
Error: Process completed with exit code [1](https://github.com/cmu-delphi/covidcast-indicators/actions/runs/5063677707/jobs/9090538663#step:8:1).
Run ## --------------------------------------------------------------------
Show testthat output
Run actions/upload-artifact@v3
Warning: No files were found with the provided path: /home/runner/work/covidcast-indicators/covidcast-indicators/backfill_corrections/delphiBackfillCorrection/check. No artifacts will be uploaded.
```