### PR TITLE
Update path for pyenv shims

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,10 @@ def deploy_production = [:]
 
 pipeline {
     agent any
+    environment {
+        // Set the PATH variable to include the pyenv shims directory.
+        PATH = "/var/lib/jenkins/.pyenv/shims:${env.PATH}"
+    }
     stages {
         stage('Build dev/feature branch') {
             when  {


### PR DESCRIPTION
### Description
Adds a small bit to the Jenkinsfile to modify the path variable that is available to Jenkins when it runs.

In this new Jenkins instance we are using pyenv to set up the Python version and environment. Typically this would be made availabe to the Jenkins shell environment by sourcing a small bit of code from one of .bash_profile or .bashrc., but Jenkins does not run interactive shell sessions so these aren't sourced.

In order to allow Jenkins to run binaries from the pyenv shims directory we need to add it to the path. We can do that with Jenkins' `environment` directive.


### Changelog
Itemize code/test/documentation changes and files added/removed.
Updates the Jenkinsfile.

### Associated Issue(s) 
- NA