### PR TITLE
attempt to fix jenkins builds

### DIFF
--- a/_delphi_utils_python/setup.py
+++ b/_delphi_utils_python/setup.py
@@ -8,6 +8,7 @@ required = [
     "boto3",
     "covidcast",
     "cvxpy",
+    "scs<3.2.6", # TODO: remove this ; it is a cvxpy dependency, and the excluded version appears to break our jenkins build. see: https://github.com/cvxgrp/scs/issues/283
     "darker[isort]~=2.1.1",
     "epiweeks",
     "freezegun",

--- a/claims_hosp/setup.py
+++ b/claims_hosp/setup.py
@@ -14,6 +14,7 @@ required = [
     "pytest-cov",
     "pytest",
     "cvxpy<1.6",
+    "scs<3.2.6", # TODO: remove this ; it is a cvxpy dependency, and the excluded version appears to break our jenkins build. see: https://github.com/cvxgrp/scs/issues/283
 ]
 
 setup(

--- a/doctor_visits/setup.py
+++ b/doctor_visits/setup.py
@@ -12,7 +12,7 @@ required = [
     "pytest",
     "scikit-learn",
     "cvxpy>=1.5",
-]
+    "scs<3.2.6", # TODO: remove this ; it is a cvxpy dependency, and the excluded version appears to break our jenkins build. see: https://github.com/cvxgrp/scs/issues/283]
 
 setup(
     name="delphi_doctor_visits",

--- a/doctor_visits/setup.py
+++ b/doctor_visits/setup.py
@@ -12,7 +12,8 @@ required = [
     "pytest",
     "scikit-learn",
     "cvxpy>=1.5",
-    "scs<3.2.6", # TODO: remove this ; it is a cvxpy dependency, and the excluded version appears to break our jenkins build. see: https://github.com/cvxgrp/scs/issues/283]
+    "scs<3.2.6", # TODO: remove this ; it is a cvxpy dependency, and the excluded version appears to break our jenkins build. see: https://github.com/cvxgrp/scs/issues/283
+]
 
 setup(
     name="delphi_doctor_visits",


### PR DESCRIPTION
the jenkins builds broke, and the logs led me to believe the [newly released `scs` version](https://pypi.org/project/scs/3.2.6/#:~:text=Released%3A%20Jul%207%2C%202024) ([a dependency of `cvxpy`](https://pypi.org/project/cvxpy/#:~:text=ECOS%20%3E%3D%202-,SCS,-%3E%3D%203.2.4.post1)) might be to blame.  then i found [a VERY recent `scs` gh issue](https://github.com/cvxgrp/scs/issues/283) that looks similar to what we are seeing.

i tried to test this fix in a few ways but couldnt get them to work easily -- i think they'd need deeper changes to our jenkins config, which probbly isnt worth it.  praps we can merge this into `main` and see if it does the trick?