### PR TITLE
Make validator raise for status

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -111,9 +111,10 @@ def get_geo_signal_combos(data_source):
     Cross references based on combinations reported available by COVIDcast metadata.
     """
     # Maps data_source name with what's in the API, lists used in case of multiple names
-
+    meta_response = requests.get("https://api.covidcast.cmu.edu/epidata/covidcast/meta")
+    meta_response.raise_for_status()
     source_signal_mappings = {i['source']:i['db_source'] for i in
-        requests.get("https://api.covidcast.cmu.edu/epidata/covidcast/meta").json()}
+        meta_response.json()}
     meta = covidcast.metadata()
     source_meta = meta[meta['data_source'] == data_source]
     # Need to convert np.records to tuples so they are hashable and can be used in sets and dicts.
@@ -139,6 +140,7 @@ def get_geo_signal_combos(data_source):
                 epidata_signal = requests.get(
                     "https://api.covidcast.cmu.edu/epidata/covidcast/meta",
                     params={'signal': f"{src}:{sig}"})
+                epidata_signal.raise_for_status()
                 # Not an active signal
                 active_status = [val['active'] for i in epidata_signal.json()
                     for val in i['signals']]

--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -19,6 +19,7 @@ required = [
     "pylint==2.8.3",
     "pytest",
     "pytest-cov",
+    "requests-mock",
     "slackclient",
     "structlog",
     "xlrd"

--- a/_delphi_utils_python/tests/validator/test_datafetcher.py
+++ b/_delphi_utils_python/tests/validator/test_datafetcher.py
@@ -4,11 +4,15 @@ from datetime import date
 import mock
 import numpy as np
 import pandas as pd
+import pytest
+from requests.exceptions import HTTPError
+import requests_mock
 from delphi_utils.validator.datafetcher import (FILENAME_REGEX,
                                                 make_date_filter,
                                                 get_geo_signal_combos,
                                                 threaded_api_calls)
 from delphi_utils.validator.errors import ValidationFailure
+
 
 
 class TestDataFetcher:
@@ -24,6 +28,7 @@ class TestDataFetcher:
     # Solution from https://stackoverflow.com/questions/15753390/
     #how-can-i-mock-requests-and-the-response
     def mocked_requests_get(*args, **kwargs):
+        # TODO #1863: convert to requests_mock
         class MockResponse:
             def __init__(self, json_data, status_code):
                 self.json_data = json_data
@@ -31,6 +36,10 @@ class TestDataFetcher:
 
             def json(self):
                 return self.json_data
+
+            def raise_for_status(self):
+                if self.status_code != 200:
+                    raise HTTPError()
         if len(kwargs) == 0:
             return MockResponse([{'source': 'chng', 'db_source': 'chng'},
                 {'source': 'covid-act-now', 'db_source': 'covid-act-now'}], 200)
@@ -38,6 +47,13 @@ class TestDataFetcher:
             return MockResponse([{"signals": [{"active": False}]}], 200)
         else:
             return MockResponse([{"signals": [{"active": True}]}], 200)
+
+    @requests_mock.Mocker(kw="mock_requests")
+    def test_bad_api_key(self, **kwargs):
+        kwargs["mock_requests"].get("https://api.covidcast.cmu.edu/epidata/covidcast/meta", status_code=429)
+        with pytest.raises(HTTPError):
+            get_geo_signal_combos("chng")
+
     @mock.patch('requests.get', side_effect=mocked_requests_get)
     @mock.patch("covidcast.metadata")
     def test_get_geo_signal_combos(self, mock_metadata, mock_get):

--- a/_delphi_utils_python/tests/validator/test_datafetcher.py
+++ b/_delphi_utils_python/tests/validator/test_datafetcher.py
@@ -48,6 +48,8 @@ class TestDataFetcher:
         else:
             return MockResponse([{"signals": [{"active": True}]}], 200)
 
+    # the `kw` approach is needed here because otherwise pytest thinks the 
+    # requests_mock arg is supposed to be a fixture
     @requests_mock.Mocker(kw="mock_requests")
     def test_bad_api_key(self, **kwargs):
         kwargs["mock_requests"].get("https://api.covidcast.cmu.edu/epidata/covidcast/meta", status_code=429)


### PR DESCRIPTION
### Description
Type of change (bug fix, new feature, etc), brief description, and motivation for these changes.

* makes validator raise for status when encountering server errors instead of trying to parse the server error as JSON
* adds requests-mock library, which seems worth it
* leaves TODOs to convert the remaining manual requests mocks

### Changelog
Itemize code/test/documentation changes and files added/removed.
- validator datafetcher.py: raise_for_status on all requests
- status.py: include requests-mock library
- tests/validator/test_datafetcher.py: use requests-mock to properly mock a request that fails with an HTTP error code; ensure such responses are handled properly by the datafetcher code

### Fixes 
- Fixes bad error messages from validator when encountering server errors
