### PR TITLE
Add multiprocess logger to the Quidel indicator

### DIFF
--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -6,7 +6,7 @@ when the module is run with `python -m MODULE_NAME`.
 """
 import atexit
 from datetime import datetime
-from multiprocessing import Pool, cpu_count, current_process
+from multiprocessing import cpu_count
 import time
 from typing import Dict, Any
 

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -6,7 +6,7 @@ when the module is run with `python -m MODULE_NAME`.
 """
 import atexit
 from datetime import datetime
-from multiprocessing import Manager, Pool, cpu_count, current_process
+from multiprocessing import Pool, cpu_count, current_process
 import time
 from typing import Dict, Any
 

--- a/quidel_covidtest/delphi_quidel_covidtest/run.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/run.py
@@ -65,8 +65,7 @@ def generate_and_export_for_nonparent_geo(geo_groups, res_key, smooth, device,
     """Generate sensors, create export CSV then return stats."""
     threaded_logger.info("Generating signal and exporting to CSV",
                          geo_res=geo_res,
-                         sensor=sensor_name,
-                         pid=current_process().pid)
+                         sensor=sensor_name)
     res_df = generate_sensor_for_nonparent_geo(geo_groups, res_key, smooth, device,
                                                first_date, last_date, suffix)
     dates = create_export_csv(res_df, geo_res=geo_res,
@@ -83,8 +82,7 @@ def generate_and_export_for_parent_geo(geo_groups, geo_data, res_key, smooth, de
     """Generate sensors, create export CSV then return stats."""
     threaded_logger.info("Generating signal and exporting to CSV",
                          geo_res=geo_res,
-                         sensor=sensor_name,
-                         pid=current_process().pid)
+                         sensor=sensor_name)
     res_df = generate_sensor_for_parent_geo(geo_groups, geo_data, res_key, smooth, device,
                                             first_date, last_date, suffix)
     dates = create_export_csv(res_df, geo_res=geo_res,
@@ -165,65 +163,63 @@ def run_module(params: Dict[str, Any]):
     n_cpu = min(8, cpu_count()) # for parallelization
     with pool_and_threadedlogger(logger, n_cpu) as (pool, threaded_logger):
         # for using loggers in multiple threads
-        # disabled due to a Pylint bug, resolved by version bump (#1886)
         logger.info("Parallelizing sensor generation", n_cpu=n_cpu)
-        with Pool(n_cpu) as pool:
-            pool_results = []
-            for geo_res in NONPARENT_GEO_RESOLUTIONS:
-                geo_data, res_key = geo_map(geo_res, data)
-                geo_groups = geo_data.groupby(res_key)
-                for agegroup in AGE_GROUPS:
-                    for sensor in sensors:
-                        if agegroup == "total":
-                            sensor_name = sensor
-                        else:
-                            sensor_name = "_".join([sensor, agegroup])
-                        pool_results.append(
-                            pool.apply_async(
-                                generate_and_export_for_nonparent_geo,
-                                args=(
-                                    # generate_sensors_for_parent_geo
-                                    geo_groups, res_key,
-                                    smoothers[sensor][1], smoothers[sensor][0],
-                                    first_date, last_date, agegroup,
-                                    # create_export_csv
-                                    geo_res, sensor_name, export_dir,
-                                    export_start_date, export_end_date,
-                                    # logger
-                                    threaded_logger
-                                )
+        pool_results = []
+        for geo_res in NONPARENT_GEO_RESOLUTIONS:
+            geo_data, res_key = geo_map(geo_res, data)
+            geo_groups = geo_data.groupby(res_key)
+            for agegroup in AGE_GROUPS:
+                for sensor in sensors:
+                    if agegroup == "total":
+                        sensor_name = sensor
+                    else:
+                        sensor_name = "_".join([sensor, agegroup])
+                    pool_results.append(
+                        pool.apply_async(
+                            generate_and_export_for_nonparent_geo,
+                            args=(
+                                # generate_sensors_for_parent_geo
+                                geo_groups, res_key,
+                                smoothers[sensor][1], smoothers[sensor][0],
+                                first_date, last_date, agegroup,
+                                # create_export_csv
+                                geo_res, sensor_name, export_dir,
+                                export_start_date, export_end_date,
+                                # logger
+                                threaded_logger
                             )
                         )
-            assert geo_res == "state" # Make sure geo_groups is for state level
-            # County/HRR/MSA level
-            for geo_res in PARENT_GEO_RESOLUTIONS:
-                geo_data, res_key = geo_map(geo_res, data) # using the last geo_groups
-                for agegroup in AGE_GROUPS:
-                    for sensor in sensors:
-                        if agegroup == "total":
-                            sensor_name = sensor
-                        else:
-                            sensor_name = "_".join([sensor, agegroup])
-                        pool_results.append(
-                            pool.apply_async(
-                                generate_and_export_for_parent_geo,
-                                args=(
-                                    # generate_sensors_for_parent_geo
-                                    geo_groups, geo_data, res_key,
-                                    smoothers[sensor][1], smoothers[sensor][0],
-                                    first_date, last_date, agegroup,
-                                    # create_export_csv
-                                    geo_res, sensor_name, export_dir,
-                                    export_start_date, export_end_date,
-                                    # logger
-                                    threaded_logger
-                                )
+                    )
+        assert geo_res == "state" # Make sure geo_groups is for state level
+        # County/HRR/MSA level
+        for geo_res in PARENT_GEO_RESOLUTIONS:
+            geo_data, res_key = geo_map(geo_res, data) # using the last geo_groups
+            for agegroup in AGE_GROUPS:
+                for sensor in sensors:
+                    if agegroup == "total":
+                        sensor_name = sensor
+                    else:
+                        sensor_name = "_".join([sensor, agegroup])
+                    pool_results.append(
+                        pool.apply_async(
+                            generate_and_export_for_parent_geo,
+                            args=(
+                                # generate_sensors_for_parent_geo
+                                geo_groups, geo_data, res_key,
+                                smoothers[sensor][1], smoothers[sensor][0],
+                                first_date, last_date, agegroup,
+                                # create_export_csv
+                                geo_res, sensor_name, export_dir,
+                                export_start_date, export_end_date,
+                                # logger
+                                threaded_logger
                             )
                         )
-            pool_results = [proc.get() for proc in pool_results]
-            for dates in pool_results:
-                if len(dates) > 0:
-                    stats.append((max(dates), len(dates)))
+                    )
+        pool_results = [proc.get() for proc in pool_results]
+        for dates in pool_results:
+            if len(dates) > 0:
+                stats.append((max(dates), len(dates)))
 
     # Export the cache file if the pipeline runs successfully.
     # Otherwise, don't update the cache file


### PR DESCRIPTION
### Description
Applies the new threaded logger to the Quidel indicator, fixing [an issue](https://github.com/cmu-delphi/covidcast-indicators/issues/1547#issuecomment-1673639250) where it would consider `sys.exit(0)` an exception and log it as a system alert.

### Changelog
- Adds multiprocess logger to the Quidel indicator.