### PR TITLE
County-level data \N char fix

### DIFF
--- a/changehc/delphi_changehc/update_sensor.py
+++ b/changehc/delphi_changehc/update_sensor.py
@@ -162,6 +162,8 @@ class CHCSensorUpdater:  # pylint: disable=too-many-instance-attributes
                                                  date_col=Config.DATE_COL)
             # this line should be removed once the fix is implemented for megacounties
             data_frame = data_frame[~((data_frame['county'].str.len() > 5) | (data_frame['county'].str.contains('_')))]
+            # handle rogue \N:
+            data_frame = data_frame[data_frame['county'] != r'\N']
         elif geo == "state":
             data_frame = gmpr.replace_geocode(data, "fips", "state_id", new_col="state",
                                               date_col=Config.DATE_COL)

--- a/changehc/tests/test_update_sensor.py
+++ b/changehc/tests/test_update_sensor.py
@@ -11,7 +11,6 @@ import numpy as np
 from boto3 import Session
 from moto import mock_s3
 import pytest
-import pdb
 
 # first party
 from delphi_changehc.config import Config
@@ -97,7 +96,6 @@ class TestCHCSensorUpdater:
             assert data_frame.shape[0] == multiple*len(su_inst.fit_dates)
             assert (data_frame.sum(numeric_only=True) == (4200,19000)).all()
             if geo == "county":
-                pdb.set_trace()
                 assert r'\N' not in data_frame.index.get_level_values('county')
 
     def test_update_sensor(self):


### PR DESCRIPTION
### Description
Some county-level data is not being ingested properly due to an unexpected character "\N" showing up on data from Chng. 
Turns out the this character is apperaring due to bad ZIP5 from soruce data where we are not able to translate it to a FIPS code. This character represents null/blank. 

### Changelog
Filter out any incoming county-data rows with \N being geo_id
