### PR TITLE
fix doctor_visits log location & export_dir

### DIFF
--- a/ansible/templates/doctor_visits-params-prod.json.j2
+++ b/ansible/templates/doctor_visits-params-prod.json.j2
@@ -1,6 +1,6 @@
 {
   "common": {
-    "export_dir": "./receiving",
+    "export_dir": "/common/covidcast/receiving/doctor-visits",
     "log_filename": "/var/log/indicators/doctor-visits.log"
   },
   "indicator": {

--- a/ansible/templates/doctor_visits-params-prod.json.j2
+++ b/ansible/templates/doctor_visits-params-prod.json.j2
@@ -1,7 +1,7 @@
 {
   "common": {
     "export_dir": "./receiving",
-    "log_filename": "./doctor-visits.log"
+    "log_filename": "/var/log/indicators/doctor-visits.log"
   },
   "indicator": {
     "input_file": "./input/SYNEDI_AGG_OUTPATIENT_18052020_1455CDT.csv.gz",


### PR DESCRIPTION
updated to be in shared system indicators log directory, the same way that the other indicators are configured
