### PR TITLE
Manually add population for national data

### DIFF
--- a/nchs_mortality/delphi_nchs_mortality/pull.py
+++ b/nchs_mortality/delphi_nchs_mortality/pull.py
@@ -127,6 +127,9 @@ Columns available:
                                     geocode_col="state", dropna=False)
     df = gmpr.add_geocode(df, "state_name", "state_id",
                           from_col="state", new_col="geo_id", dropna=False)
-    # Manually set geo_id for national data
+    # Manually set geo_id and population for national data
+    national_pop = gmpr.get_crosswalk("nation", "pop")
+    us_pop = national_pop.loc[national_pop["nation"] == "us"]["pop"][0]
+    df.loc[df["state"] == "United States", "population"] = us_pop
     df.loc[df["state"] == "United States", "geo_id"] = "us"
     return df[keep_columns]


### PR DESCRIPTION
### Description
Within `nchs-mortality` national data, values for `*_prop` national signals were previously null, as described in [this PR comment](https://github.com/cmu-delphi/covidcast-indicators/pull/1912#issuecomment-1908406819). This is because the original data mixes in state and US data (with the geo column `state = "United States"`), so the population, which is retrieved from a static census dataframe, wasn't populated correctly for US data.

### Changelog
Fixes this by properly setting population for national data.

### Fixes 
Fixes #1906.