### PR TITLE
Doctor_visits patching code

### DIFF
--- a/doctor_visits/README.md
+++ b/doctor_visits/README.md
@@ -53,3 +53,9 @@ The output will show the number of unit tests that passed and failed, along
 with the percentage of code covered by the tests. None of the tests should
 fail and the code lines that are not covered by unit tests should be small and
 should not include critical sub-routines.
+
+## Running Patches:
+To get data issued during specific date range, output in batch issue format, adjust `params.json` in accordance with `patch.py`, then run
+```
+env/bin/python delphi_doctor_visits/patch.py
+```

--- a/doctor_visits/README.md
+++ b/doctor_visits/README.md
@@ -57,5 +57,5 @@ should not include critical sub-routines.
 ## Running Patches:
 To get data issued during specific date range, output in batch issue format, adjust `params.json` in accordance with `patch.py`, then run
 ```
-env/bin/python delphi_doctor_visits/patch.py
+env/bin/python -m delphi_doctor_visits.patch
 ```

--- a/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
+++ b/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
@@ -51,9 +51,14 @@ def change_date_format(name):
     name = '_'.join(split_name)
     return name
 
-def download(ftp_credentials, out_path, logger):
+def download(ftp_credentials, out_path, logger, issue=None):
     """Pull the latest raw files."""
-    current_time = datetime.datetime.now()
+
+    if issue is None:
+        current_time = datetime.datetime.now()
+    else:
+        current_time = datetime.datetime.strptime(issue, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
+
     logger.info("starting download", time=current_time)
     seconds_in_day = 24 * 60 * 60
 

--- a/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
+++ b/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
@@ -51,12 +51,12 @@ def change_date_format(name):
     name = '_'.join(split_name)
     return name
 
-def download(ftp_credentials, out_path, logger, issue=None):
+def download(ftp_credentials, out_path, logger, issue_date=None):
     """Pull the latest raw files."""
-    if issue is None:
+    if not issue_date:
         current_time = datetime.datetime.now()
     else:
-        current_time = datetime.datetime.strptime(issue, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
+        current_time = datetime.datetime.strptime(issue_date, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
 
     logger.info("starting download", time=current_time)
     seconds_in_day = 24 * 60 * 60

--- a/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
+++ b/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
@@ -53,7 +53,6 @@ def change_date_format(name):
 
 def download(ftp_credentials, out_path, logger, issue=None):
     """Pull the latest raw files."""
-
     if issue is None:
         current_time = datetime.datetime.now()
     else:

--- a/doctor_visits/delphi_doctor_visits/get_latest_claims_name.py
+++ b/doctor_visits/delphi_doctor_visits/get_latest_claims_name.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 def get_latest_filename(dir_path, logger, patch=False):
     """Get the latest filename from the list of downloaded raw files."""
-    current_date = datetime.datetime.now()
+    if patch:
+        current_date = datetime.datetime.strptime(issue, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
+    else:
+        current_date = datetime.datetime.now()
     files = list(Path(dir_path).glob("*"))
 
     latest_timestamp = datetime.datetime(1900, 1, 1)
@@ -24,8 +27,7 @@ def get_latest_filename(dir_path, logger, patch=False):
                     latest_timestamp = timestamp
                     latest_filename = file
 
-    if not patch:
-        assert current_date.date() == latest_timestamp.date(), "no drop for today"
+    assert current_date.date() == latest_timestamp.date(), f"no drop for {current_date}"
 
     logger.info("Latest claims file", filename=latest_filename)
 

--- a/doctor_visits/delphi_doctor_visits/get_latest_claims_name.py
+++ b/doctor_visits/delphi_doctor_visits/get_latest_claims_name.py
@@ -5,7 +5,7 @@
 import datetime
 from pathlib import Path
 
-def get_latest_filename(dir_path, logger):
+def get_latest_filename(dir_path, logger, patch=False):
     """Get the latest filename from the list of downloaded raw files."""
     current_date = datetime.datetime.now()
     files = list(Path(dir_path).glob("*"))
@@ -24,7 +24,8 @@ def get_latest_filename(dir_path, logger):
                     latest_timestamp = timestamp
                     latest_filename = file
 
-    assert current_date.date() == latest_timestamp.date(), "no drop for today"
+    if not patch:
+        assert current_date.date() == latest_timestamp.date(), "no drop for today"
 
     logger.info("Latest claims file", filename=latest_filename)
 

--- a/doctor_visits/delphi_doctor_visits/get_latest_claims_name.py
+++ b/doctor_visits/delphi_doctor_visits/get_latest_claims_name.py
@@ -5,10 +5,10 @@
 import datetime
 from pathlib import Path
 
-def get_latest_filename(dir_path, logger, issue=None):
+def get_latest_filename(dir_path, logger, issue_date=None):
     """Get the latest filename from the list of downloaded raw files."""
-    if issue:
-        current_date = datetime.datetime.strptime(issue, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
+    if issue_date:
+        current_date = datetime.datetime.strptime(issue_date, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
     else:
         current_date = datetime.datetime.now()
     files = list(Path(dir_path).glob("*"))

--- a/doctor_visits/delphi_doctor_visits/get_latest_claims_name.py
+++ b/doctor_visits/delphi_doctor_visits/get_latest_claims_name.py
@@ -5,9 +5,9 @@
 import datetime
 from pathlib import Path
 
-def get_latest_filename(dir_path, logger, patch=False):
+def get_latest_filename(dir_path, logger, issue=None):
     """Get the latest filename from the list of downloaded raw files."""
-    if patch:
+    if issue:
         current_date = datetime.datetime.strptime(issue, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
     else:
         current_date = datetime.datetime.now()

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -6,18 +6,17 @@ It will generate data for that range of issue dates, and store them in batch iss
 """
 from datetime import datetime, timedelta
 from os import makedirs
+
 from delphi_utils import read_params, get_structured_logger
 from delphi_doctor_visits.run import run_module
-from datetime import datetime, timedelta
+
 
 if __name__ == "__main__":
-    '''
-    Run the doctor visits indicator for a range of issue dates, specified in params.json using following keys:
-    - "patch": Only used for patching data
-        - "start_date": str, YYYY-MM-DD format, first issue date
-        - "end_date": str, YYYY-MM-DD format, last issue date
-        - "patch_dir": str, directory to write all issues output
-    '''
+    # Run the doctor visits indicator for a range of issue dates, specified in params.json using following keys:
+    # - "patch": Only used for patching data
+    #     - "start_date": str, YYYY-MM-DD format, first issue date
+    #     - "end_date": str, YYYY-MM-DD format, last issue date
+    #     - "patch_dir": str, directory to write all issues output
     params = read_params()
     logger = get_structured_logger(__name__, filename=params["common"]["log_filename"])
 

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -1,5 +1,10 @@
-import json
-import subprocess
+"""
+This module is used for patching data in the delphi_doctor_visits package.
+To use this module, you need to specify the range of issue dates in params.json.
+It will generate data for that range of issue dates, and store them in batch issue format:
+[name-of-patch]/issue_[issue-date]/nssp/actual_data_file.csv
+"""
+from datetime import datetime, timedelta
 from os import makedirs
 from delphi_utils import read_params, get_structured_logger
 from delphi_doctor_visits.run import run_module
@@ -9,15 +14,15 @@ if __name__ == "__main__":
     '''
     Run the doctor visits indicator for a range of issue dates, specified in params.json using following keys:
     - "patch": Only used for patching data
-        + start_date: str, YYYY-MM-DD format, first issue date
-        + end_date: str, YYYY-MM-DD format, last issue date
-        + patch_dir: str, directory to write all issues output
+        - "start_date": str, YYYY-MM-DD format, first issue date
+        - "end_date": str, YYYY-MM-DD format, last issue date
+        - "patch_dir": str, directory to write all issues output
     '''
     params = read_params()
     logger = get_structured_logger(__name__, filename=params["common"]["log_filename"])
 
     start_issue = datetime.strptime(params["patch"]["start_issue"], "%Y-%m-%d")
-    end_issue = datetime.strptime(params["patch"]["end_issue"], "%Y-%m-%d") 
+    end_issue = datetime.strptime(params["patch"]["end_issue"], "%Y-%m-%d")
 
     logger.info(f"""Start patching {params["patch"]["patch_dir"]}""")
     logger.info(f"""Start issue: {start_issue.strftime("%Y-%m-%d")}""")
@@ -32,9 +37,10 @@ if __name__ == "__main__":
 
         params["patch"]["current_issue"] = current_issue.strftime("%Y-%m-%d")
 
-        current_issue_dir = f"""{params["patch"]["patch_dir"]}/issue_{params['patch']['current_issue'].replace("-", "")}/nssp"""
-        params["common"]["export_dir"] = f"""{current_issue_dir}"""
+        current_issue_yyyymmdd = current_issue.strftime("%Y%m%d")
+        current_issue_dir = f"""{params["patch"]["patch_dir"]}/issue_{current_issue_yyyymmdd}/nssp"""
         makedirs(f"{current_issue_dir}", exist_ok=True)
+        params["common"]["export_dir"] = f"""{current_issue_dir}"""
 
         run_module(params)
         current_issue += timedelta(days=1)

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -4,7 +4,7 @@ This module is used for patching data in the delphi_doctor_visits package.
 To use this module, you need to specify the range of issue dates in params.json.
 
 It will generate data for that range of issue dates, and store them in batch issue format:
-[name-of-patch]/issue_[issue-date]/nssp/actual_data_file.csv
+[name-of-patch]/issue_[issue-date]/doctor-visits/actual_data_file.csv
 """
 
 from datetime import datetime, timedelta
@@ -40,7 +40,7 @@ if __name__ == "__main__":
         params["patch"]["current_issue"] = current_issue.strftime("%Y-%m-%d")
 
         current_issue_yyyymmdd = current_issue.strftime("%Y%m%d")
-        current_issue_dir = f"""{params["patch"]["patch_dir"]}/issue_{current_issue_yyyymmdd}/nssp"""
+        current_issue_dir = f"""{params["patch"]["patch_dir"]}/issue_{current_issue_yyyymmdd}/doctor-visits"""
         makedirs(f"{current_issue_dir}", exist_ok=True)
         params["common"]["export_dir"] = f"""{current_issue_dir}"""
 

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -11,7 +11,7 @@ from os import makedirs
 
 from delphi_utils import read_params, get_structured_logger
 
-from delphi_doctor_visits.run import run_module
+from .run import run_module
 
 if __name__ == "__main__":
     # Run the doctor visits indicator for a range of issue dates, specified in params.json using following keys:

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -1,0 +1,33 @@
+import json
+import subprocess
+from os import makedirs
+from delphi_utils import read_params, get_structured_logger
+from delphi_doctor_visits.run import run_module
+from datetime import datetime, timedelta
+
+if __name__ == "__main__":
+    params = read_params()
+    logger = get_structured_logger(__name__, filename=params["common"]["log_filename"])
+
+    start_issue = datetime.strptime(params["patch"]["start_issue"], "%Y-%m-%d")
+    end_issue = datetime.strptime(params["patch"]["end_issue"], "%Y-%m-%d") 
+
+    logger.info(f"""Start patching {params["patch"]["patch_dir"]}""")
+    logger.info(f"""Start issue: {start_issue.strftime("%Y-%m-%d")}""")
+    logger.info(f"""End issue: {end_issue.strftime("%Y-%m-%d")}""")
+
+    makedirs(params["patch"]["patch_dir"], exist_ok=True)
+
+    current_issue = start_issue
+
+    while current_issue <= end_issue:
+        logger.info(f"""Running issue {current_issue.strftime("%Y-%m-%d")}""")
+
+        params["patch"]["current_issue"] = current_issue.strftime("%Y-%m-%d")
+
+        current_issue_dir = f"""{params["patch"]["patch_dir"]}/issue_{params['patch']['current_issue'].replace("-", "")}/nssp"""
+        params["common"]["export_dir"] = f"""{current_issue_dir}"""
+        makedirs(f"{current_issue_dir}", exist_ok=True)
+
+        run_module(params)
+        current_issue += timedelta(days=1)

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -1,6 +1,8 @@
 """
 This module is used for patching data in the delphi_doctor_visits package.
+
 To use this module, you need to specify the range of issue dates in params.json.
+
 It will generate data for that range of issue dates, and store them in batch issue format:
 [name-of-patch]/issue_[issue-date]/nssp/actual_data_file.csv
 """

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     #     - "end_date": str, YYYY-MM-DD format, last issue date
     #     - "patch_dir": str, directory to write all issues output
     params = read_params()
-    logger = get_structured_logger(__name__, filename=params["common"]["log_filename"])
+    logger = get_structured_logger("delphi_doctor_visits.patch", filename=params["common"]["log_filename"])
 
     start_issue = datetime.strptime(params["patch"]["start_issue"], "%Y-%m-%d")
     end_issue = datetime.strptime(params["patch"]["end_issue"], "%Y-%m-%d")
@@ -44,5 +44,5 @@ if __name__ == "__main__":
         makedirs(f"{current_issue_dir}", exist_ok=True)
         params["common"]["export_dir"] = f"""{current_issue_dir}"""
 
-        run_module(params)
+        run_module(params, logger)
         current_issue += timedelta(days=1)

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -9,8 +9,9 @@ It will generate data for that range of issue dates, and store them in batch iss
 from datetime import datetime, timedelta
 from os import makedirs
 
-from delphi_doctor_visits.run import run_module
 from delphi_utils import read_params, get_structured_logger
+
+from delphi_doctor_visits.run import run_module
 
 if __name__ == "__main__":
     # Run the doctor visits indicator for a range of issue dates, specified in params.json using following keys:

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -14,12 +14,17 @@ from delphi_utils import get_structured_logger, read_params
 
 from .run import run_module
 
-if __name__ == "__main__":
-    # Run the doctor visits indicator for a range of issue dates, specified in params.json using following keys:
-    # - "patch": Only used for patching data
-    #     - "start_date": str, YYYY-MM-DD format, first issue date
-    #     - "end_date": str, YYYY-MM-DD format, last issue date
-    #     - "patch_dir": str, directory to write all issues output
+
+def patch():
+    """
+    Run the doctor visits indicator for a range of issue dates.
+
+    The range of issue dates is specified in params.json using the following keys:
+    - "patch": Only used for patching data
+        - "start_date": str, YYYY-MM-DD format, first issue date
+        - "end_date": str, YYYY-MM-DD format, last issue date
+        - "patch_dir": str, directory to write all issues output
+    """
     params = read_params()
     logger = get_structured_logger("delphi_doctor_visits.patch", filename=params["common"]["log_filename"])
 
@@ -46,3 +51,7 @@ if __name__ == "__main__":
 
         run_module(params, logger)
         current_issue += timedelta(days=1)
+
+
+if __name__ == "__main__":
+    patch()

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -6,6 +6,13 @@ from delphi_doctor_visits.run import run_module
 from datetime import datetime, timedelta
 
 if __name__ == "__main__":
+    '''
+    Run the doctor visits indicator for a range of issue dates, specified in params.json using following keys:
+    - "patch": Only used for patching data
+        + start_date: str, YYYY-MM-DD format, first issue date
+        + end_date: str, YYYY-MM-DD format, last issue date
+        + patch_dir: str, directory to write all issues output
+    '''
     params = read_params()
     logger = get_structured_logger(__name__, filename=params["common"]["log_filename"])
 

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -9,9 +9,8 @@ It will generate data for that range of issue dates, and store them in batch iss
 from datetime import datetime, timedelta
 from os import makedirs
 
-from delphi_utils import read_params, get_structured_logger
 from delphi_doctor_visits.run import run_module
-
+from delphi_utils import read_params, get_structured_logger
 
 if __name__ == "__main__":
     # Run the doctor visits indicator for a range of issue dates, specified in params.json using following keys:

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -1,7 +1,21 @@
 """
 This module is used for patching data in the delphi_doctor_visits package.
 
-To use this module, you need to specify the range of issue dates in params.json.
+To use this module, you need to specify the range of issue dates in params.json, like so:
+
+{
+  "common": {
+    ...
+  },
+  "validation": {
+    ...
+  },
+  "patch": {
+    "patch_dir": "/Users/minhkhuele/Desktop/delphi/covidcast-indicators/doctor_visits/AprilPatch",
+    "start_issue": "2024-04-20",
+    "end_issue": "2024-04-21"
+  }
+}
 
 It will generate data for that range of issue dates, and store them in batch issue format:
 [name-of-patch]/issue_[issue-date]/doctor-visits/actual_data_file.csv

--- a/doctor_visits/delphi_doctor_visits/patch.py
+++ b/doctor_visits/delphi_doctor_visits/patch.py
@@ -6,10 +6,11 @@ To use this module, you need to specify the range of issue dates in params.json.
 It will generate data for that range of issue dates, and store them in batch issue format:
 [name-of-patch]/issue_[issue-date]/nssp/actual_data_file.csv
 """
+
 from datetime import datetime, timedelta
 from os import makedirs
 
-from delphi_utils import read_params, get_structured_logger
+from delphi_utils import get_structured_logger, read_params
 
 from .run import run_module
 

--- a/doctor_visits/delphi_doctor_visits/run.py
+++ b/doctor_visits/delphi_doctor_visits/run.py
@@ -57,10 +57,7 @@ def run_module(params):  # pylint: disable=too-many-statements
     patch = issue is not None
 
     # pull latest data
-    download(params["indicator"]["ftp_credentials"],
-             params["indicator"]["input_dir"],
-             logger,
-             issue=issue)
+    download(params["indicator"]["ftp_credentials"], params["indicator"]["input_dir"], logger, issue=issue)
 
     # find the latest files (these have timestamps)
     claims_file = get_latest_filename(params["indicator"]["input_dir"], logger, patch=patch)

--- a/doctor_visits/delphi_doctor_visits/run.py
+++ b/doctor_visits/delphi_doctor_visits/run.py
@@ -53,13 +53,13 @@ def run_module(params):  # pylint: disable=too-many-statements
         __name__, filename=params["common"].get("log_filename"),
         log_exceptions=params["common"].get("log_exceptions", True))
 
-    issue = params.get("patch", {}).get("current_issue", None)
+    issue_date = params.get("patch", {}).get("current_issue", None)
 
     # pull latest data
-    download(params["indicator"]["ftp_credentials"], params["indicator"]["input_dir"], logger, issue=issue)
+    download(params["indicator"]["ftp_credentials"], params["indicator"]["input_dir"], logger, issue_date=issue_date)
 
     # find the latest files (these have timestamps)
-    claims_file = get_latest_filename(params["indicator"]["input_dir"], logger, issue=issue)
+    claims_file = get_latest_filename(params["indicator"]["input_dir"], logger, issue_date=issue_date)
 
     # modify data
     modify_and_write(claims_file, logger)

--- a/doctor_visits/delphi_doctor_visits/run.py
+++ b/doctor_visits/delphi_doctor_visits/run.py
@@ -54,13 +54,12 @@ def run_module(params):  # pylint: disable=too-many-statements
         log_exceptions=params["common"].get("log_exceptions", True))
 
     issue = params.get("patch", {}).get("current_issue", None)
-    patch = issue is not None
 
     # pull latest data
     download(params["indicator"]["ftp_credentials"], params["indicator"]["input_dir"], logger, issue=issue)
 
     # find the latest files (these have timestamps)
-    claims_file = get_latest_filename(params["indicator"]["input_dir"], logger, patch=patch)
+    claims_file = get_latest_filename(params["indicator"]["input_dir"], logger, issue=issue)
 
     # modify data
     modify_and_write(claims_file, logger)

--- a/doctor_visits/delphi_doctor_visits/run.py
+++ b/doctor_visits/delphi_doctor_visits/run.py
@@ -42,18 +42,28 @@ def run_module(params):  # pylint: disable=too-many-statements
             - "se": bool, whether to write out standard errors
             - "obfuscated_prefix": str, prefix for signal name if write_se is True.
             - "parallel": bool, whether to update sensor in parallel.
+        - "patch": Only used for patching data
+            - start_date: str, YYYY-MM-DD format, first issue date
+            - end_date: str, YYYY-MM-DD format, last issue date
+            - patch_dir: str, directory to write all issues output
+            - current_issue: str, YYYY-MM-DD format, current issue date to patch
     """
     start_time = time.time()
     logger = get_structured_logger(
         __name__, filename=params["common"].get("log_filename"),
         log_exceptions=params["common"].get("log_exceptions", True))
 
+    issue = params.get("patch", {}).get("current_issue", None)
+    patch = issue is not None
+
     # pull latest data
     download(params["indicator"]["ftp_credentials"],
-             params["indicator"]["input_dir"], logger)
+             params["indicator"]["input_dir"],
+             logger,
+             issue=issue)
 
     # find the latest files (these have timestamps)
-    claims_file = get_latest_filename(params["indicator"]["input_dir"], logger)
+    claims_file = get_latest_filename(params["indicator"]["input_dir"], logger, patch=patch)
 
     # modify data
     modify_and_write(claims_file, logger)

--- a/doctor_visits/delphi_doctor_visits/run.py
+++ b/doctor_visits/delphi_doctor_visits/run.py
@@ -20,7 +20,7 @@ from .modify_claims_drops import modify_and_write
 from .get_latest_claims_name import get_latest_filename
 
 
-def run_module(params):  # pylint: disable=too-many-statements
+def run_module(params, logger=None):  # pylint: disable=too-many-statements
     """
     Run doctor visits indicator.
 
@@ -49,11 +49,11 @@ def run_module(params):  # pylint: disable=too-many-statements
             - "patch_dir": str, directory to write all issues output
     """
     start_time = time.time()
-    logger = get_structured_logger(
-        __name__, filename=params["common"].get("log_filename"),
-        log_exceptions=params["common"].get("log_exceptions", True))
-
     issue_date = params.get("patch", {}).get("current_issue", None)
+    if not logger:
+        logger = get_structured_logger(
+            __name__, filename=params["common"].get("log_filename"),
+            log_exceptions=params["common"].get("log_exceptions", True))
 
     # pull latest data
     download(params["indicator"]["ftp_credentials"], params["indicator"]["input_dir"], logger, issue_date=issue_date)

--- a/doctor_visits/delphi_doctor_visits/run.py
+++ b/doctor_visits/delphi_doctor_visits/run.py
@@ -52,8 +52,10 @@ def run_module(params, logger=None):  # pylint: disable=too-many-statements
     issue_date = params.get("patch", {}).get("current_issue", None)
     if not logger:
         logger = get_structured_logger(
-            __name__, filename=params["common"].get("log_filename"),
-            log_exceptions=params["common"].get("log_exceptions", True))
+            __name__,
+            filename=params["common"].get("log_filename"),
+            log_exceptions=params["common"].get("log_exceptions", True),
+        )
 
     # pull latest data
     download(params["indicator"]["ftp_credentials"], params["indicator"]["input_dir"], logger, issue_date=issue_date)

--- a/doctor_visits/delphi_doctor_visits/run.py
+++ b/doctor_visits/delphi_doctor_visits/run.py
@@ -42,11 +42,11 @@ def run_module(params):  # pylint: disable=too-many-statements
             - "se": bool, whether to write out standard errors
             - "obfuscated_prefix": str, prefix for signal name if write_se is True.
             - "parallel": bool, whether to update sensor in parallel.
-        - "patch": Only used for patching data
-            - start_date: str, YYYY-MM-DD format, first issue date
-            - end_date: str, YYYY-MM-DD format, last issue date
-            - patch_dir: str, directory to write all issues output
-            - current_issue: str, YYYY-MM-DD format, current issue date to patch
+        - "patch": Only used for patching data, remove if not patching.
+                   Check out patch.py and README for more details on how to run patches.
+            - "start_date": str, YYYY-MM-DD format, first issue date
+            - "end_date": str, YYYY-MM-DD format, last issue date
+            - "patch_dir": str, directory to write all issues output
     """
     start_time = time.time()
     logger = get_structured_logger(

--- a/doctor_visits/tests/test_download.py
+++ b/doctor_visits/tests/test_download.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from delphi_doctor_visits.download_claims_ftp_files import download
+
+class TestDownload(unittest.TestCase):
+    @patch('delphi_doctor_visits.download_claims_ftp_files.paramiko.SSHClient')
+    @patch('delphi_doctor_visits.download_claims_ftp_files.path.exists', return_value=False)
+    def test_download(self, mock_exists, mock_sshclient):
+        mock_sshclient_instance = MagicMock()
+        mock_sshclient.return_value = mock_sshclient_instance
+        mock_sftp = MagicMock()
+        mock_sshclient_instance.open_sftp.return_value = mock_sftp
+        mock_sftp.listdir_attr.return_value = [MagicMock(filename="SYNEDI_AGG_OUTPATIENT_20200207_1455CDT.csv.gz")]
+        ftp_credentials = {"host": "test_host", "user": "test_user", "pass": "test_pass", "port": "test_port"}
+        out_path = "./test_data/"
+        logger = MagicMock()
+
+        #case 1: download with issue_date that does not exist on ftp server
+        download(ftp_credentials, out_path, logger, issue_date="2020-02-08")
+        mock_sshclient_instance.connect.assert_called_once_with(ftp_credentials["host"], username=ftp_credentials["user"], password=ftp_credentials["pass"], port=ftp_credentials["port"])
+        mock_sftp.get.assert_not_called()
+
+        # case 2: download with issue_date that exists on ftp server
+        download(ftp_credentials, out_path, logger, issue_date="2020-02-07")
+        mock_sftp.get.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/doctor_visits/tests/test_get_latest_claims_name.py
+++ b/doctor_visits/tests/test_get_latest_claims_name.py
@@ -19,4 +19,4 @@ class TestGetLatestFileName:
 
     def test_get_latest_claims_name_with_issue_date(self):
         result = get_latest_filename(self.dir_path, self.logger, issue_date="2020-02-07")
-        assert str(result) == f"{self.dir_path}/SYNEDI_AGG_OUTPATIENT_07022020_1455CDT.csv"
+        assert str(result) == f"{self.dir_path}/SYNEDI_AGG_OUTPATIENT_07022020_1455CDT.csv.gz"

--- a/doctor_visits/tests/test_get_latest_claims_name.py
+++ b/doctor_visits/tests/test_get_latest_claims_name.py
@@ -11,9 +11,12 @@ from delphi_doctor_visits.get_latest_claims_name import get_latest_filename
 
 class TestGetLatestFileName:
     logger = Mock()
-    
+    dir_path = "test_data"
+
     def test_get_latest_claims_name(self):
-        dir_path = "./test_data/"
-        
         with pytest.raises(AssertionError):
-            get_latest_filename(dir_path, self.logger)
+            get_latest_filename(self.dir_path, self.logger)
+
+    def test_get_latest_claims_name_with_issue_date(self):
+        result = get_latest_filename(self.dir_path, self.logger, issue_date="2020-02-07")
+        assert str(result) == f"{self.dir_path}/SYNEDI_AGG_OUTPATIENT_07022020_1455CDT.csv"

--- a/doctor_visits/tests/test_patch.py
+++ b/doctor_visits/tests/test_patch.py
@@ -1,0 +1,37 @@
+import unittest
+from unittest.mock import patch as mock_patch, call
+from delphi_doctor_visits.patch import patch
+import os
+import shutil
+
+class TestPatchModule(unittest.TestCase):
+    def test_patch(self):
+        with mock_patch('delphi_doctor_visits.patch.run_module') as mock_run_module, \
+             mock_patch('delphi_doctor_visits.patch.get_structured_logger') as mock_get_structured_logger, \
+             mock_patch('delphi_doctor_visits.patch.read_params') as mock_read_params:
+
+            mock_read_params.return_value = {
+                "common": {
+                    "log_filename": "test.log"
+                },
+                "patch": {
+                    "start_issue": "2021-01-01",
+                    "end_issue": "2021-01-02",
+                    "patch_dir": "./patch_dir"
+                }
+            }
+
+            patch()
+
+            self.assertIn('current_issue', mock_read_params.return_value)
+            self.assertEqual(mock_read_params.return_value['current_issue'], '2021-01-02')
+
+            self.assertTrue(os.path.isdir('./patch_dir'))
+            self.assertTrue(os.path.isdir('./patch_dir/issue_20210101/doctor-visits'))
+            self.assertTrue(os.path.isdir('./patch_dir/issue_20210102/doctor-visits'))
+
+            # Clean up the created directories after the test
+            shutil.rmtree(mock_read_params.return_value["patch"]["patch_dir"])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/doctor_visits/tests/test_patch.py
+++ b/doctor_visits/tests/test_patch.py
@@ -23,8 +23,8 @@ class TestPatchModule(unittest.TestCase):
 
             patch()
 
-            self.assertIn('current_issue', mock_read_params.return_value)
-            self.assertEqual(mock_read_params.return_value['current_issue'], '2021-01-02')
+            self.assertIn('current_issue', mock_read_params.return_value['patch'])
+            self.assertEqual(mock_read_params.return_value['patch']['current_issue'], '2021-01-02')
 
             self.assertTrue(os.path.isdir('./patch_dir'))
             self.assertTrue(os.path.isdir('./patch_dir/issue_20210101/doctor-visits'))


### PR DESCRIPTION
### Description
This change automates multi-day patching for `doctor_visits` indicators, producing `csv` files organized in batch issue format: `[name-of-patch]/issue_[issue-date]/nssp/actual_data_file.csv`, making it easier to ingest large batches of patch data.

Users start by specify in `params.json` the start issue and end issue of the patch, along with a directory where output is stored in. For example:
```{json}
  "patch": {
    "patch_dir": "/Users/minhkhuele/Desktop/delphi/covidcast-indicators/doctor_visits/AprilPatch",
    "start_issue": "2024-04-20",
    "end_issue": "2024-04-21"
  }
```
the run patch.py will create a directory 'covidcast-indicators/doctor_visits/AprilPatch' containing:

```
AprilPatch/
    issue_20240420/
        doctor-visits/
            20240408_state_smoothed_adj_cli.csv
            20240408_state_smoothed_cli.csv
            ...
    issue_20240421/
        doctor-visits/
            20240409_state_smoothed_adj_cli.csv
            20240408_state_smoothed_cli.csv
            ...
```
