### PR TITLE
first attempt at fixing broken backfill build

### DIFF
--- a/.github/workflows/backfill-corr-ci.yml
+++ b/.github/workflows/backfill-corr-ci.yml
@@ -10,49 +10,28 @@ name: R backfill corrections
 
 on:
   push:
-    branches: [ main, prod ]
+    branches: [main, prod]
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
-    branches: [ main, prod ]
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main, prod]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    strategy:
-      matrix:
-        r-version: [4.2.1]
     defaults:
       run:
         working-directory: backfill_corrections/delphiBackfillCorrection
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up R ${{ matrix.r-version }}
+      - uses: actions/checkout@v4
+
+      - name: Set up R 4.2
         uses: r-lib/actions/setup-r@v2
         with:
-          r-version: ${{ matrix.r-version }}
           use-public-rspm: true
-      - name: Install linux dependencies
-        run: |
-            sudo apt-get install \
-              libcurl4-openssl-dev \
-              libgdal-dev \
-              libudunits2-dev \
-              libglpk-dev \
-              libharfbuzz-dev \
-              libfribidi-dev
-      - name: Get date
-        id: get-date
-        run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-      - name: Cache R packages
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-backfillcorr-${{ steps.get-date.outputs.date }}
-          restore-keys: |
-            ${{ runner.os }}-r-backfillcorr-
+          r-version: 4.2
+
       - name: Install and cache dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -60,7 +39,8 @@ jobs:
         with:
           extra-packages: any::rcmdcheck
           working-directory: backfill_corrections/delphiBackfillCorrection
-          upgrade: 'TRUE'
+          upgrade: "TRUE"
+
       - name: Check package
         uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -2,14 +2,15 @@ name: Build indicator container images and upload to registry
 
 on:
   push:
-    branches: [ main, prod ]
+    branches: [main, prod]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        packages: [ backfill_corrections ]
+        packages: [backfill_corrections]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/backfill_corrections/Dockerfile
+++ b/backfill_corrections/Dockerfile
@@ -1,7 +1,7 @@
 FROM gurobi/optimizer:9.5.1 as gurobi
 
 ## Install R and tidyverse
-FROM rocker/tidyverse:latest
+FROM rocker/tidyverse:4.2
 
 WORKDIR /opt/gurobi
 COPY --from=gurobi /opt/gurobi .
@@ -15,22 +15,17 @@ ENV LD_LIBRARY_PATH $GUROBI_HOME/lib
 RUN ln -s -f /usr/share/zoneinfo/America/New_York /etc/localtime
 
 RUN apt-get update && apt-get install -qq -y \
-    libglpk-dev\
+    apt-file \
     python3-venv \
     python3-dev \
     python3-pip
 
-RUN install2.r --error \
-    roxygen2 \
-    Rglpk \
-    argparser
-
+RUN R -e 'install.packages("pak", repos = sprintf("https://r-lib.github.io/p/pak/stable/%s/%s/%s", .Platform$pkgType, R.Version()$os, R.Version()$arch))'
+RUN R -e 'install.packages(c("rspm"))'
 RUN --mount=type=secret,id=GITHUB_TOKEN \
     export GITHUB_PAT="$(cat /run/secrets/GITHUB_TOKEN)" && \
-    R -e 'devtools::install_version("bettermc", version = "1.1.2")' && \
-    R -e 'devtools::install_github("cmu-delphi/covidcast", ref = "evalcast", subdir = "R-packages/evalcast")' && \
-    R -e 'devtools::install_github(repo="ryantibs/quantgen", subdir="quantgen")' && \
-    R -e 'install.packages(list.files(path="/opt/gurobi/linux64/R/", pattern="^gurobi_.*[.]tar[.]gz$", full.names = TRUE), repos=NULL)'
+    R -e 'rspm::enable(); pak::pkg_install(c("roxygen2", "Rglpk", "argparser", "gfkse/bettermc@v1.1.2", "cmu-delphi/covidcast/R-packages/evalcast@evalcast", "ryantibs/quantgen/quantgen"))'
+RUN R -e 'install.packages(list.files(path="/opt/gurobi/linux64/R/", pattern="^gurobi_.*[.]tar[.]gz$", full.names = TRUE), repos=NULL)'
 
 WORKDIR /backfill_corrections/
 ADD ./delphiBackfillCorrection ./delphiBackfillCorrection/


### PR DESCRIPTION
### Description
The buildprocess in https://github.com/cmu-delphi/covidcast-indicators/pull/1957 broke seemingly caused by an update to the R version. This should fix that.

### Changelog

- R CMD CHECK for this package only works on R <= 4.2, so pin Dockerfile to `rocker/tidyverse:4.2`
- Update Dockerfile to use `pak` and `rspm` to install dependencies via binaries (removed system dependencies install command because `pak` takes care of those), should speed things up
- Tested the Dockerfile build process locally and it built successfully
- Simplified `backfill-corr-ci.yml` (setup-r-dependencies already caches, so no need for the caching action)


