### PR TITLE
Don't block `google-symptoms` file upload when validation fails

### DIFF
--- a/ansible/templates/google_symptoms-params-prod.json.j2
+++ b/ansible/templates/google_symptoms-params-prod.json.j2
@@ -28,6 +28,7 @@
       "span_length": 14,
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
+      "dry_run": true,
       "suppressed_errors": [
         {"signal": "ageusia_raw_search"},
         {"signal": "ageusia_smoothed_search"},

--- a/google_symptoms/params.json.template
+++ b/google_symptoms/params.json.template
@@ -16,6 +16,7 @@
       "span_length": 14,
       "min_expected_lag": {"all": "3"},
       "max_expected_lag": {"all": "4"},
+      "dry_run": true,
       "suppressed_errors": [
         {"signal": "ageusia_raw_search"},
         {"signal": "ageusia_smoothed_search"},


### PR DESCRIPTION
### Description
When `google-symptoms` has a long-standing outage, when it eventually comes back online, the validator fails because it (rightfully) can't find recent data for the data source in the API. This isn't a very useful error message and in general the validator has lots of false positives, so turn off validation blocking for now. [Context](https://delphi-org.slack.com/archives/C04LJ169KNF/p1689886428435579?thread_ts=1689872541.367489&cid=C04LJ169KNF).

### Changelog
- local and ansible template `params.json`
