### PR TITLE
Clarify API reference data error messages; authenticate API reference data requests

### DIFF
--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -10,7 +10,6 @@ import requests
 import pandas as pd
 import numpy as np
 import covidcast
-from .. import read_params
 from .errors import APIDataFetchError, ValidationFailure
 
 FILENAME_REGEX = re.compile(
@@ -103,15 +102,13 @@ def load_csv(path):
         })
 
 
-def get_geo_signal_combos(data_source):
+def get_geo_signal_combos(data_source, api_key):
     """
     Get list of geo type-signal type combinations that we expect to see.
 
     Cross references based on combinations reported available by COVIDcast metadata.
     """
-    params = read_params()
-    assert "validation" in params
-    api_key = ("epidata", params["validation"]["common"]["api_credentials"])
+    api_key = ("epidata", api_key)
     # Maps data_source name with what's in the API, lists used in case of multiple names
     meta_response = requests.get("https://api.covidcast.cmu.edu/epidata/covidcast/meta",
                                  auth=api_key)

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -166,14 +166,12 @@ def fetch_api_reference(data_source, start_date, end_date, geo_type, signal_type
         api_df = covidcast.signal(
             data_source, signal_type, start_date, end_date, geo_type)
 
+    error_context = f"when fetching reference data from {start_date} to {end_date} " +\
+        f"for data source: {data_source}, signal type: {signal_type}, geo type: {geo_type}"
+    if api_df is None:
+        raise APIDataFetchError("Error: no API data was returned " + error_context)
     if not isinstance(api_df, pd.DataFrame):
-        custom_msg = "Error fetching data from " + str(start_date) + \
-                     " to " + str(end_date) + \
-                     " for data source: " + data_source + \
-                     ", signal type: " + signal_type + \
-                     ", geo type: " + geo_type
-
-        raise APIDataFetchError(custom_msg)
+        raise APIDataFetchError("Error: API return value was not a dataframe " + error_context)
 
     column_names = ["geo_id", "val",
                     "se", "sample_size", "time_value"]

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -220,11 +220,13 @@ def get_one_api_df(data_source, min_date, max_date,
     dict_lock.release()
 
 
-def threaded_api_calls(data_source, min_date, max_date, geo_signal_combos, n_threads=32):
+MAX_ALLOWED_THREADS = 32
+
+def threaded_api_calls(data_source, min_date, max_date, geo_signal_combos, n_threads=MAX_ALLOWED_THREADS):
     """Get data from API for all geo-signal combinations in a threaded way."""
-    if n_threads > 32:
-        n_threads = 32
-        print("Warning: Don't run more than 32 threads at once due "
+    if n_threads > MAX_ALLOWED_THREADS:
+        n_threads = MAX_ALLOWED_THREADS
+        warnings.warn(f"Warning: Don't run more than {MAX_ALLOWED_THREADS} threads at once due "
                 + "to API resource limitations")
 
     output_dict = dict()

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -165,6 +165,7 @@ def fetch_api_reference(data_source, start_date, end_date, geo_type, signal_type
 
     error_context = f"when fetching reference data from {start_date} to {end_date} " +\
         f"for data source: {data_source}, signal type: {signal_type}, geo type: {geo_type}"
+
     if api_df is None:
         raise APIDataFetchError("Error: no API data was returned " + error_context)
     if not isinstance(api_df, pd.DataFrame):
@@ -217,7 +218,8 @@ def get_one_api_df(data_source, min_date, max_date,
 
 MAX_ALLOWED_THREADS = 32
 
-def threaded_api_calls(data_source, min_date, max_date, geo_signal_combos, n_threads=MAX_ALLOWED_THREADS):
+def threaded_api_calls(data_source, min_date, max_date,
+                       geo_signal_combos, n_threads=MAX_ALLOWED_THREADS):
     """Get data from API for all geo-signal combinations in a threaded way."""
     if n_threads > MAX_ALLOWED_THREADS:
         n_threads = MAX_ALLOWED_THREADS

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -223,8 +223,8 @@ def threaded_api_calls(data_source, min_date, max_date,
     """Get data from API for all geo-signal combinations in a threaded way."""
     if n_threads > MAX_ALLOWED_THREADS:
         n_threads = MAX_ALLOWED_THREADS
-        warnings.warn(f"Warning: instead of requested thread count, using only {MAX_ALLOWED_THREADS} threads due "
-                + "to API resource limitations")
+        warnings.warn("Warning: instead of requested thread count, using " + \
+            f"only {MAX_ALLOWED_THREADS} threads due to API resource limitations")
 
     output_dict = dict()
     dict_lock = threading.Lock()

--- a/_delphi_utils_python/delphi_utils/validator/datafetcher.py
+++ b/_delphi_utils_python/delphi_utils/validator/datafetcher.py
@@ -223,7 +223,7 @@ def threaded_api_calls(data_source, min_date, max_date,
     """Get data from API for all geo-signal combinations in a threaded way."""
     if n_threads > MAX_ALLOWED_THREADS:
         n_threads = MAX_ALLOWED_THREADS
-        warnings.warn(f"Warning: Don't run more than {MAX_ALLOWED_THREADS} threads at once due "
+        warnings.warn(f"Warning: instead of requested thread count, using only {MAX_ALLOWED_THREADS} threads due "
                 + "to API resource limitations")
 
     output_dict = dict()

--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -51,7 +51,7 @@ class DynamicValidator:
 
         self.params = self.Parameters(
             data_source=common_params["data_source"],
-            api_key = params["common"]["api_credentials"],
+            api_key = common_params["api_credentials"],
             time_window=TimeWindow.from_params(common_params["end_date"],
                                                common_params["span_length"]),
             generation_date=date.today(),

--- a/_delphi_utils_python/delphi_utils/validator/dynamic.py
+++ b/_delphi_utils_python/delphi_utils/validator/dynamic.py
@@ -15,7 +15,7 @@ class DynamicValidator:
     """Class for validation of static properties of individual datasets."""
 
     @dataclass
-    class Parameters:
+    class Parameters: # pylint: disable=too-many-instance-attributes
         """Configuration parameters."""
 
         # data source name, one of
@@ -82,7 +82,8 @@ class DynamicValidator:
         covidcast.use_api_key(self.params.api_key)
 
         # Get all expected combinations of geo_type and signal.
-        geo_signal_combos = get_geo_signal_combos(self.params.data_source, api_key = self.params.api_key)
+        geo_signal_combos = get_geo_signal_combos(self.params.data_source,
+                                                  api_key = self.params.api_key)
 
         all_api_df = threaded_api_calls(self.params.data_source,
                                         self.params.time_window.start_date - outlier_lookbehind,

--- a/_delphi_utils_python/tests/validator/test_datafetcher.py
+++ b/_delphi_utils_python/tests/validator/test_datafetcher.py
@@ -54,7 +54,7 @@ class TestDataFetcher:
     def test_bad_api_key(self, **kwargs):
         kwargs["mock_requests"].get("https://api.covidcast.cmu.edu/epidata/covidcast/meta", status_code=429)
         with pytest.raises(HTTPError):
-            get_geo_signal_combos("chng")
+            get_geo_signal_combos("chng", api_key="")
 
     @mock.patch('requests.get', side_effect=mocked_requests_get)
     @mock.patch("covidcast.metadata")
@@ -78,11 +78,11 @@ class TestDataFetcher:
                                                                 "hrr", "msa", "msa",
                                                                 "state"]
                                                   })
-        assert set(get_geo_signal_combos("chng")) == set(
+        assert set(get_geo_signal_combos("chng", api_key="")) == set(
             [("state", "smoothed_outpatient_cli"),
              ("state", "smoothed_outpatient_covid"),
              ("county", "smoothed_outpatient_covid")])
-        assert set(get_geo_signal_combos("covid-act-now")) == set(
+        assert set(get_geo_signal_combos("covid-act-now", api_key="")) == set(
             [("hrr", "pcr_specimen_positivity_rate"),
              ("msa", "pcr_specimen_positivity_rate"),
              ("msa", "pcr_specimen_total_tests")])
@@ -138,7 +138,8 @@ class TestDataFetcher:
             ("state", "b"): ValidationFailure("api_data_fetch_error",
                                               geo_type="state",
                                               signal="b",
-                                             message="Error fetching data from 2020-03-10 "
+                                             message="Error: no API data was returned when "
+                                             "fetching reference data from 2020-03-10 "
                                              "to 2020-06-10 for data source: "
                                              "source, signal type: b, geo type: state")
         }

--- a/_delphi_utils_python/tests/validator/test_dynamic.py
+++ b/_delphi_utils_python/tests/validator/test_dynamic.py
@@ -11,7 +11,8 @@ class TestReferencePadding:
         "common": {
             "data_source": "",
             "span_length": 1,
-            "end_date": "2020-09-02"
+            "end_date": "2020-09-02",
+            "api_credentials": ""
         }
     }
 

--- a/_delphi_utils_python/tests/validator/test_dynamic.py
+++ b/_delphi_utils_python/tests/validator/test_dynamic.py
@@ -82,7 +82,8 @@ class TestCheckRapidChange:
         "common": {
             "data_source": "",
             "span_length": 1,
-            "end_date": "2020-09-02"
+            "end_date": "2020-09-02",
+            "api_credentials": ""
         }
     }
 
@@ -115,7 +116,8 @@ class TestCheckNaVals:
         "common": {
             "data_source": "",
             "span_length": 14,
-            "end_date": "2020-09-02"
+            "end_date": "2020-09-02",
+            "api_credentials": ""
         }
     }
     def test_missing(self):
@@ -138,7 +140,8 @@ class TestCheckAvgValDiffs:
         "common": {
             "data_source": "",
             "span_length": 1,
-            "end_date": "2020-09-02"
+            "end_date": "2020-09-02",
+            "api_credentials": ""
         }
     }
 
@@ -279,7 +282,8 @@ class TestDataOutlier:
         "common": {
             "data_source": "",
             "span_length": 1,
-            "end_date": "2020-09-02"
+            "end_date": "2020-09-02",
+            "api_credentials": ""
         }
     }
     pd.set_option("display.max_rows", None, "display.max_columns", None)
@@ -472,7 +476,8 @@ class TestDateComparison:
         "common": {
             "data_source": "",
             "span_length": 1,
-            "end_date": "2020-09-02"
+            "end_date": "2020-09-02",
+            "api_credentials": ""
         }
     }
 

--- a/_delphi_utils_python/tests/validator/test_validator.py
+++ b/_delphi_utils_python/tests/validator/test_validator.py
@@ -15,7 +15,8 @@ class TestValidatorInitialization:
                 "common": {
                     "data_source": "",
                     "span_length": 0,
-                    "end_date": "2020-09-01"
+                    "end_date": "2020-09-01",
+                    "api_credentials": ""
                 }
             }
         }
@@ -46,7 +47,8 @@ class TestValidatorInitialization:
                                            "signal": "b"},
                                           {"check_name":"c",
                                            "date": None,
-                                           "geo_type": "d"}]
+                                           "geo_type": "d"}],
+                    "api_credentials": ""
                 }
             }
         }
@@ -76,7 +78,8 @@ class TestValidatorInitialization:
                                                "date": None,
                                                "geo_type": "d"},
                                               {"check_name": "a",
-                                               "fake": "b"}]
+                                               "fake": "b"}],
+                        "api_credentials": ""
                     }
                 }
             })
@@ -98,7 +101,8 @@ class TestValidatorInitialization:
                                           {"check_name":"c",
                                            "date": None,
                                            "geo_type": "d"},
-                                          ["ab"]]
+                                          ["ab"]],
+                    "api_credentials": ""
                     }
                 }
             })


### PR DESCRIPTION
### Description
Address this [comment](https://delphi-org.slack.com/archives/C04LJ169KNF/p1689872781398279?thread_ts=1689872541.367489&cid=C04LJ169KNF). `google-symptoms` validation was [failing with an ambiguous error](https://delphi-org.slack.com/archives/C04LJ169KNF/p1689872541367489) message, `Error fetching data from 2023-06-20 to 2023-07-17 for data source: google-symptoms...`.

To enable better debugging in the future, change the wording to be more specific and add a check for a `None` API result. Also authenticate COVIDcast requests in a more general way, adding the API key to the `Parameters` object.

### Changelog
- `delphi_utils/validator/dynamic.py`
- `delphi_utils/validator/datafetcher.py`