### PR TITLE
Set backfill corrections pip to 22.0.3

### DIFF
--- a/.github/workflows/backfill-corr-ci.yml
+++ b/.github/workflows/backfill-corr-ci.yml
@@ -58,6 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          extra-packages: any::rcmdcheck
           working-directory: backfill_corrections/delphiBackfillCorrection
           upgrade: 'TRUE'
       - name: Check package

--- a/backfill_corrections/Dockerfile
+++ b/backfill_corrections/Dockerfile
@@ -17,7 +17,8 @@ RUN ln -s -f /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN apt-get update && apt-get install -qq -y \
     libglpk-dev\
     python3-venv \
-    python3-dev
+    python3-dev \
+    python3-pip
 
 RUN python3 -m pip install --upgrade pip==22.0.3 
 

--- a/backfill_corrections/Dockerfile
+++ b/backfill_corrections/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && apt-get install -qq -y \
     python3-venv \
     python3-dev
 
+RUN python3 -m pip install --upgrade pip==22.0.3 
+
 RUN install2.r --error \
     roxygen2 \
     Rglpk \


### PR DESCRIPTION
### Description
- Set backfill corrections pip to 22.0.3 to solve current CI [failed runs](https://github.com/cmu-delphi/covidcast-indicators/actions/runs/5086068679/jobs/9140173022).
- Restore Nat's change: #1850

