### PR TITLE
add warnings for unreasonable weekday effect

### DIFF
--- a/_delphi_utils_python/delphi_utils/weekday.py
+++ b/_delphi_utils_python/delphi_utils/weekday.py
@@ -41,9 +41,15 @@ class Weekday:
                 logger.error("Unable to calculate weekday correction")
             else:
                 params[i,:] = result
-        if np.exp(-params).max() == np.inf:
+        # the values multiplied by in calc_adjustment
+        # Sunday, the last day here, is a sum of the other days
+        effective_multipliers = np.exp(np.concatenate([-params[:,:6], params[:,:6].sum(axis=0, keepdims = True)]))
+
+        if effective_multipliers.max() == np.inf or effective_multipliers.min() == -np.inf:
             logger.warning("largest weekday correction is infinite. Defaulting to no correction")
             params = np.zeros((nums.shape[1], X.shape[1]))
+        else if effective_multipliers.max() > 1000:
+            logger.warning("largest weekday correction is over a factor of 1000. This is probably an error, but may be associated with a zero value.")
         return params
 
     @staticmethod

--- a/_delphi_utils_python/delphi_utils/weekday.py
+++ b/_delphi_utils_python/delphi_utils/weekday.py
@@ -48,7 +48,7 @@ class Weekday:
         if effective_multipliers.max() == np.inf or effective_multipliers.min() == -np.inf:
             logger.warning("largest weekday correction is infinite. Defaulting to no correction")
             params = np.zeros((nums.shape[1], X.shape[1]))
-        else if effective_multipliers.max() > 1000:
+        elif effective_multipliers.max() > 1000:
             logger.warning("largest weekday correction is over a factor of 1000. This is probably an error, but may be associated with a zero value.")
         return params
 

--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -27,7 +27,7 @@ required = [
 
 setup(
     name="delphi_utils",
-    version="0.3.23",
+    version="0.3.24",
     description="Shared Utility Functions for Indicators",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -27,7 +27,7 @@ required = [
 
 setup(
     name="delphi_utils",
-    version="0.3.24",
+    version="0.3.23",
     description="Shared Utility Functions for Indicators",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
+++ b/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
@@ -61,12 +61,16 @@ def download(ftp_credentials, out_path, logger):
     client = paramiko.SSHClient()
     client.set_missing_host_key_policy(AllowAnythingPolicy())
 
-    client.connect(ftp_credentials["host"],
-                   username=ftp_credentials["user"],
-                   password=ftp_credentials["pass"],
-                   port=ftp_credentials["port"])
+    client.connect(
+        ftp_credentials["host"],
+        username=ftp_credentials["user"],
+        password=ftp_credentials["pass"],
+        port=ftp_credentials["port"],
+        allow_agent=False,
+        look_for_keys=False,
+    )
     sftp = client.open_sftp()
-    sftp.chdir('/optum/receiving')
+    sftp.chdir("/optum/receiving")
 
     # go through files in recieving dir
     files_to_download = []


### PR DESCRIPTION
### Description
A possible source of problems in `doctor_visits` is Weekday adjustment. This adds warnings if the parameters ever get too large, and overrides them if they're ever infinite.

### Changelog
Itemize code/test/documentation changes and files added/removed.
- add warning if the weekday multiplier is ever over 1000 (this is after applying `exp(-params)` appropriately
- add warning and return a null multiplier if the values are infinite

### Fixes 
- Unclear if this fixes `doctor_visits` or not
