### PR TITLE
added progress chunk to limit logging

### DIFF
--- a/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
+++ b/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
@@ -24,6 +24,7 @@ def print_callback(filename, logger, bytes_so_far, bytes_total, progress_chunks)
     rough_percent_transferred = int(100 * (bytes_so_far / bytes_total))
     if rough_percent_transferred in progress_chunks:
         logger.info("Transfer in progress", filename=filename, percent=rough_percent_transferred)
+        # Remove progress chunk, so it is not logged again
         progress_chunks.remove(rough_percent_transferred)
 
 OLD_FILENAME_TIMESTAMP = re.compile(
@@ -98,6 +99,6 @@ def download(ftp_credentials, out_path, logger):
     for infile, outfile in filepaths_to_download.items():
         callback_for_filename = functools.partial(print_callback, infile, logger, progress_chunks=[0, 25, 50, 75])
         sftp.get(infile, outfile, callback=callback_for_filename)
-        logger.info("Transfer in progress", filename=infile, percent=100)
+        logger.info("Transfer finished", filename=infile, percent=100)
 
     client.close()

--- a/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
+++ b/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
@@ -19,11 +19,12 @@ class AllowAnythingPolicy(paramiko.MissingHostKeyPolicy):
         return
 
 
-def print_callback(filename, logger, bytes_so_far, bytes_total):
+def print_callback(filename, logger, bytes_so_far, bytes_total, progress_chunks):
     """Print the callback information."""
     rough_percent_transferred = int(100 * (bytes_so_far / bytes_total))
-    if (rough_percent_transferred % 25) == 0:
+    if rough_percent_transferred in progress_chunks:
         logger.info("Transfer in progress", filename=filename, percent=rough_percent_transferred)
+        progress_chunks.remove(rough_percent_transferred)
 
 OLD_FILENAME_TIMESTAMP = re.compile(
     r".*EDI_AGG_INPATIENT_[0-9]_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
@@ -95,7 +96,8 @@ def download(ftp_credentials, out_path, logger):
 
     # download!
     for infile, outfile in filepaths_to_download.items():
-        callback_for_filename = functools.partial(print_callback, infile, logger)
+        callback_for_filename = functools.partial(print_callback, infile, logger, progress_chunks=[0,25,50,75])
         sftp.get(infile, outfile, callback=callback_for_filename)
+        logger.info("Transfer in progress", filename=infile, percent=100)
 
     client.close()

--- a/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
+++ b/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
@@ -96,7 +96,7 @@ def download(ftp_credentials, out_path, logger):
 
     # download!
     for infile, outfile in filepaths_to_download.items():
-        callback_for_filename = functools.partial(print_callback, infile, logger, progress_chunks=[0,25,50,75])
+        callback_for_filename = functools.partial(print_callback, infile, logger, progress_chunks=[0, 25, 50, 75])
         sftp.get(infile, outfile, callback=callback_for_filename)
         logger.info("Transfer in progress", filename=infile, percent=100)
 

--- a/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
+++ b/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
@@ -100,7 +100,7 @@ def download(ftp_credentials, out_path, logger, issue_date=None):
 
     # download!
     for infile, outfile in filepaths_to_download.items():
-        callback_for_filename = functools.partial(print_callback, infile, logger, progress_chunks=[0,25,50,75])
+        callback_for_filename = functools.partial(print_callback, infile, logger, progress_chunks=[0, 25, 50, 75])
         sftp.get(infile, outfile, callback=callback_for_filename)
         logger.info("Transfer in progress", filename=infile, percent=100)
 

--- a/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
+++ b/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
@@ -24,6 +24,7 @@ def print_callback(filename, logger, bytes_so_far, bytes_total, progress_chunks)
     rough_percent_transferred = int(100 * (bytes_so_far / bytes_total))
     if rough_percent_transferred in progress_chunks:
         logger.info("Transfer in progress", filename=filename, percent=rough_percent_transferred)
+        # Remove progress chunk, so it is not logged again
         progress_chunks.remove(rough_percent_transferred)
 
 OLD_FILENAME_TIMESTAMP = re.compile(
@@ -102,6 +103,6 @@ def download(ftp_credentials, out_path, logger, issue_date=None):
     for infile, outfile in filepaths_to_download.items():
         callback_for_filename = functools.partial(print_callback, infile, logger, progress_chunks=[0, 25, 50, 75])
         sftp.get(infile, outfile, callback=callback_for_filename)
-        logger.info("Transfer in progress", filename=infile, percent=100)
+        logger.info("Transfer finished", filename=infile, percent=100)
 
     client.close()

--- a/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
+++ b/doctor_visits/delphi_doctor_visits/download_claims_ftp_files.py
@@ -19,12 +19,12 @@ class AllowAnythingPolicy(paramiko.MissingHostKeyPolicy):
         return
 
 
-def print_callback(filename, logger, bytes_so_far, bytes_total):
+def print_callback(filename, logger, bytes_so_far, bytes_total, progress_chunks):
     """Print the callback information."""
     rough_percent_transferred = int(100 * (bytes_so_far / bytes_total))
-    if (rough_percent_transferred % 25) == 0:
+    if rough_percent_transferred in progress_chunks:
         logger.info("Transfer in progress", filename=filename, percent=rough_percent_transferred)
-
+        progress_chunks.remove(rough_percent_transferred)
 
 OLD_FILENAME_TIMESTAMP = re.compile(
     r".*EDI_AGG_OUTPATIENT_[0-9]_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
@@ -100,7 +100,8 @@ def download(ftp_credentials, out_path, logger, issue_date=None):
 
     # download!
     for infile, outfile in filepaths_to_download.items():
-        callback_for_filename = functools.partial(print_callback, infile, logger)
+        callback_for_filename = functools.partial(print_callback, infile, logger, progress_chunks=[0,25,50,75])
         sftp.get(infile, outfile, callback=callback_for_filename)
+        logger.info("Transfer in progress", filename=infile, percent=100)
 
     client.close()


### PR DESCRIPTION
### Description
too much logging for the progress

hopsital-admission
```
{"time": "datetime.datetime(2024, 8, 14, 14, 37, 55, 187263)", "event": "starting download", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:37:55.187298Z"}
{"filename": "EDI_AGG_INPATIENT_20240813_1452CDT.csv.gz", "event": "File to download", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:37:58.514091Z"}
{"filename": "EDI_AGG_INPATIENT_20240814_0252CDT.csv.gz", "event": "File to download", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:37:58.514295Z"}
{"filename": "EDI_AGG_INPATIENT_20240813_1452CDT.csv.gz", "percent": 0, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:37:58.587617Z"}
{"filename": "EDI_AGG_INPATIENT_20240813_1452CDT.csv.gz", "percent": 25, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:38:02.373432Z"}
{"filename": "EDI_AGG_INPATIENT_20240813_1452CDT.csv.gz", "percent": 50, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:38:05.321412Z"}
{"filename": "EDI_AGG_INPATIENT_20240813_1452CDT.csv.gz", "percent": 75, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:38:07.928315Z"}
{"filename": "EDI_AGG_INPATIENT_20240813_1452CDT.csv.gz", "percent": 100, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:38:10.895372Z"}
{"filename": "EDI_AGG_INPATIENT_20240814_0252CDT.csv.gz", "percent": 0, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:38:10.985207Z"}
{"filename": "EDI_AGG_INPATIENT_20240814_0252CDT.csv.gz", "percent": 25, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:38:14.024649Z"}
{"filename": "EDI_AGG_INPATIENT_20240814_0252CDT.csv.gz", "percent": 50, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:38:17.388245Z"}
{"filename": "EDI_AGG_INPATIENT_20240814_0252CDT.csv.gz", "percent": 75, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:38:20.633262Z"}
{"filename": "EDI_AGG_INPATIENT_20240814_0252CDT.csv.gz", "percent": 100, "event": "Transfer in progress", "logger": "delphi_claims_hosp.run", "level": "info", "pid": 68373, "timestamp": "2024-08-14T18:38:23.601564Z"}
```

doctor-visits
```
{"time": "datetime.datetime(2024, 8, 14, 14, 39, 49, 406542)", "event": "starting download", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:39:49.406580Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240813_1452CDT.csv.gz", "event": "File to download", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:39:53.062629Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240814_0252CDT.csv.gz", "event": "File to download", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:39:53.062878Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240813_1452CDT.csv.gz", "percent": 0, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:39:53.182709Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240813_1452CDT.csv.gz", "percent": 25, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:40:09.275755Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240813_1452CDT.csv.gz", "percent": 50, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:40:19.720957Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240813_1452CDT.csv.gz", "percent": 75, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:40:30.740461Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240813_1452CDT.csv.gz", "percent": 100, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:40:41.629636Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240814_0252CDT.csv.gz", "percent": 0, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:40:41.721008Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240814_0252CDT.csv.gz", "percent": 25, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:40:53.522189Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240814_0252CDT.csv.gz", "percent": 50, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:41:04.152777Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240814_0252CDT.csv.gz", "percent": 75, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:41:16.296555Z"}
{"filename": "EDI_AGG_OUTPATIENT_20240814_0252CDT.csv.gz", "percent": 100, "event": "Transfer in progress", "logger": "delphi_doctor_visits.run", "level": "info", "pid": 68402, "timestamp": "2024-08-14T18:41:27.713898Z"}

```


### Associated Issue(s) 
- Addresses #(2017)
