### PR TITLE
Ds/makefiles

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,5 @@ d4b056e7a4c11982324e9224c9f9f6fd5d5ec65c
 79072dcdec3faca9aaeeea65de83f7fa5c00d53f
 # Sort setup.py dependencies
 6912077acba97e835aff7d0cd3d64309a1a9241d
+# Clean Makefiles
+07c1d02fa5446c8e0de7649e494d259b4ebb3d1b

--- a/_delphi_utils_python/Makefile
+++ b/_delphi_utils_python/Makefile
@@ -1,27 +1,23 @@
 .PHONY = venv, lint, test, clean, release
 
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e '.[dev]'
+	env/bin/pip install -e '.[dev]'
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install '.[dev]'
+	env/bin/pip install '.[dev]'
 
 lint:
-	. env/bin/activate; pylint delphi_utils --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle delphi_utils
+	env/bin/pylint delphi_utils --rcfile=../pyproject.toml
+	env/bin/pydocstyle delphi_utils
 
 format:
-	. env/bin/activate; darker delphi_utils
+	env/bin/darker delphi_utils
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=delphi_utils --cov-report=term-missing)
 
 clean:
@@ -29,5 +25,4 @@ clean:
 	rm -f params.json
 
 release: lint test
-	. env/bin/activate ; \
-	python -m build --sdist --wheel
+	env/bin/python -m build --sdist --wheel

--- a/_template_python/Makefile
+++ b/_template_python/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/changehc/Makefile
+++ b/changehc/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/claims_hosp/Makefile
+++ b/claims_hosp/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/doctor_visits/Makefile
+++ b/doctor_visits/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/google_symptoms/Makefile
+++ b/google_symptoms/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/hhs_hosp/Makefile
+++ b/hhs_hosp/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/nchs_mortality/Makefile
+++ b/nchs_mortality/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/nssp/Makefile
+++ b/nssp/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/nwss_wastewater/Makefile
+++ b/nwss_wastewater/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/quidel_covidtest/Makefile
+++ b/quidel_covidtest/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:

--- a/sir_complainsalot/Makefile
+++ b/sir_complainsalot/Makefile
@@ -2,29 +2,25 @@
 
 dir = $(shell find ./delphi_* -name __init__.py | grep -o 'delphi_[_[:alnum:]]*' | head -1)
 venv:
-	python3.8 -m venv env; \
-	. env/bin/activate; \
-	python -m pip install pip==23.0.1
+	python3.8 -m venv env
+	env/bin/python -m pip install pip==23.0.1
 
 install: venv
-	. env/bin/activate; \
-	pip install -e ../_delphi_utils_python ;\
-	pip install -e .
+	env/bin/pip install -e ../_delphi_utils_python
+	env/bin/pip install -e .
 
 install-ci: venv
-	. env/bin/activate; \
-	pip install ../_delphi_utils_python ;\
-	pip install .
+	env/bin/pip install ../_delphi_utils_python
+	env/bin/pip install .
 
 lint:
-	. env/bin/activate; pylint $(dir) --rcfile=../pyproject.toml
-	. env/bin/activate; pydocstyle $(dir)
+	env/bin/pylint $(dir) --rcfile=../pyproject.toml
+	env/bin/pydocstyle $(dir)
 
 format:
-	. env/bin/activate; darker $(dir)
+	env/bin/darker $(dir)
 
 test:
-	. env/bin/activate ;\
 	(cd tests && ../env/bin/pytest --cov=$(dir) --cov-report=term-missing)
 
 clean:


### PR DESCRIPTION
### Description
The Makefiles have this pattern of activating Python environments for a single line command, which bloats the file. This directly calls the environment instead. Personal preference, but figured I'd put this up, in case others agree that this is clearer.

### Changelog
* Reduce lines in makefiles
* Ignore blame on this, since it's essentially just a formatting commit