### PR TITLE
Support `chng-fips` county group reporting in `chng` for privacy

### DIFF
--- a/ansible/templates/changehc-params-prod.json.j2
+++ b/ansible/templates/changehc-params-prod.json.j2
@@ -23,7 +23,7 @@
     "n_waiting_days": 3,
     "se": false,
     "parallel": false,
-    "geos": ["state", "msa", "hrr", "county", "hhs", "nation"],
+    "geos": ["state", "msa", "hrr", "chng-fips", "hhs", "nation"],
     "weekday": [true, false],
     "types": ["covid","cli","flu"],
     "wip_signal": "",

--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -14,8 +14,7 @@
     },
     "chng": {
       "max_age": 6,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
-      "retired-signals": ["smoothed_outpatient_covid", "smoothed_adj_outpatient_covid", "smoothed_outpatient_cli", "smoothed_adj_outpatient_cli"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
     },
     "google-symptoms": {
       "max_age": 6,

--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -14,7 +14,15 @@
     },
     "chng": {
       "max_age": 6,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
+      "retired-signals": [
+        ["smoothed_outpatient_covid", "county"],
+        ["smoothed_adj_outpatient_covid", "county"],
+        ["smoothed_outpatient_cli", "county"],
+        ["smoothed_adj_outpatient_cli", "county"],
+        ["smoothed_outpatient_flu", "county"],
+        ["smoothed_adj_outpatient_flu", "county"]
+      ]
     },
     "google-symptoms": {
       "max_age": 6,

--- a/changehc/params.json.template
+++ b/changehc/params.json.template
@@ -24,9 +24,9 @@
     "n_waiting_days": 3,
     "se": false,
     "parallel": false,
-    "geos": ["state", "msa", "hrr", "county", "nation", "hhs"],
+    "geos": ["state", "msa", "hrr", "chng-fips", "nation", "hhs"],
     "weekday": [true, false],
-    "types": ["covid","cli"],
+    "types": ["covid","cli", "flu"],
     "wip_signal": "",
     "ftp_conn": {
       "host": "",

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -14,7 +14,15 @@
     },
     "chng": {
       "max_age": 6,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
+      "retired-signals": [
+        ["smoothed_outpatient_covid", "county"],
+        ["smoothed_adj_outpatient_covid", "county"],
+        ["smoothed_outpatient_cli", "county"],
+        ["smoothed_adj_outpatient_cli", "county"],
+        ["smoothed_outpatient_flu", "county"],
+        ["smoothed_adj_outpatient_flu", "county"]
+      ]
     },
     "google-symptoms": {
       "max_age": 6,


### PR DESCRIPTION
### Description
Report signals for `chng-fips` county groups instead of counties. See the [geomapper support PR](https://github.com/cmu-delphi/covidcast-indicators/pull/1787) for more context.

Turn off sirCAL alerting for county versions of all signals using [this format](https://github.com/cmu-delphi/covidcast-indicators/pull/1233).

#### Big Note
From local testing, it looks like the new county groups are never actually reported... This doesn't seem to be a definitional issue, that is, theoretically county groups could be reported if they had enough total claims reported. But because the county groups are low-population areas in general, they tend not to have enough total claims reported to be included in the output, based on our filtering logic.

Do we want to do more investigation here? I started in on population comparisons (do counties of similar population to county groups also get filtered out? Some megacounties do, at least) but didn't do anything super formal or thorough.

Non-adjusted `county` and `chng-fips` values match exactly (although `county` files have an extra entry for a county called "\N"??); adjusted `county` and `chng-fips` values are very similar but not exactly the same.

### Changelog
- `update_sensor.py`
- Local and production template params for `chng` and sirCAL.
