### PR TITLE
leap year fixes for claims_hosp and quidel_covidtest

### DIFF
--- a/claims_hosp/delphi_claims_hosp/backfill.py
+++ b/claims_hosp/delphi_claims_hosp/backfill.py
@@ -44,7 +44,10 @@ def store_backfill_file(claims_filepath, _end_date, backfill_dir):
     backfilldata = gmpr.add_geocode(backfilldata, from_code="fips", new_code="state_id",
                            from_col="fips", new_col="state_id")
     #Store one year's backfill data
-    _start_date = _end_date.replace(year=_end_date.year-1)
+    if _end_date.day == 29 and _end_date.month == 2:
+        _start_date = datetime(_end_date.year-1, 2, 28)
+    else:
+        _start_date = _end_date.replace(year=_end_date.year-1)
     selected_columns = ['time_value', 'fips', 'state_id',
                         'den', 'num']
     backfilldata = backfilldata.loc[(backfilldata["time_value"] >= _start_date)

--- a/quidel_covidtest/delphi_quidel_covidtest/backfill.py
+++ b/quidel_covidtest/delphi_quidel_covidtest/backfill.py
@@ -45,7 +45,10 @@ def store_backfill_file(df, _end_date, backfill_dir):
                         "totalTest_age_0_17": "den_age_0_17"},
                         axis=1, inplace=True)
     #Store one year's backfill data
-    _start_date = _end_date.replace(year=_end_date.year-1)
+    if _end_date.day == 29 and _end_date.month == 2:
+        _start_date = datetime(_end_date.year-1, 2, 28)
+    else:
+        _start_date = _end_date.replace(year=_end_date.year-1)
     selected_columns = ['time_value', 'fips', 'state_id',
                         'den_total', 'num_total',
                         'num_age_0_4', 'den_age_0_4',


### PR DESCRIPTION
fixes for handling leap year in the backfill methods of `claims_hosp` and `quidel_covidtest`

shamlessly stolen and copypasta'd from [a similar method in `changehc`](https://github.com/cmu-delphi/covidcast-indicators/blob/a99327b4cc1ab070aea032d3d8812a32a19a1e03/changehc/delphi_changehc/backfill.py#L44-L47).
