### PR TITLE
switch from input_file to input_dir

### DIFF
--- a/ansible/templates/doctor_visits-params-prod.json.j2
+++ b/ansible/templates/doctor_visits-params-prod.json.j2
@@ -4,7 +4,7 @@
     "log_filename": "/var/log/indicators/doctor-visits.log"
   },
   "indicator": {
-    "input_file": "./input/SYNEDI_AGG_OUTPATIENT_18052020_1455CDT.csv.gz",
+    "input_dir": "./retrieve_files",
     "drop_date": "",
     "n_backfill_days": 70,
     "n_waiting_days": 3,


### PR DESCRIPTION
### Description
Originally when doctor_visits was running on bigchunk 2, the series of scripts back then used `input_file` to specify location of one source file extracted from ftp server at a time. Now we use `input_dir` to specify a whole directory where all relevant source files can be extracted into.

### Changelog
- params.json