### PR TITLE
bug fix(backfill docker): upgrade pip in the right place

### DIFF
--- a/backfill_corrections/Dockerfile
+++ b/backfill_corrections/Dockerfile
@@ -20,8 +20,6 @@ RUN apt-get update && apt-get install -qq -y \
     python3-dev \
     python3-pip
 
-RUN python3 -m pip install --upgrade pip==22.0.3 
-
 RUN install2.r --error \
     roxygen2 \
     Rglpk \

--- a/backfill_corrections/Makefile
+++ b/backfill_corrections/Makefile
@@ -56,6 +56,7 @@ install-python:
 	fi
 	python3 -m venv env
 	source env/bin/activate && \
+	python -m pip install --upgrade pip && \
 	pip install wheel && \
 	pip install --timeout 1000 delphi_utils
 


### PR DESCRIPTION
@minhkhul and I have been trying to fix this for a couple days now, see #1852

In the previous attempted fix, we accidentally upgraded pip outside the venv, so this fixes that.