### PR TITLE
lint: minor code clean to nwss

### DIFF
--- a/nchs_mortality/delphi_nchs_mortality/constants.py
+++ b/nchs_mortality/delphi_nchs_mortality/constants.py
@@ -25,8 +25,3 @@ SENSORS = [
         "prop"
 ]
 INCIDENCE_BASE = 100000
-
-# this is necessary as a delimiter in the f-string expressions we use to
-# construct detailed error reports
-# (https://www.python.org/dev/peps/pep-0498/#escape-sequences)
-NEWLINE = "\n"

--- a/nchs_mortality/delphi_nchs_mortality/pull.py
+++ b/nchs_mortality/delphi_nchs_mortality/pull.py
@@ -9,7 +9,7 @@ from sodapy import Socrata
 
 from delphi_utils.geomap import GeoMapper
 
-from .constants import METRICS, RENAME, NEWLINE
+from .constants import METRICS, RENAME
 
 def standardize_columns(df):
     """Rename columns to comply with a standard set.
@@ -90,10 +90,10 @@ Expected column(s) missed, The dataset schema may
 have changed. Please investigate and amend the code.
 
 Columns needed:
-{NEWLINE.join(type_dict.keys())}
+{'\n'.join(type_dict.keys())}
 
 Columns available:
-{NEWLINE.join(df.columns)}
+{'\n'.join(df.columns)}
 """) from exc
 
     df = df[keep_columns + ["timestamp", "state"]].set_index("timestamp")

--- a/nwss_wastewater/delphi_nwss/constants.py
+++ b/nwss_wastewater/delphi_nwss/constants.py
@@ -22,18 +22,23 @@ PROVIDER_NORMS = {
         "microbial",
     ],
 }
-METRIC_DATES = ["date_start", "date_end"]
-SAMPLE_SITE_NAMES = {
-    "wwtp_jurisdiction": "category",
-    "wwtp_id": int,
-    "reporting_jurisdiction": "category",
-    "sample_location": "category",
-    "county_names": "category",
-    "county_fips": "category",
-    "population_served": float,
-    "sampling_prior": bool,
-    "sample_location_specify": float,
-}
 SIG_DIGITS = 4
 
-NEWLINE = "\n"
+TYPE_DICT = {key: float for key in SIGNALS}
+TYPE_DICT.update({"timestamp": "datetime64[ns]"})
+TYPE_DICT_METRIC = {key: float for key in METRIC_SIGNALS}
+TYPE_DICT_METRIC.update({key: "datetime64[ns]" for key in ["date_start", "date_end"]})
+# Sample site names
+TYPE_DICT_METRIC.update(
+    {
+        "wwtp_jurisdiction": "category",
+        "wwtp_id": int,
+        "reporting_jurisdiction": "category",
+        "sample_location": "category",
+        "county_names": "category",
+        "county_fips": "category",
+        "population_served": float,
+        "sampling_prior": bool,
+        "sample_location_specify": float,
+    }
+)

--- a/nwss_wastewater/delphi_nwss/run.py
+++ b/nwss_wastewater/delphi_nwss/run.py
@@ -21,6 +21,7 @@ the following structure:
         - "bucket_name: str, name of S3 bucket to read/write
         - "cache_dir": str, directory of locally cached data
 """
+
 import time
 from datetime import datetime
 
@@ -138,10 +139,10 @@ def run_module(params):
     run_stats = []
     ## build the base version of the signal at the most detailed geo level you can get.
     ## compute stuff here or farm out to another function or file
-    df_pull = pull_nwss_data(socrata_token)
+    df_pull = pull_nwss_data(socrata_token, logger)
     ## aggregate
     # iterate over the providers and the normalizations that they specifically provide
-    for (provider, normalization) in zip(
+    for provider, normalization in zip(
         PROVIDER_NORMS["provider"], PROVIDER_NORMS["normalization"]
     ):
         # copy by only taking the relevant subsection

--- a/nwss_wastewater/tests/test_run.py
+++ b/nwss_wastewater/tests/test_run.py
@@ -1,17 +1,7 @@
-from datetime import datetime, date
-import json
-from unittest.mock import patch
-import tempfile
-import os
-import time
-from datetime import datetime
-
 import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
-from delphi_utils import S3ArchiveDiffer, get_structured_logger, create_export_csv, Nans
 
-from delphi_nwss.constants import GEOS, SIGNALS
 from delphi_nwss.run import (
     add_needed_columns,
     generate_weights,
@@ -23,13 +13,9 @@ from delphi_nwss.run import (
 
 def test_sum_all_nan():
     """Check that sum_all_nan returns NaN iff everything is a NaN"""
-    no_nans = np.array([3, 5])
-    assert sum_all_nan(no_nans) == 8
-    partial_nan = np.array([np.nan, 3, 5])
+    assert sum_all_nan(np.array([3, 5])) == 8
     assert np.isclose(sum_all_nan([np.nan, 3, 5]), 8)
-
-    oops_all_nans = np.array([np.nan, np.nan])
-    assert np.isnan(oops_all_nans).all()
+    assert np.isnan(np.array([np.nan, np.nan])).all()
 
 
 def test_weight_generation():


### PR DESCRIPTION
### Description
Was easier to just make a bunch of changes than to make review comments. It's mostly just code style lints that I preferred, happy to revert some pieces if you disagree. The actual important parts of the code seemed fine to me.

### Changelog
- Turn type_dict and type_dict_metric into global constants, remove constructor function
- Remove a few simple functions
- Change the schema change error message, inline the message
- Add logger statement when df_concentration or df_metric contain columns not in TYPE_DICT or TYPE_DICT_METRIC

### Fixes 
To be merged into #1946 
