### PR TITLE
upload-artifact@v2 -> v4

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Release
         run: |
           make release
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: delphi_utils
           path: _delphi_utils_python/dist/*.tar.gz


### PR DESCRIPTION
### Description
After [merging to prod](https://github.com/cmu-delphi/covidcast-indicators/pull/2049) for release, upload_pypi job is [failing](https://github.com/cmu-delphi/covidcast-indicators/actions/runs/10834683586) due to [upload-artifact@v2 deprecation](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).

This change [should](https://github.com/cmu-delphi/covidcast-indicators/pull/2050) fix the problem.
