### PR TITLE
Reformat NSSP county zip code

### DIFF
--- a/nssp/delphi_nssp/constants.py
+++ b/nssp/delphi_nssp/constants.py
@@ -37,6 +37,6 @@ TYPE_DICT.update(
         "timestamp": "datetime64[ns]",
         "geography": str,
         "county": str,
-        "fips": int,
+        "fips": str,
     }
 )

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -68,7 +68,7 @@ def pull_nssp_data(socrata_token: str):
         raise ValueError(warn_string(df_ervisits, TYPE_DICT)) from exc
 
     # Format county fips to all be 5 digits with leading zeros
-    df_ervisits['fips'] = df_ervisits['fips'].apply(lambda x: str(x).zfill(5) if str(x) != '0' else '0')
+    df_ervisits["fips"] = df_ervisits["fips"].apply(lambda x: str(x).zfill(5) if str(x) != "0" else "0")
 
     keep_columns = ["timestamp", "geography", "county", "fips"]
     return df_ervisits[SIGNALS + keep_columns]

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -67,5 +67,8 @@ def pull_nssp_data(socrata_token: str):
     except KeyError as exc:
         raise ValueError(warn_string(df_ervisits, TYPE_DICT)) from exc
 
+    # Format county fips to all be 5 digits with leading zeros
+    df_ervisits['fips'] = df_ervisits['fips'].apply(lambda x: str(x).zfill(5) if str(x) != '0' else '0')
+
     keep_columns = ["timestamp", "geography", "county", "fips"]
     return df_ervisits[SIGNALS + keep_columns]

--- a/nssp/tests/test_data/page.txt
+++ b/nssp/tests/test_data/page.txt
@@ -61,5 +61,26 @@
         "hsa_nci_id": "All",
         "fips": "0",
         "trend_source": "United States"
+    },
+    {
+    "week_end": "2023-05-13T00:00:00.000",
+    "geography": "Colorado",
+    "county": "Jefferson",
+    "percent_visits_combined": "0.84",
+    "percent_visits_covid": "0.59",
+    "percent_visits_influenza": "0.23",
+    "percent_visits_rsv": "0.03",
+    "percent_visits_smoothed": "0.83",
+    "percent_visits_smoothed_covid": "0.62",
+    "percent_visits_smoothed_1": "0.18",
+    "percent_visits_smoothed_rsv": "0.02",
+    "ed_trends_covid": "Decreasing",
+    "ed_trends_influenza": "No Change",
+    "ed_trends_rsv": "Decreasing",
+    "hsa": "Denver (Denver), CO - Jefferson, CO",
+    "hsa_counties": "Adams, Arapahoe, Clear Creek, Denver, Douglas, Elbert, Gilpin, Grand, Jefferson, Park, Summit",
+    "hsa_nci_id": "688",
+    "fips": "8059",
+    "trend_source": "HSA"
     }
 ]

--- a/nssp/tests/test_pull.py
+++ b/nssp/tests/test_pull.py
@@ -49,6 +49,7 @@ class TestPullNSSPData(unittest.TestCase):
         assert result["geography"].notnull().all(), "geography has rogue NaN"
         assert result["county"].notnull().all(), "county has rogue NaN"
         assert result["fips"].notnull().all(), "fips has rogue NaN"
+        assert result["fips"].apply(lambda x: isinstance(x, str) and len(x) != 4).all(), "fips formatting should be 5 digits, including leading zeros if exists"
 
         # Check for each signal in SIGNALS
         for signal in SIGNALS:

--- a/nssp/tests/test_pull.py
+++ b/nssp/tests/test_pull.py
@@ -49,7 +49,7 @@ class TestPullNSSPData(unittest.TestCase):
         assert result["geography"].notnull().all(), "geography has rogue NaN"
         assert result["county"].notnull().all(), "county has rogue NaN"
         assert result["fips"].notnull().all(), "fips has rogue NaN"
-        assert result["fips"].apply(lambda x: isinstance(x, str) and len(x) != 4).all(), "fips formatting should be 5 digits, including leading zeros if exists"
+        assert result["fips"].apply(lambda x: isinstance(x, str) and len(x) != 4).all(), "fips formatting should always be 5 digits; include leading zeros if aplicable"
 
         # Check for each signal in SIGNALS
         for signal in SIGNALS:


### PR DESCRIPTION
### Description
[Testing NSSP on staging](https://cronicle-prod-01.delphi.cmu.edu/#JobDetails?id=jlxj2cuv60v) shows some NSSP geo_ids at county level don't match what's expected in our db and so cannot be ingested. This is because our db takes 5-digit zip codes (e.g. 08059), while nssp source may note the same county down with 4-digit (8059). 

This fix adds a leading 0 all 4-digit zip codes present in nssp source.

### Changelog
This fix adds a leading 0 all 4-digit zip codes present in nssp source when pulling from API.
