### PR TITLE
Add multiprocessing to the Quidel indicator

### DIFF
--- a/quidel_covidtest/.pylintrc
+++ b/quidel_covidtest/.pylintrc
@@ -9,6 +9,7 @@ disable=logging-format-interpolation,
     no-self-use,
     # Allow pytest classes to have one test.
     too-few-public-methods
+enable=useless-suppression
 
 [BASIC]
 

--- a/quidel_covidtest/delphi_quidel_covidtest/geo_maps.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/geo_maps.py
@@ -75,11 +75,11 @@ def add_parent_state(data, geo_res, geo_key):
     """
     fips_to_state = GMPR.get_crosswalk(from_code="fips", to_code="state")
     if geo_res == "county":
-        mix_map = fips_to_state[["fips", "state_id"]]  # pylint: disable=unsubscriptable-object
+        mix_map = fips_to_state[["fips", "state_id"]]
     else:
         fips_to_geo_res = GMPR.get_crosswalk(from_code="fips", to_code=geo_res)
         mix_map = fips_to_geo_res[["fips", geo_res]].merge(
-                fips_to_state[["fips", "state_id"]],  # pylint: disable=unsubscriptable-object
+                fips_to_state[["fips", "state_id"]],
                 on="fips",
                 how="inner")
         mix_map = GMPR.add_population_column(mix_map, "fips").groupby(

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -152,10 +152,10 @@ def run_module(params: Dict[str, Any]):
             pool_results = [(proc.get(), sensor_name) for (proc, sensor_name) in pool_results]
             for state_df, sensor_name in pool_results:
                 dates = create_export_csv(state_df, geo_res=geo_res,
-                                            sensor=sensor_name,
-                                            export_dir=export_dir,
-                                            start_date=export_start_date,
-                                            end_date=export_end_date)
+                                          sensor=sensor_name,
+                                          export_dir=export_dir,
+                                          start_date=export_start_date,
+                                          end_date=export_end_date)
                 if len(dates) > 0:
                     stats.append((max(dates), len(dates)))
     assert geo_res == "state" # Make sure geo_groups is for state level
@@ -186,10 +186,10 @@ def run_module(params: Dict[str, Any]):
             pool_results = [(proc.get(), sensor_name) for (proc, sensor_name) in pool_results]
             for res_df, sensor_name in pool_results:
                 dates = create_export_csv(res_df, geo_res=geo_res,
-                                            sensor=sensor_name, export_dir=export_dir,
-                                            start_date=export_start_date,
-                                            end_date=export_end_date,
-                                            remove_null_samples=True)
+                                          sensor=sensor_name, export_dir=export_dir,
+                                          start_date=export_start_date,
+                                          end_date=export_end_date,
+                                          remove_null_samples=True)
                 if len(dates) > 0:
                     stats.append((max(dates), len(dates)))
 

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -204,9 +204,6 @@ def run_module(params: Dict[str, Any]):
                         sensor_name = sensor
                     else:
                         sensor_name = "_".join([sensor, agegroup])
-                    logger.info("Generating signal and exporting to CSV",
-                                geo_res=geo_res,
-                                sensor=sensor_name)
                     pool_results.append(
                         pool.apply_async(
                             generate_and_export_for_parent_geo,

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -56,7 +56,7 @@ def get_smooth_info(sensors, _SMOOTHERS):
             smoothers[sensor] = smoothers.pop(RAW_TEST_PER_DEVICE)
     return smoothers
 
-def run_module(params: Dict[str, Any]):
+def run_module(params: Dict[str, Any]): # pylint: disable=too-many-statements
     """Run the quidel_covidtest indicator.
 
     The `params` argument is expected to have the following structure:

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -229,7 +229,6 @@ def run_module(params: Dict[str, Any]):
             if len(dates) > 0:
                 stats.append((max(dates), len(dates)))
 
-
     # Export the cache file if the pipeline runs successfully.
     # Otherwise, don't update the cache file
     update_cache_file(df, _end_date, cache_dir)

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -57,7 +57,7 @@ def get_smooth_info(sensors, _SMOOTHERS):
             smoothers[sensor] = smoothers.pop(RAW_TEST_PER_DEVICE)
     return smoothers
 
-def generate_and_export_for_nonparent_geo(state_groups, res_key, smooth, device,
+def generate_and_export_for_nonparent_geo(geo_groups, res_key, smooth, device,
                                           first_date, last_date, suffix, # generate args
                                           geo_res, sensor_name, export_dir,
                                           export_start_date, export_end_date, # export args
@@ -68,7 +68,7 @@ def generate_and_export_for_nonparent_geo(state_groups, res_key, smooth, device,
             geo_res=geo_res,
             sensor=sensor_name,
             pid=os.getpid())
-    res_df = generate_sensor_for_nonparent_geo(state_groups, res_key, smooth, device,
+    res_df = generate_sensor_for_nonparent_geo(geo_groups, res_key, smooth, device,
                                                first_date, last_date, suffix)
     dates = create_export_csv(res_df, geo_res=geo_res,
                               sensor=sensor_name, export_dir=export_dir,
@@ -76,7 +76,7 @@ def generate_and_export_for_nonparent_geo(state_groups, res_key, smooth, device,
                               end_date=export_end_date)
     return dates
 
-def generate_and_export_for_parent_geo(state_groups, geo_data, res_key, smooth, device,
+def generate_and_export_for_parent_geo(geo_groups, geo_data, res_key, smooth, device,
                                        first_date, last_date, suffix, # generate args
                                        geo_res, sensor_name, export_dir,
                                        export_start_date, export_end_date, # export args
@@ -87,7 +87,7 @@ def generate_and_export_for_parent_geo(state_groups, geo_data, res_key, smooth, 
                 geo_res=geo_res,
                 sensor=sensor_name,
                 pid=os.getpid())
-    res_df = generate_sensor_for_parent_geo(state_groups, geo_data, res_key, smooth, device,
+    res_df = generate_sensor_for_parent_geo(geo_groups, geo_data, res_key, smooth, device,
                                             first_date, last_date, suffix)
     dates = create_export_csv(res_df, geo_res=geo_res,
                               sensor=sensor_name, export_dir=export_dir,

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -6,8 +6,7 @@ when the module is run with `python -m MODULE_NAME`.
 """
 import atexit
 from datetime import datetime
-import multiprocessing
-from multiprocessing import Manager, Pool, cpu_count
+from multiprocessing import Manager, Pool, cpu_count, current_process
 import os
 import time
 from typing import Dict, Any
@@ -70,7 +69,7 @@ def generate_and_export_for_nonparent_geo(geo_groups, res_key, smooth, device,
         logger.info("Generating signal and exporting to CSV",
                 geo_res=geo_res,
                 sensor=sensor_name,
-                pid=multiprocessing.current_process().pid)
+                pid=current_process().pid)
     res_df = generate_sensor_for_nonparent_geo(geo_groups, res_key, smooth, device,
                                                first_date, last_date, suffix)
     dates = create_export_csv(res_df, geo_res=geo_res,
@@ -91,7 +90,7 @@ def generate_and_export_for_parent_geo(geo_groups, geo_data, res_key, smooth, de
         logger.info("Generating signal and exporting to CSV",
                     geo_res=geo_res,
                     sensor=sensor_name,
-                    pid=multiprocessing.current_process().pid)
+                    pid=current_process().pid)
     res_df = generate_sensor_for_parent_geo(geo_groups, geo_data, res_key, smooth, device,
                                             first_date, last_date, suffix)
     dates = create_export_csv(res_df, geo_res=geo_res,

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -169,7 +169,8 @@ def run_module(params: Dict[str, Any]):
     smoothers = get_smooth_info(sensors, SMOOTHERS)
     n_cpu = min(8, cpu_count()) # for parallelization
     with Manager() as manager:
-         # for using loggers in multiple threads
+        # for using loggers in multiple threads
+        # disabled due to a Pylint bug, resolved by version bump (#1886)
         lock = manager.Lock() # pylint: disable=no-member
         logger.info("Parallelizing sensor generation", n_cpu=n_cpu)
         with Pool(n_cpu) as pool:


### PR DESCRIPTION
### Description
Parallelizes the long-running `generate_sensor_for_*_geo` functions in the Quidel indicator - see #1547

In a local test run, this change made the total runtime for the `pull` step of this indicator 4.2x faster, and the runtime of the `generate` functions 6x faster:
 
<img width="1193" alt="Indicator runtime before the parallelization" src="https://github.com/cmu-delphi/covidcast-indicators/assets/13783592/a8ada8d0-b02b-4827-b68a-6009df597931">

_Indicator runtime before the parallelization - note the `generate_sensor_for_parent_geo` call..._

<img width="1189" alt="Indicator runtime after the parallelization" src="https://github.com/cmu-delphi/covidcast-indicators/assets/13783592/3f53b752-730c-44cf-bab7-a1be8039bc29">

_Indicator runtime after the parallelization - `generate` call replaced by multiprocessing functions._

### Changelog
- Adds multiprocessing to Quidel indicator.