### PR TITLE
avoid linking keywords in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,5 @@ Itemize code/test/documentation changes and files added/removed.
 - change1
 - change2
 
-### Fixes 
-- Fixes #(issue)
+### Associated Issue(s) 
+- Addresses #(issue)


### PR DESCRIPTION
[Certain phrasing in a PR can "link" it to a particular issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).  Merging a PR that is "linked" to an issue will automatically close that issue.  This can be handy, but it can also be problematic if the issue is closed unintentionally, like when a PR does not completely cover all of the points made in the issue.  For examples of this, see: https://github.com/cmu-delphi/covidcast-indicators/issues/1676#issuecomment-2118194957 and https://github.com/cmu-delphi/covidcast-indicators/issues/1973#issuecomment-2249126852 .  The automatic closing behavior can not be disabled, though it is a [commonly](https://github.com/orgs/community/discussions/23476) [requested](https://github.com/orgs/community/discussions/17308) [feature](https://github.com/orgs/community/discussions/66741).  This PR removes those linking keywords from the template to reduce the possibility of an undesired linking.
