### PR TITLE
fix: build-indicators.sh looks for setup.py and pyproject.toml

### DIFF
--- a/jenkins/build-indicator.sh
+++ b/jenkins/build-indicator.sh
@@ -17,4 +17,6 @@ source env/bin/activate
 pip install pip==23.0.1 --retries 10 --timeout 20
 pip install numpy --retries 10 --timeout 20
 pip install ../_delphi_utils_python/. --retries 10 --timeout 20
-([ -f setup.py ] || [ -f pyproject.toml ]) && pip install . --retries 10 --timeout 20
+if [ -f setup.py ] || [ -f pyproject.toml ]; then
+    pip install . --retries 10 --timeout 20
+fi

--- a/jenkins/build-indicator.sh
+++ b/jenkins/build-indicator.sh
@@ -17,4 +17,4 @@ source env/bin/activate
 pip install pip==23.0.1 --retries 10 --timeout 20
 pip install numpy --retries 10 --timeout 20
 pip install ../_delphi_utils_python/. --retries 10 --timeout 20
-[ ! -f setup.py ] || pip install . --retries 10 --timeout 20
+([ -f setup.py ] || [ -f pyproject.toml ]) && pip install . --retries 10 --timeout 20

--- a/jenkins/build-indicator.sh
+++ b/jenkins/build-indicator.sh
@@ -17,4 +17,4 @@ source env/bin/activate
 pip install pip==23.0.1 --retries 10 --timeout 20
 pip install numpy --retries 10 --timeout 20
 pip install ../_delphi_utils_python/. --retries 10 --timeout 20
-[ ! -f pyproject.toml ] || pip install . --retries 10 --timeout 20
+[ ! -f setup.py ] || pip install . --retries 10 --timeout 20


### PR DESCRIPTION
### Description
Our Jenkins build script previously looked in every indicator folder and if it finds `setup.py` it installs the indicator. I changed this check to `pyproject.toml`, in anticipation of #2016, but that is premature. This adds the `setup.py` check in, but also future proofs by adding a check for `pyproject.toml` as well.

### Changelog
Maintaining previous behavior and future-proofing `Jenkins/build-indicators.sh`.

### Associated Issue(s) 
- Addresses #(issue)
