### PR TITLE
Revert "Request rcmdcheck to be installed with dependencies in backfill corrections CI"

### DIFF
--- a/.github/workflows/backfill-corr-ci.yml
+++ b/.github/workflows/backfill-corr-ci.yml
@@ -58,7 +58,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
           working-directory: backfill_corrections/delphiBackfillCorrection
           upgrade: 'TRUE'
       - name: Check package


### PR DESCRIPTION
Reverts cmu-delphi/covidcast-indicators#1850 due to ci [failure](https://github.com/cmu-delphi/covidcast-indicators/actions/runs/5081193622/jobs/9129194459).