### PR TITLE
Shut sircal up about historical chng signals

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -14,7 +14,8 @@
     },
     "chng": {
       "max_age": 6,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
+      "retired-signals": ["7dav_outpatient_covid","7dav_inpatient_covid"]
     },
     "google-symptoms": {
       "max_age": 6,

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -14,7 +14,8 @@
     },
     "chng": {
       "max_age": 6,
-      "maintainers": ["U01AP8GSWG3","U01069KCRS7"]
+      "maintainers": ["U01AP8GSWG3","U01069KCRS7"],
+      "retired-signals": ["7dav_outpatient_covid","7dav_inpatient_covid"]
     },
     "google-symptoms": {
       "max_age": 6,


### PR DESCRIPTION
### Description
[We're adding two historical signals to chng](https://cmu-delphi.atlassian.net/browse/OKRS24-105). For now they are not getting updates in the future. This PR makes sircal not check for new data in these signals. 

