### PR TITLE
Turn sircal alerts back on for all chng signals

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -14,8 +14,7 @@
     },
     "chng": {
       "max_age": 6,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
-      "retired-signals": ["smoothed_outpatient_covid", "smoothed_adj_outpatient_covid", "smoothed_outpatient_cli", "smoothed_adj_outpatient_cli"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "google-symptoms": {
       "max_age": 6,


### PR DESCRIPTION
### Description
SirCAL alerts were temporarily turned off in https://github.com/cmu-delphi/covidcast-indicators/pull/1313 and never turned back on.

### Changelog
- sirCAL template and local params files

### Fixes 
We want to get alerts!
