### PR TITLE
Add params to control solver, default Clarabel, pin cvxpy version

### DIFF
--- a/_delphi_utils_python/delphi_utils/weekday.py
+++ b/_delphi_utils_python/delphi_utils/weekday.py
@@ -12,13 +12,13 @@ class Weekday:
     """Class to handle weekday effects."""
 
     @staticmethod
-    def get_params(data, denominator_col, numerator_cols, date_col, scales, logger, solver=cp.ECOS):
+    def get_params(data, denominator_col, numerator_cols, date_col, scales, logger, solver=cp.CLARABEL):
         r"""Fit weekday correction for each col in numerator_cols.
 
         Return a matrix of parameters: the entire vector of betas, for each time
         series column in the data.
 
-        solver: Historically we default to "ECOS" but if encounter numerical issues, "CLARABEL" can be used instead.
+        solver: Historically use "ECOS" but due to numerical issues, "CLARABEL" is now default.
         """
         tmp = data.reset_index()
         denoms = tmp.groupby(date_col).sum()[denominator_col]
@@ -46,7 +46,7 @@ class Weekday:
         return params
 
     @staticmethod
-    def _fit(X, scales, npnums, npdenoms, solver=cp.ECOS):
+    def _fit(X, scales, npnums, npdenoms, solver=cp.CLARABEL):
         r"""Correct a signal estimated as numerator/denominator for weekday effects.
 
         The ordinary estimate would be numerator_t/denominator_t for each time point
@@ -81,7 +81,7 @@ class Weekday:
         ll = (numerator * (X*b + log(denominator)) - sum(exp(X*b) + log(denominator)))
                 / num_days
 
-        solver: Historically we default to "ECOS" but if encounter numerical issues, "CLARABEL" can be used instead.
+        solver: Historically use "ECOS" but due to numerical issues, "CLARABEL" is now default.
         """
         b = cp.Variable((X.shape[1]))
 

--- a/_delphi_utils_python/delphi_utils/weekday.py
+++ b/_delphi_utils_python/delphi_utils/weekday.py
@@ -12,19 +12,14 @@ class Weekday:
     """Class to handle weekday effects."""
 
     @staticmethod
-    def get_params_legacy(data, denominator_col, numerator_cols, date_col, scales, logger):
-        # This preserves the older default behavior of using the ECOS solver.
-        # NOTE: "ECOS" solver will not be installed by default as of cvxpy 1.6
-        return get_params(data, denominator_col, numerator_cols, date_col, scales, logger, solver_override=cp.ECOS)
-
-    @staticmethod
     def get_params(data, denominator_col, numerator_cols, date_col, scales, logger, solver_override=None):
         r"""Fit weekday correction for each col in numerator_cols.
 
         Return a matrix of parameters: the entire vector of betas, for each time
         series column in the data.
 
-        solver: Historically used "ECOS" but due to numerical stability issues, "CLARABEL" (introduced in cvxpy 1.3) is now the default solver in cvxpy 1.5.
+        solver: Historically used "ECOS" but due to numerical stability issues, "CLARABEL"
+        (introduced in cvxpy 1.3)is now the default solver in cvxpy 1.5.
         """
         if solver_override is None:
             solver = cp.CLARABEL
@@ -54,6 +49,14 @@ class Weekday:
                 params[i,:] = result
 
         return params
+
+    @staticmethod
+    def get_params_legacy(data, denominator_col, numerator_cols, date_col, scales, logger):
+        r"""
+        This preserves the older default behavior of using the ECOS solver.
+        NOTE: "ECOS" solver will not be installed by default as of cvxpy 1.6
+        """
+        return get_params(data, denominator_col, numerator_cols, date_col, scales, logger, solver_override=cp.ECOS)
 
     @staticmethod
     def _fit(X, scales, npnums, npdenoms, solver):

--- a/_delphi_utils_python/delphi_utils/weekday.py
+++ b/_delphi_utils_python/delphi_utils/weekday.py
@@ -56,7 +56,7 @@ class Weekday:
         This preserves the older default behavior of using the ECOS solver.
         NOTE: "ECOS" solver will not be installed by default as of cvxpy 1.6
         """
-        return get_params(data, denominator_col, numerator_cols, date_col, scales, logger, solver_override=cp.ECOS)
+        return Weekday.get_params(data, denominator_col, numerator_cols, date_col, scales, logger, solver_override=cp.ECOS)
 
     @staticmethod
     def _fit(X, scales, npnums, npdenoms, solver):

--- a/_delphi_utils_python/delphi_utils/weekday.py
+++ b/_delphi_utils_python/delphi_utils/weekday.py
@@ -93,7 +93,7 @@ class Weekday:
         for scale in scales:
             try:
                 prob = cp.Problem(cp.Minimize((-ll + lmbda * penalty) / scale))
-                _ = prob.solve(solver=cp.CLARABEL)
+                _ = prob.solve()
                 return b.value
             except SolverError:
                 # If the magnitude of the objective function is too large, an error is

--- a/_delphi_utils_python/delphi_utils/weekday.py
+++ b/_delphi_utils_python/delphi_utils/weekday.py
@@ -53,7 +53,8 @@ class Weekday:
     @staticmethod
     def get_params_legacy(data, denominator_col, numerator_cols, date_col, scales, logger):
         r"""
-        This preserves the older default behavior of using the ECOS solver.
+        Preserves older default behavior of using the ECOS solver.
+
         NOTE: "ECOS" solver will not be installed by default as of cvxpy 1.6
         """
         return Weekday.get_params(

--- a/_delphi_utils_python/delphi_utils/weekday.py
+++ b/_delphi_utils_python/delphi_utils/weekday.py
@@ -58,13 +58,7 @@ class Weekday:
         NOTE: "ECOS" solver will not be installed by default as of cvxpy 1.6
         """
         return Weekday.get_params(
-            data,
-            denominator_col,
-            numerator_cols,
-            date_col,
-            scales,
-            logger,
-            solver_override=cp.ECOS
+            data, denominator_col, numerator_cols, date_col, scales, logger, solver_override=cp.ECOS
         )
 
     @staticmethod

--- a/_delphi_utils_python/delphi_utils/weekday.py
+++ b/_delphi_utils_python/delphi_utils/weekday.py
@@ -56,7 +56,15 @@ class Weekday:
         This preserves the older default behavior of using the ECOS solver.
         NOTE: "ECOS" solver will not be installed by default as of cvxpy 1.6
         """
-        return Weekday.get_params(data, denominator_col, numerator_cols, date_col, scales, logger, solver_override=cp.ECOS)
+        return Weekday.get_params(
+            data,
+            denominator_col,
+            numerator_cols,
+            date_col,
+            scales,
+            logger,
+            solver_override=cp.ECOS
+        )
 
     @staticmethod
     def _fit(X, scales, npnums, npdenoms, solver):

--- a/_delphi_utils_python/tests/test_weekday.py
+++ b/_delphi_utils_python/tests/test_weekday.py
@@ -25,6 +25,31 @@ class TestWeekday:
                                     -0.81464459, -0.76322013, -0.7667211,-0.8251475]])
         assert np.allclose(result, expected_result)
 
+    def test_get_params_legacy(self):
+        TEST_LOGGER = logging.getLogger()
+
+        result = Weekday.get_params(self.TEST_DATA, "den", ["num"], "date", [1], TEST_LOGGER)
+        print(result)
+        expected_result = [
+            -0.05993665,
+            -0.0727396,
+            -0.05618517,
+            0.0343405,
+            0.12534997,
+            0.04561813,
+            -2.27669028,
+            -1.89564374,
+            -1.5695407,
+            -1.29838116,
+            -1.08216513,
+            -0.92089259,
+            -0.81456355,
+            -0.76317802,
+            -0.76673598,
+            -0.82523745,
+        ]
+        assert np.allclose(result, expected_result)
+
     def test_calc_adjustment_with_zero_parameters(self):
         params = np.array([[0, 0, 0, 0, 0, 0, 0]])
 

--- a/_delphi_utils_python/tests/test_weekday.py
+++ b/_delphi_utils_python/tests/test_weekday.py
@@ -28,7 +28,7 @@ class TestWeekday:
     def test_get_params_legacy(self):
         TEST_LOGGER = logging.getLogger()
 
-        result = Weekday.get_params(self.TEST_DATA, "den", ["num"], "date", [1], TEST_LOGGER)
+        result = Weekday.get_params_legacy(self.TEST_DATA, "den", ["num"], "date", [1], TEST_LOGGER)
         print(result)
         expected_result = [
             -0.05993665,

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -10,8 +10,6 @@ Created: 2020-09-27
 import logging
 from multiprocessing import Pool, cpu_count
 
-import cvxpy as cp
-
 # third party
 import numpy as np
 import pandas as pd

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -9,6 +9,7 @@ Created: 2020-09-27
 # standard packages
 import logging
 from multiprocessing import Pool, cpu_count
+import cvxpy as cp
 
 # third party
 import numpy as np
@@ -159,6 +160,7 @@ class ClaimsHospIndicatorUpdater:
             Config.DATE_COL,
             [1, 1e5],
             logger,
+            cp.ECOS,
         ) if self.weekday else None
 
         # run fitting code (maybe in parallel)

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -155,14 +155,13 @@ class ClaimsHospIndicatorUpdater:
 
         # handle if we need to adjust by weekday
         wd_params = (
-            Weekday.get_params(
+            Weekday.get_params_legacy(
                 data_frame,
                 "den",
                 ["num"],
                 Config.DATE_COL,
                 [1, 1e5],
                 logger,
-                cp.ECOS,
             )
             if self.weekday
             else None

--- a/claims_hosp/delphi_claims_hosp/update_indicator.py
+++ b/claims_hosp/delphi_claims_hosp/update_indicator.py
@@ -9,18 +9,19 @@ Created: 2020-09-27
 # standard packages
 import logging
 from multiprocessing import Pool, cpu_count
+
 import cvxpy as cp
 
 # third party
 import numpy as np
 import pandas as pd
-from delphi_utils import GeoMapper
 
 # first party
-from delphi_utils import Weekday
+from delphi_utils import GeoMapper, Weekday
+
 from .config import Config, GeoConstants
-from .load_data import load_data
 from .indicator import ClaimsHospIndicator
+from .load_data import load_data
 
 
 class ClaimsHospIndicatorUpdater:
@@ -153,16 +154,19 @@ class ClaimsHospIndicatorUpdater:
         data_frame = self.geo_reindex(data)
 
         # handle if we need to adjust by weekday
-        wd_params = Weekday.get_params(
-            data_frame,
-            "den",
-            ["num"],
-            Config.DATE_COL,
-            [1, 1e5],
-            logger,
-            cp.ECOS,
-        ) if self.weekday else None
-
+        wd_params = (
+            Weekday.get_params(
+                data_frame,
+                "den",
+                ["num"],
+                Config.DATE_COL,
+                [1, 1e5],
+                logger,
+                cp.ECOS,
+            )
+            if self.weekday
+            else None
+        )
         # run fitting code (maybe in parallel)
         rates = {}
         std_errs = {}

--- a/claims_hosp/setup.py
+++ b/claims_hosp/setup.py
@@ -13,6 +13,7 @@ required = [
     "pylint==2.8.3",
     "pytest-cov",
     "pytest",
+    "cvxpy<=1.4",
 ]
 
 setup(

--- a/claims_hosp/setup.py
+++ b/claims_hosp/setup.py
@@ -13,7 +13,7 @@ required = [
     "pylint==2.8.3",
     "pytest-cov",
     "pytest",
-    "cvxpy<=1.4",
+    "cvxpy<1.6",
 ]
 
 setup(

--- a/doctor_visits/delphi_doctor_visits/update_sensor.py
+++ b/doctor_visits/delphi_doctor_visits/update_sensor.py
@@ -133,7 +133,7 @@ def update_sensor(
         Config.DATE_COL,
         [1, 1e5, 1e10, 1e15],
         logger,
-        cp.CLARABEL, # switch to using Clarabel for weekday adjustment to avoid numerical issues with historical ECOS use
+        cp.CLARABEL, # switch to Clarabel to avoid numerical issues associated w ECOS
     ) if weekday else None
     if weekday and np.any(np.all(params == 0,axis=1)):
         # Weekday correction failed for at least one count type

--- a/doctor_visits/delphi_doctor_visits/update_sensor.py
+++ b/doctor_visits/delphi_doctor_visits/update_sensor.py
@@ -15,6 +15,7 @@ from multiprocessing import Pool, cpu_count
 # third party
 import numpy as np
 import pandas as pd
+import cvxpy as cp
 
 # first party
 from delphi_utils import Weekday
@@ -132,6 +133,7 @@ def update_sensor(
         Config.DATE_COL,
         [1, 1e5, 1e10, 1e15],
         logger,
+        cp.CLARABEL, # switch to using Clarabel for weekday adjustment to avoid numerical issues with historical ECOS use
     ) if weekday else None
     if weekday and np.any(np.all(params == 0,axis=1)):
         # Weekday correction failed for at least one count type

--- a/doctor_visits/delphi_doctor_visits/update_sensor.py
+++ b/doctor_visits/delphi_doctor_visits/update_sensor.py
@@ -11,11 +11,11 @@ Modified:
 # standard packages
 from datetime import timedelta
 from multiprocessing import Pool, cpu_count
+import cvxpy as cp
 
 # third party
 import numpy as np
 import pandas as pd
-import cvxpy as cp
 
 # first party
 from delphi_utils import Weekday
@@ -126,16 +126,20 @@ def update_sensor(
         (burn_in_dates >= startdate) & (burn_in_dates <= enddate))[0][:len(sensor_dates)]
 
     # handle if we need to adjust by weekday
-    params = Weekday.get_params(
-        data,
-        "Denominator",
-        Config.CLI_COLS + Config.FLU1_COL,
-        Config.DATE_COL,
-        [1, 1e5, 1e10, 1e15],
-        logger,
-        cp.CLARABEL, # switch to Clarabel to avoid numerical issues associated w ECOS
-    ) if weekday else None
-    if weekday and np.any(np.all(params == 0,axis=1)):
+    params = (
+        Weekday.get_params(
+            data,
+            "Denominator",
+            Config.CLI_COLS + Config.FLU1_COL,
+            Config.DATE_COL,
+            [1, 1e5, 1e10, 1e15],
+            logger,
+            cp.CLARABEL,  # switch to Clarabel to avoid numerical issues associated w ECOS
+        )
+        if weekday
+        else None
+    )
+    if weekday and np.any(np.all(params == 0, axis=1)):
         # Weekday correction failed for at least one count type
         return None
 

--- a/doctor_visits/delphi_doctor_visits/update_sensor.py
+++ b/doctor_visits/delphi_doctor_visits/update_sensor.py
@@ -11,6 +11,7 @@ Modified:
 # standard packages
 from datetime import timedelta
 from multiprocessing import Pool, cpu_count
+
 import cvxpy as cp
 
 # third party
@@ -19,6 +20,7 @@ import pandas as pd
 
 # first party
 from delphi_utils import Weekday
+
 from .config import Config
 from .geo_maps import GeoMaps
 from .sensor import DoctorVisitsSensor

--- a/doctor_visits/delphi_doctor_visits/update_sensor.py
+++ b/doctor_visits/delphi_doctor_visits/update_sensor.py
@@ -12,8 +12,6 @@ Modified:
 from datetime import timedelta
 from multiprocessing import Pool, cpu_count
 
-import cvxpy as cp
-
 # third party
 import numpy as np
 import pandas as pd
@@ -136,7 +134,6 @@ def update_sensor(
             Config.DATE_COL,
             [1, 1e5, 1e10, 1e15],
             logger,
-            cp.CLARABEL,  # switch to Clarabel to avoid numerical issues associated w ECOS
         )
         if weekday
         else None

--- a/doctor_visits/setup.py
+++ b/doctor_visits/setup.py
@@ -11,6 +11,7 @@ required = [
     "pytest-cov",
     "pytest",
     "scikit-learn",
+    "cvxpy>=1.5",
 ]
 
 setup(


### PR DESCRIPTION
Rollback [this](https://github.com/cmu-delphi/covidcast-indicators/pull/1966) change and replace with version pinning


### Description
ECOS solver is used by hospital admissions (claims_hosp) and doctor_visits weekday-adjusted signals. Recently this solver causes severe numerical problems in some of doctor_visits outlier datapoints. This is not a problem in hospital admissions. Therefore, we change the solver used in doctor_visits to Clarabel and keep ECOS use in claims_hosp for consistency.

Knowing that the default solver in cvxpy 1.5 onward will be Clarabel while previous versions keep ECOS, we pin the versions accordingly for these two indicators.

### Changelog
- remove clarabel spec in weekday
- pin claims_hosp cvxpy setup to <=1.4
- pin doctor_visits cvxpy setup to >=1.5
- Specify use of clarabel/ecos as params.
### Fixes 
- Fixes same as #1966 without affecting claims_hosp
