### PR TITLE
Add API key to hhs run module

### DIFF
--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -80,7 +80,8 @@ def run_module(params):
             - "common":
                 - "api_credentials": str, api key to prevent hitting max number of query limit.
     """
-    Epidata.auth = ('epidata', str(params["validation"]["common"]["api_credentials"]))
+    if params.get("validation") and params["validation"].get("common") and params["validation"]["common"].get("api_credentials"):
+        Epidata.auth = ('epidata', str(params["validation"]["common"]["api_credentials"]))
     start_time = time.time()
     logger = get_structured_logger(
         __name__, filename=params["common"].get("log_filename"),

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -76,6 +76,9 @@ def run_module(params):
             - "export_dir": str, directory to write output
             - "log_filename" (optional): str, name of file to write logs
             - "epidata" (optional): dict, extra parameters to send to Epidata.covid_hosp
+        - "validation":
+            - "common":
+                - "api_credentials": str, api key to prevent hitting max number of query limit.
     """
     Epidata.auth = ('epidata', str(params["validation"]["common"]["api_credentials"]))
     start_time = time.time()

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -80,7 +80,8 @@ def run_module(params):
             - "common":
                 - "api_credentials": str, api key to prevent hitting max number of query limit.
     """
-    if params.get("validation") and params["validation"].get("common") and params["validation"]["common"].get("api_credentials"):
+    if params.get("validation") and params["validation"].get("common") and \
+        params["validation"]["common"].get("api_credentials"):
         Epidata.auth = ('epidata', str(params["validation"]["common"]["api_credentials"]))
     start_time = time.time()
     logger = get_structured_logger(

--- a/hhs_hosp/delphi_hhs/run.py
+++ b/hhs_hosp/delphi_hhs/run.py
@@ -77,6 +77,7 @@ def run_module(params):
             - "log_filename" (optional): str, name of file to write logs
             - "epidata" (optional): dict, extra parameters to send to Epidata.covid_hosp
     """
+    Epidata.auth = ('epidata', str(params["validation"]["common"]["api_credentials"]))
     start_time = time.time()
     logger = get_structured_logger(
         __name__, filename=params["common"].get("log_filename"),

--- a/hhs_hosp/tests/test_run.py
+++ b/hhs_hosp/tests/test_run.py
@@ -185,6 +185,12 @@ def test_output_files(mock_covid_hosp):
         params = {
             "common": {
                 "export_dir": tmpdir
+            },
+            "validation": {
+                "common": {
+                "data_source": "hhs",
+                "api_credentials": "fakecred"
+                }
             }
         }
         run_module(params)
@@ -215,6 +221,12 @@ def test_ignore_last_range_no_results(mock_covid_hosp, mock_export):
     params = {
         "common": {
             "export_dir": "./receiving"
-        }
+        },
+        "validation": {
+                "common": {
+                "data_source": "hhs",
+                "api_credentials": "fakecred"
+                }
+            }
     }
     assert not run_module(params)  # function should not raise value error and has no return value


### PR DESCRIPTION
### Description
There's an epidata covidhosp api call in hhs run module that got exposed to needing api key. The key is already available in params.json, so only need to add in code.

### Changelog
Add api key to hhs_run.