### PR TITLE
bring loggers in sync and add multiproc capabilities

### DIFF
--- a/_delphi_utils_python/delphi_utils/logger.py
+++ b/_delphi_utils_python/delphi_utils/logger.py
@@ -76,9 +76,7 @@ def get_structured_logger(name=__name__,
         handlers=[logging.StreamHandler()])
 
     def add_pid(_logger, _method_name, event_dict):
-        """
-        Add current PID to the event dict.
-        """
+        """Add current PID to the event dict."""
         event_dict["pid"] = os.getpid()
         return event_dict
 
@@ -149,25 +147,29 @@ class LoggerThread():
 
     class SubLogger():
         """
-        multiprocessing-safe logger-like interface
-        to convey log messages to a listening LoggerThread
+        Multiprocessing-safe logger-like interface
+        to convey log messages to a listening LoggerThread.
         """
+
         def __init__(self, queue):
             self.queue = queue
+
         def _log(self, level, *args, **kwargs):
             kwargs_plus = {'sub_pid': multiprocessing.current_process().pid}
             kwargs_plus.update(kwargs)
             self.queue.put([level, args, kwargs_plus])
+
         def info(self, *args, **kwargs):
-            """log an INFO level message"""
+            """Log an INFO level message."""
             self._log(logging.INFO, *args, **kwargs)
+
         def warn(self, *args, **kwargs):
-            """log an WARN level message"""
+            """Log a WARN level message."""
             self._log(logging.WARN, *args, **kwargs)
 
 
     def get_sublogger(self):
-        """accessor method to retrieve a SubLogger for this LoggerThread"""
+        """Accessor method to retrieve a SubLogger for this LoggerThread."""
         return self.sublogger
 
     def __init__(self, logger, q=None):
@@ -203,7 +205,7 @@ class LoggerThread():
         self.running = True
 
     def stop(self):
-        """terminate this LoggerThread"""
+        """Terminate this LoggerThread."""
         if not self.running:
             self.logger.warn('thread already stopped')
             return
@@ -218,7 +220,7 @@ class LoggerThread():
 @contextlib.contextmanager
 def pool_and_threadedlogger(logger, *poolargs):
     """
-    emulates the multiprocessing.Pool() context manager,
+    Emulates the multiprocessing.Pool() context manager,
     but also provides a logger that can be used by pool workers.
     """
     with multiprocessing.Manager() as manager:

--- a/_delphi_utils_python/delphi_utils/logger.py
+++ b/_delphi_utils_python/delphi_utils/logger.py
@@ -1,21 +1,38 @@
-"""Structured logger utility for creating JSON logs in Delphi pipelines."""
+"""Structured logger utility for creating JSON logs."""
+
+# the Delphi group uses two ~identical versions of this file.
+# try to keep them in sync with edits, for sanity.
+#   https://github.com/cmu-delphi/covidcast-indicators/blob/main/_delphi_utils_python/delphi_utils/logger.py
+#   https://github.com/cmu-delphi/delphi-epidata/blob/dev/src/common/logger.py
+
 import logging
+import os
+import structlog
 import sys
 import threading
-import structlog
+import traceback
 
 
 def handle_exceptions(logger):
     """Handle exceptions using the provided logger."""
-    def exception_handler(etype, value, traceback):
-        logger.exception("Top-level exception occurred",
-                         exc_info=(etype, value, traceback))
 
-    def multithread_exception_handler(args):
-        exception_handler(args.exc_type, args.exc_value, args.exc_traceback)
+    def exception_handler(scope, etype, value, traceback):
+        logger.exception("Top-level exception occurred", scope=scope, exc_info=(etype, value, traceback))
 
-    sys.excepthook = exception_handler
-    threading.excepthook = multithread_exception_handler
+    def sys_exception_handler(etype, value, traceback):
+        exception_handler("sys", etype, value, traceback)
+
+    def threading_exception_handler(args):
+        if args.exc_type == SystemExit and args.exc_value.code == 0:
+            # `sys.exit(0)` is considered "successful termination":
+            #   https://docs.python.org/3/library/sys.html#sys.exit
+            logger.debug(f"normal thread exit", thread=args.thread,
+                        stack="".join(traceback.format_exception(args.exc_type, args.exc_value, args.exc_traceback)))
+        else:
+            exception_handler(f"thread: {args.thread}", args.exc_type, args.exc_value, args.exc_traceback)
+
+    sys.excepthook = sys_exception_handler
+    threading.excepthook = threading_exception_handler
 
 
 def get_structured_logger(name=__name__,
@@ -40,12 +57,23 @@ def get_structured_logger(name=__name__,
     is a good choice.
     filename: An (optional) file to write log output.
     """
-    # Configure the basic underlying logging configuration
+    # Set the underlying logging configuration
+    if "LOG_DEBUG" in os.environ:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+
     logging.basicConfig(
         format="%(message)s",
-        level=logging.INFO,
-        handlers=[logging.StreamHandler()]
-    )
+        level=log_level,
+        handlers=[logging.StreamHandler()])
+
+    def add_pid(_logger, _method_name, event_dict):
+        """
+        Add current PID to the event dict.
+        """
+        event_dict["pid"] = os.getpid()
+        return event_dict
 
     # Configure structlog. This uses many of the standard suggestions from
     # the structlog documentation.
@@ -57,6 +85,8 @@ def get_structured_logger(name=__name__,
             structlog.stdlib.add_logger_name,
             # Include log level in output.
             structlog.stdlib.add_log_level,
+            # Include PID in output.
+            add_pid,
             # Allow formatting into arguments e.g., logger.info("Hello, %s",
             # name)
             structlog.stdlib.PositionalArgumentsFormatter(),
@@ -68,7 +98,7 @@ def get_structured_logger(name=__name__,
             # Decode unicode characters
             structlog.processors.UnicodeDecoder(),
             # Render as JSON
-            structlog.processors.JSONRenderer()
+            structlog.processors.JSONRenderer(),
         ],
         # Use a dict class for keeping track of data.
         context_class=dict,
@@ -84,10 +114,90 @@ def get_structured_logger(name=__name__,
     system_logger = logging.getLogger(name)
     if filename and not system_logger.handlers:
         system_logger.addHandler(logging.FileHandler(filename))
-    system_logger.setLevel(logging.INFO)
+    system_logger.setLevel(log_level)
     logger = structlog.wrap_logger(system_logger)
 
     if log_exceptions:
         handle_exceptions(logger)
 
     return logger
+
+
+
+
+# the above loggers are thread-safe but not multiprocessing-safe.  a `LoggerThread` will spawn a thread that listens to a mp.Queue and logs messages from it with the provided logger, so other processes can send logging messages to it via the logger-like `SubLogger` interface.  the SubLogger even logs the pid of the caller.  this is good to use with a set of jobs that are part of a mp.Pool, but isnt recommended for general use because of overhead from threading and multiprocessing, and because it might introduce lag to log messages.
+
+import multiprocessing
+import contextlib
+
+class LoggerThread():
+  # TODO: add checks to prevent use of a stopped thread?
+  # TODO: reduce level of a bunch of debugging logs (search "self.logger.info")
+
+  class SubLogger():
+    def __init__(self, queue):
+      self.queue = queue
+    def _log(self, level, *args, **kwargs):
+      kwargs_plus = {'sub_pid': multiprocessing.current_process().pid}
+      kwargs_plus.update(kwargs)
+      self.queue.put([level, args, kwargs_plus])
+    # TODO: add log levels beyond `info`
+    def info(self, *args, **kwargs):
+      self._log(logging.INFO, *args, **kwargs)
+
+
+  def get_sublogger(self):
+    return self.sublogger
+
+  def __init__(self, logger, q=None):
+    self.logger = logger
+    if q:
+      self.msg_queue = q
+    else:
+      self.msg_queue = multiprocessing.Queue()
+
+    def logger_thread_worker():
+      self.logger.info('thread started')
+      while True:
+        msg = self.msg_queue.get()
+        if msg == 'STOP':
+          self.logger.info('received stop signal')
+          break
+        level, args, kwargs = msg
+        # TODO: add log levels beyond `info`
+        if level == logging.INFO:
+          self.logger.info(*args, **kwargs)
+        else:
+          self.logger.error('received unknown logging level!  exiting...')
+          break
+      self.logger.info('stopping thread')
+
+    self.thread = threading.Thread(target=logger_thread_worker, name="LoggerThread__"+self.logger.name)
+    self.logger.info('starting thread')
+    self.thread.start()
+
+    self.sublogger = LoggerThread.SubLogger(self.msg_queue)
+
+  def stop(self):
+    # TODO: make this safely re-callable?
+    self.logger.info('sending stop signal')
+    self.msg_queue.put('STOP')
+    self.thread.join()
+    self.logger.info('thread stopped')
+
+
+
+@contextlib.contextmanager
+def pool_and_threadedlogger(logger, *poolargs):
+  """
+  emulates the multiprocessing.Pool() context manager, but also provides a logger that can be used by pool workers.
+  """
+  with multiprocessing.Manager() as manager:
+    logger_thread = LoggerThread(logger, manager.Queue())
+    try:
+      with multiprocessing.Pool(*poolargs) as pool:
+        yield pool, logger_thread.get_sublogger()
+        pool.close()
+        pool.join()
+    finally:
+      logger_thread.stop()

--- a/_delphi_utils_python/delphi_utils/logger.py
+++ b/_delphi_utils_python/delphi_utils/logger.py
@@ -238,6 +238,8 @@ def pool_and_threadedlogger(logger, *poolargs):
     Emulates the multiprocessing.Pool() context manager,
     but also provides (via a LoggerThread) a SubLogger proxy to logger
     that can be safely used by pool workers.
+    The SubLogger proxy interface supports these methods: debug, info, warning, error,
+    and critical.
     Also "cleans up" the pool by waiting for workers to complete
     as it exits the context.
     """

--- a/_delphi_utils_python/delphi_utils/logger.py
+++ b/_delphi_utils_python/delphi_utils/logger.py
@@ -128,10 +128,10 @@ def get_structured_logger(name=__name__,
     return logger
 
 
-
-
 class LoggerThread():
     """
+    A construct to use a logger from multiprocessing workers/jobs.
+
     the bare structlog loggers are thread-safe but not multiprocessing-safe.
     a `LoggerThread` will spawn a thread that listens to a mp.Queue
     and logs messages from it with the provided logger,
@@ -143,15 +143,18 @@ class LoggerThread():
     but isnt recommended for general use
     because of overhead from threading and multiprocessing,
     and because it might introduce lag to log messages.
+
+    somewhat inspired by:
+    docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes
     """
 
     class SubLogger():
         """
-        Multiprocessing-safe logger-like interface
-        to convey log messages to a listening LoggerThread.
+        MP-safe logger-like interface  to convey log messages to a listening LoggerThread.
         """
 
         def __init__(self, queue):
+            """Save a handle to the queue"""
             self.queue = queue
 
         def _log(self, level, *args, **kwargs):
@@ -159,13 +162,27 @@ class LoggerThread():
             kwargs_plus.update(kwargs)
             self.queue.put([level, args, kwargs_plus])
 
+        def debug(self, *args, **kwargs):
+            """Log a DEBUG level message."""
+            self._log(logging.DEBUG, *args, **kwargs)
+
         def info(self, *args, **kwargs):
             """Log an INFO level message."""
             self._log(logging.INFO, *args, **kwargs)
 
-        def warn(self, *args, **kwargs):
-            """Log a WARN level message."""
-            self._log(logging.WARN, *args, **kwargs)
+        def warning(self, *args, **kwargs):
+            """Log a WARNING level message."""
+            self._log(logging.WARNING, *args, **kwargs)
+
+        def error(self, *args, **kwargs):
+            """Log an ERROR level message."""
+            self._log(logging.ERROR, *args, **kwargs)
+
+        def critical(self, *args, **kwargs):
+            """Log a CRITICAL level message."""
+            self._log(logging.CRITICAL, *args, **kwargs)
+
+
 
 
     def get_sublogger(self):
@@ -173,6 +190,7 @@ class LoggerThread():
         return self.sublogger
 
     def __init__(self, logger, q=None):
+        """Save handles to logger and queue, creating queue if not specified."""
         self.logger = logger
         if q:
             self.msg_queue = q
@@ -187,12 +205,12 @@ class LoggerThread():
                     logger.debug('received stop signal')
                     break
                 level, args, kwargs = msg
-                if level == logging.INFO:
-                    logger.info(*args, **kwargs)
-                if level == logging.WARN:
-                    logger.warn(*args, **kwargs)
+                if level in [logging.DEBUG, logging.INFO, logging.WARNING,
+                             logging.ERROR, logging.CRITICAL]:
+                    logger.log(level, *args, **kwargs)
                 else:
-                    logger.error('received unknown logging level!  exiting...')
+                    logger.error('received unknown logging level!  exiting...',
+                                 level=level, args_kwargs=(args, kwargs))
                     break
             logger.debug('stopping thread')
 
@@ -207,7 +225,7 @@ class LoggerThread():
     def stop(self):
         """Terminate this LoggerThread."""
         if not self.running:
-            self.logger.warn('thread already stopped')
+            self.logger.warning('thread already stopped')
             return
         self.logger.debug('sending stop signal')
         self.msg_queue.put('STOP')
@@ -216,12 +234,13 @@ class LoggerThread():
         self.logger.info('thread stopped')
 
 
-
 @contextlib.contextmanager
 def pool_and_threadedlogger(logger, *poolargs):
     """
+    Makes a proxy to logger available to a mp.Pool, which it also cleans up.
+
     Emulates the multiprocessing.Pool() context manager,
-    but also provides a logger that can be used by pool workers.
+    but also provides a wrapper to logger that can be used by pool workers.
     """
     with multiprocessing.Manager() as manager:
         logger_thread = LoggerThread(logger, manager.Queue())

--- a/_delphi_utils_python/delphi_utils/logger.py
+++ b/_delphi_utils_python/delphi_utils/logger.py
@@ -149,12 +149,10 @@ class LoggerThread():
     """
 
     class SubLogger():
-        """
-        MP-safe logger-like interface  to convey log messages to a listening LoggerThread.
-        """
+        """MP-safe logger-like interface to convey log messages to a listening LoggerThread."""
 
         def __init__(self, queue):
-            """Save a handle to the queue"""
+            """Create SubLogger with a bound queue."""
             self.queue = queue
 
         def _log(self, level, *args, **kwargs):
@@ -186,11 +184,11 @@ class LoggerThread():
 
 
     def get_sublogger(self):
-        """Accessor method to retrieve a SubLogger for this LoggerThread."""
+        """Retrieve SubLogger for this LoggerThread."""
         return self.sublogger
 
     def __init__(self, logger, q=None):
-        """Save handles to logger and queue, creating queue if not specified."""
+        """Create and start LoggerThread with supplied logger, creating a queue if not provided."""
         self.logger = logger
         if q:
             self.msg_queue = q
@@ -237,10 +235,13 @@ class LoggerThread():
 @contextlib.contextmanager
 def pool_and_threadedlogger(logger, *poolargs):
     """
-    Makes a proxy to logger available to a mp.Pool, which it also cleans up.
+    Provide (to a context) a multiprocessing Pool and a proxy to the supplied logger.
 
     Emulates the multiprocessing.Pool() context manager,
-    but also provides a wrapper to logger that can be used by pool workers.
+    but also provides (via a LoggerThread) a SubLogger proxy to logger
+    that can be safely used by pool workers.
+    Also "cleans up" the pool by waiting for workers to complete
+    as it exits the context.
     """
     with multiprocessing.Manager() as manager:
         logger_thread = LoggerThread(logger, manager.Queue())

--- a/_delphi_utils_python/delphi_utils/logger.py
+++ b/_delphi_utils_python/delphi_utils/logger.py
@@ -10,14 +10,15 @@ import os
 import structlog
 import sys
 import threading
-import traceback
+from traceback import format_exception
 
 
 def handle_exceptions(logger):
     """Handle exceptions using the provided logger."""
 
     def exception_handler(scope, etype, value, traceback):
-        logger.exception("Top-level exception occurred", scope=scope, exc_info=(etype, value, traceback))
+        logger.exception("Top-level exception occurred",
+                         scope=scope, exc_info=(etype, value, traceback))
 
     def sys_exception_handler(etype, value, traceback):
         exception_handler("sys", etype, value, traceback)
@@ -26,10 +27,13 @@ def handle_exceptions(logger):
         if args.exc_type == SystemExit and args.exc_value.code == 0:
             # `sys.exit(0)` is considered "successful termination":
             #   https://docs.python.org/3/library/sys.html#sys.exit
-            logger.debug(f"normal thread exit", thread=args.thread,
-                        stack="".join(traceback.format_exception(args.exc_type, args.exc_value, args.exc_traceback)))
+            logger.debug("normal thread exit", thread=args.thread,
+                        stack="".join(
+                            format_exception(
+                                args.exc_type, args.exc_value, args.exc_traceback)))
         else:
-            exception_handler(f"thread: {args.thread}", args.exc_type, args.exc_value, args.exc_traceback)
+            exception_handler(f"thread: {args.thread}",
+                              args.exc_type, args.exc_value, args.exc_traceback)
 
     sys.excepthook = sys_exception_handler
     threading.excepthook = threading_exception_handler
@@ -125,79 +129,94 @@ def get_structured_logger(name=__name__,
 
 
 
-# the above loggers are thread-safe but not multiprocessing-safe.  a `LoggerThread` will spawn a thread that listens to a mp.Queue and logs messages from it with the provided logger, so other processes can send logging messages to it via the logger-like `SubLogger` interface.  the SubLogger even logs the pid of the caller.  this is good to use with a set of jobs that are part of a mp.Pool, but isnt recommended for general use because of overhead from threading and multiprocessing, and because it might introduce lag to log messages.
 
-import multiprocessing
 import contextlib
+import multiprocessing
 
 class LoggerThread():
-  # TODO: add checks to prevent use of a stopped thread?
-  # TODO: reduce level of a bunch of debugging logs (search "self.logger.info")
+    """
+    the bare structlog loggers are thread-safe but not multiprocessing-safe.
+    a `LoggerThread` will spawn a thread that listens to a mp.Queue
+    and logs messages from it with the provided logger,
+    so other processes can send logging messages to it
+    via the logger-like `SubLogger` interface.
+    the SubLogger even logs the pid of the caller.
 
-  class SubLogger():
-    def __init__(self, queue):
-      self.queue = queue
-    def _log(self, level, *args, **kwargs):
-      kwargs_plus = {'sub_pid': multiprocessing.current_process().pid}
-      kwargs_plus.update(kwargs)
-      self.queue.put([level, args, kwargs_plus])
-    # TODO: add log levels beyond `info`
-    def info(self, *args, **kwargs):
-      self._log(logging.INFO, *args, **kwargs)
+    this is good to use with a set of jobs that are part of a mp.Pool,
+    but isnt recommended for general use
+    because of overhead from threading and multiprocessing,
+    and because it might introduce lag to log messages.
+    """
 
+    # TODO: add checks to prevent use of a stopped thread?
+    # TODO: reduce level of a bunch of debugging logs (search "self.logger.info")
 
-  def get_sublogger(self):
-    return self.sublogger
-
-  def __init__(self, logger, q=None):
-    self.logger = logger
-    if q:
-      self.msg_queue = q
-    else:
-      self.msg_queue = multiprocessing.Queue()
-
-    def logger_thread_worker():
-      self.logger.info('thread started')
-      while True:
-        msg = self.msg_queue.get()
-        if msg == 'STOP':
-          self.logger.info('received stop signal')
-          break
-        level, args, kwargs = msg
+    class SubLogger():
+        def __init__(self, queue):
+            self.queue = queue
+        def _log(self, level, *args, **kwargs):
+            kwargs_plus = {'sub_pid': multiprocessing.current_process().pid}
+            kwargs_plus.update(kwargs)
+            self.queue.put([level, args, kwargs_plus])
         # TODO: add log levels beyond `info`
-        if level == logging.INFO:
-          self.logger.info(*args, **kwargs)
+        def info(self, *args, **kwargs):
+            self._log(logging.INFO, *args, **kwargs)
+
+
+    def get_sublogger(self):
+        return self.sublogger
+
+    def __init__(self, logger, q=None):
+        self.logger = logger
+        if q:
+            self.msg_queue = q
         else:
-          self.logger.error('received unknown logging level!  exiting...')
-          break
-      self.logger.info('stopping thread')
+            self.msg_queue = multiprocessing.Queue()
 
-    self.thread = threading.Thread(target=logger_thread_worker, name="LoggerThread__"+self.logger.name)
-    self.logger.info('starting thread')
-    self.thread.start()
+        def logger_thread_worker():
+            self.logger.info('thread started')
+            while True:
+                msg = self.msg_queue.get()
+                if msg == 'STOP':
+                    self.logger.info('received stop signal')
+                    break
+                level, args, kwargs = msg
+                # TODO: add log levels beyond `info`
+                if level == logging.INFO:
+                    self.logger.info(*args, **kwargs)
+                else:
+                    self.logger.error('received unknown logging level!  exiting...')
+                    break
+            self.logger.info('stopping thread')
 
-    self.sublogger = LoggerThread.SubLogger(self.msg_queue)
+        self.thread = threading.Thread(target=logger_thread_worker,
+                                       name="LoggerThread__"+self.logger.name)
+        self.logger.info('starting thread')
+        self.thread.start()
 
-  def stop(self):
-    # TODO: make this safely re-callable?
-    self.logger.info('sending stop signal')
-    self.msg_queue.put('STOP')
-    self.thread.join()
-    self.logger.info('thread stopped')
+        self.sublogger = LoggerThread.SubLogger(self.msg_queue)
+
+    def stop(self):
+        # TODO: make this safely re-callable?
+        self.logger.info('sending stop signal')
+        self.msg_queue.put('STOP')
+        self.thread.join()
+        self.logger.info('thread stopped')
 
 
 
 @contextlib.contextmanager
 def pool_and_threadedlogger(logger, *poolargs):
-  """
-  emulates the multiprocessing.Pool() context manager, but also provides a logger that can be used by pool workers.
-  """
-  with multiprocessing.Manager() as manager:
-    logger_thread = LoggerThread(logger, manager.Queue())
-    try:
-      with multiprocessing.Pool(*poolargs) as pool:
-        yield pool, logger_thread.get_sublogger()
-        pool.close()
-        pool.join()
-    finally:
-      logger_thread.stop()
+    """
+    emulates the multiprocessing.Pool() context manager,
+    but also provides a logger that can be used by pool workers.
+    """
+    with multiprocessing.Manager() as manager:
+        logger_thread = LoggerThread(logger, manager.Queue())
+        try:
+            with multiprocessing.Pool(*poolargs) as pool:
+                yield pool, logger_thread.get_sublogger()
+                pool.close()
+                pool.join()
+        finally:
+            logger_thread.stop()

--- a/_delphi_utils_python/delphi_utils/logger.py
+++ b/_delphi_utils_python/delphi_utils/logger.py
@@ -181,8 +181,6 @@ class LoggerThread():
             self._log(logging.CRITICAL, *args, **kwargs)
 
 
-
-
     def get_sublogger(self):
         """Retrieve SubLogger for this LoggerThread."""
         return self.sublogger


### PR DESCRIPTION
#### this does a few things, including:

- bringing the `logger.py` files from https://github.com/cmu-delphi/delphi-epidata/ and https://github.com/cmu-delphi/covidcast-indicators/ back in sync.  (there will be equivalent PRs in both repositories.)

- larger functional differences are now applied to both:
  - the version in `covidcast-indicators` didnt log PIDs 
  - nor did it have the env var trick to get debug-level output
  - the version in `delphi-epidata` didnt always respect output filenames properly (though it seems we didnt actually trigger this in practice; look at the collapsible section below for how to see this for yourself).

- differentiated the uncaught exception handlers a bit
  - and reduced the log level for messages from threads exiting cleanly.  this is mostly because multiprocessing.Manager processes start and [stop threads](https://github.com/python/cpython/blob/3.8/Lib/multiprocessing/managers.py#L289-L291) often.

- added multiprocess-safe logging constructs, which should be helpful in https://github.com/cmu-delphi/covidcast-indicators/pull/1881 and in the future. (see collapsible section below for sample usage)

---

<details>
<summary>to reproduce bad outfile behavior:</summary>

- first, in your shell:

```
curl https://raw.githubusercontent.com/cmu-delphi/covidcast-indicators/main/_delphi_utils_python/delphi_utils/logger.py -o ci_logger.py

curl https://raw.githubusercontent.com/cmu-delphi/delphi-epidata/dev/src/common/logger.py -o de_logger.py
```

- then follow these instructions: toggle the commented-out-ness of the imports below, remove files foo.txt and bar.txt, paste this into your `python3` interpreter, check those files, and repeat:                       

```python
import de_logger as a_logger
#import ci_logger as a_logger

foo = a_logger.get_structured_logger('foo', filename='foo.txt')
bar = a_logger.get_structured_logger('bar', filename='bar.txt')
foo.info("hi")
bar.info("oh hello")
```

</details>

<details>
<summary>two example usages of multiprocessing-compatible logger:</summary>

- this approach uses `multiprocessing` directly, requires explicit termination of the LoggerThread (after ensuring the pool jobs have completed), and requires the `sublogger` to be instantiated before the worker and bound in an accessible scope (it must be used as though it is local to the worker, it cannot be passed as an argument to pool methods)

```python
import multiprocessing
from delphi.epidata.common.logger import get_structured_logger, LoggerThread

logger = get_structured_logger('sample_1')

lt = LoggerThread(logger)
sl = lt.get_sublogger()
sl.info("test")

def worker_1(message):
  # do something here
  sl.info(message)
  # do somethine else here

num_processes = 5
with multiprocessing.Pool(num_processes) as pool:
  pool.apply_async(worker_1, args=["abcd"])
  pool.apply_async(worker_1, args=["efgh"])
  pool.close()
  pool.join()

lt.stop()
```

- this approach uses the context manager to provide a pool and logger, and the logger can be used in arguments to pool methods.  this is a little bit less lightweight (the multiprocessing.Manager() it uses will spawn its own subprocess and a number of threads within it) but it is cleaner and more straightforward.

```python
from delphi.epidata.common.logger import get_structured_logger, pool_and_threadedlogger

logger = get_structured_logger('sample_2')

def worker_2(message, sublogger):
  # do something here
  sublogger.info(message)
  # do somethine else here

num_processes = 5  # optional argument passed to Pool constructor
with pool_and_threadedlogger(logger, num_processes) as (pool, sublogger):
  pool.apply_async(worker_2, args=["asdf", sublogger])
  pool.apply_async(worker_2, args=["jkl;", sublogger])
  pool.apply_async(worker_2, args=["qwerty", sublogger])
```

</details>
