### PR TITLE
Increase `hhs` expected lag settings by 1 week to account for new delivery schedule

### DIFF
--- a/ansible/templates/hhs_hosp-params-prod.json.j2
+++ b/ansible/templates/hhs_hosp-params-prod.json.j2
@@ -8,8 +8,8 @@
       "data_source": "hhs",
       "api_credentials": "{{ validation_api_key }}",
       "span_length": 14,
-      "min_expected_lag": {"all": "1"},
-      "max_expected_lag": {"all": "7"},
+      "min_expected_lag": {"all": "8"},
+      "max_expected_lag": {"all": "14"},
       "dry_run": true,
       "suppressed_errors": []
     },

--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -48,7 +48,7 @@
       "maintainers": []
     },
     "hhs": {
-      "max_age":8,
+      "max_age":15,
       "maintainers": []
     }
   }

--- a/hhs_hosp/params.json.template
+++ b/hhs_hosp/params.json.template
@@ -7,8 +7,8 @@
     "common": {
       "data_source": "hhs",
       "span_length": 14,
-      "min_expected_lag": {"all": "1"},
-      "max_expected_lag": {"all": "7"},
+      "min_expected_lag": {"all": "8"},
+      "max_expected_lag": {"all": "14"},
       "dry_run": true,
       "suppressed_errors": []
     },

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -47,7 +47,7 @@
       "maintainers": []
     },
     "hhs": {
-      "max_age":8,
+      "max_age":15,
       "maintainers": []
     }
   }


### PR DESCRIPTION
### Description
The reporting lag of the `hhs` sources has increased, causing sirCAL and validator to [alert](https://delphi-org.slack.com/archives/C01LZ3A2UMU/p1689912199555889) when expected lags are exceeded.

E.g. both [state](https://healthdata.gov/dataset/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/6xf2-c3ie) and [state timeseries](https://healthdata.gov/Hospital/COVID-19-Reported-Patient-Impact-and-Hospital-Capa/g62h-syeh) sources were updated today, but the most recent data available is for July 15 (corresponds to lag of 9 days when sirCAL checks, based on our indicator + sirCAL schedule).

This seems to be part of a change in reporting schedule. Both sources say they now report only weekly, on Fridays, instead of "regularly" which historically was once or more per week (and sometimes every day). It appears that each Friday release includes daily data from the last complete week (Sun-Sat).

### Changelog
- sirCAL local and production template `params.json`
- `hhs` local and production template `params.json`

### Fixes 
Ongoing alerts from sirCAL about `hhs` being older than expected.
