### PR TITLE
Nssp staging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@
    - TODO: #527 Get this list automatically from python-ci.yml at runtime.
  */
 
-def indicator_list = ["backfill_corrections", "changehc", "claims_hosp", "google_symptoms", "hhs_hosp", "nchs_mortality", "quidel_covidtest", "sir_complainsalot", "doctor_visits", "nwss_wastewater"]
+def indicator_list = ["backfill_corrections", "changehc", "claims_hosp", "google_symptoms", "hhs_hosp", "nchs_mortality", "quidel_covidtest", "sir_complainsalot", "doctor_visits", "nwss_wastewater", "nssp"]
 def build_package_main = [:]
 def build_package_prod = [:]
 def deploy_staging = [:]

--- a/ansible/templates/nssp-params-prod.json.j2
+++ b/ansible/templates/nssp-params-prod.json.j2
@@ -1,0 +1,13 @@
+{
+  "common": {
+    "export_dir": "/common/covidcast/receiving/nssp",
+    "log_filename": "/var/log/indicators/nssp.log",
+    "log_exceptions": false
+  },
+  "indicator": {
+    "wip_signal": true,
+    "export_start_date": "2020-02-01",
+    "static_file_dir": "./static",
+    "socrata_token": "{{ nwss_wastewater_token }}"
+  }
+}

--- a/ansible/templates/nssp-params-prod.json.j2
+++ b/ansible/templates/nssp-params-prod.json.j2
@@ -8,6 +8,6 @@
     "wip_signal": true,
     "export_start_date": "2020-02-01",
     "static_file_dir": "./static",
-    "socrata_token": "{{ nwss_wastewater_token }}"
+    "socrata_token": "{{ nssp_token }}"
   }
 }

--- a/ansible/vars.yaml
+++ b/ansible/vars.yaml
@@ -56,6 +56,9 @@ nchs_mortality_token: "{{ vault_cdc_socrata_token }}"
 # NWSS
 nwss_wastewater_token: "{{ vault_cdc_socrata_token }}"
 
+# nssp
+nssp_token: "{{ vault_cdc_socrata_token }}"
+
 # SirCAL
 sir_complainsalot_api_key: "{{ vault_sir_complainsalot_api_key }}"
 sir_complainsalot_slack_token: "{{ vault_sir_complainsalot_slack_token }}"


### PR DESCRIPTION
### Description
These are configurations to help nssp run in staging, not nssp indicator itself. This should not be merged until nssp indicator is already merged.

### Changelog
- add ansible config for params.json used in staging
- add nssp to indicator list in jenkinsfile.
- apart from changes here, also created `nssp` dir in `/common/covidcast/receiving/` on staging for .csv files to live in along with other indicators. 

