### PR TITLE
Add NSSP secondary source

### DIFF
--- a/nssp/DETAILS.md
+++ b/nssp/DETAILS.md
@@ -5,12 +5,22 @@ We import the NSSP Emergency Department Visit data, including percentage and smo
 There are 2 sources we grab data from for nssp:
 - Primary source: https://data.cdc.gov/Public-Health-Surveillance/NSSP-Emergency-Department-Visit-Trajectories-by-St/rdmq-nq56/data_preview
 - Secondary source: https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview
-There are 8 signals output from the primary source and 4 output from secondary. Secondary source data is only available from state-level geos and above, though secondary data might be updated more often.
+There are 8 signals output from the primary source and 4 output from secondary. There are no smoothed signals from secondary source.
+
+Note that the data produced from secondary source are mostly the same as their primary source equivalent, with past analysis shows around 95% of datapoints having less than 0.1 value difference and the other 5% having a 0.1 to 1.2 value difference. 
 
 ## Geographical Levels
-* `state`: reported using two-letter postal code
-* `county`: reported using fips code
-* `national`: just `us` for now
+Primary source:
+* `state`: reported from source using two-letter postal code
+* `county`: reported from source using fips code
+* `national`: just `us` for now, reported from source
+* `hhs`, `hrr`, `msa`: not reported from source, so we computed them from county-level data using a weighted mean. Each county is assigned a weight equal to its population in the last census (2020).
+
+Secondary source:
+* `state`: reported from source
+* `hhs`: reported from source
+* `national`: reported from source
+
 ## Metrics
 *  `percent_visits_covid`, `percent_visits_rsv`, `percent_visits_influenza`: percentage of emergency department patient visits for specified pathogen.
 *  `percent_visits_combined`: sum of the three percentages of visits for flu, rsv and covid.

--- a/nssp/DETAILS.md
+++ b/nssp/DETAILS.md
@@ -4,7 +4,7 @@ We import the NSSP Emergency Department Visit data, including percentage and smo
 
 There are 2 sources we grab data from for nssp:
 - Primary source: https://data.cdc.gov/Public-Health-Surveillance/NSSP-Emergency-Department-Visit-Trajectories-by-St/rdmq-nq56/data_preview
-- Secondary source: https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview
+- Secondary (2023RVR) source: https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview
 There are 8 signals output from the primary source and 4 output from secondary. There are no smoothed signals from secondary source.
 
 Note that the data produced from secondary source are mostly the same as their primary source equivalent, with past analysis shows around 95% of datapoints having less than 0.1 value difference and the other 5% having a 0.1 to 1.2 value difference. 
@@ -16,7 +16,7 @@ Primary source:
 * `national`: just `us` for now, reported from source
 * `hhs`, `hrr`, `msa`: not reported from source, so we computed them from county-level data using a weighted mean. Each county is assigned a weight equal to its population in the last census (2020).
 
-Secondary source:
+Secondary (2023RVR) source:
 * `state`: reported from source
 * `hhs`: reported from source
 * `national`: reported from source
@@ -26,5 +26,5 @@ Secondary source:
 *  `percent_visits_combined`: sum of the three percentages of visits for flu, rsv and covid.
 *  `smoothed_percent_visits_covid`, `smoothed_percent_visits_rsv`, `smoothed_percent_visits_influenza`: 3 week moving average of the percentage of emergency department patient visits for specified pathogen.
 *  `smoothed_percent_visits_combined`: 3 week moving average of the sum of the three percentages of visits for flu, rsv and covid.
-*  `percent_visits_covid_secondary`, `percent_visits_rsv_secondary`, `percent_visits_influenza_secondary`: Taken from secondary source, percentage of emergency department patient visits for specified pathogen.
-*  `percent_visits_combined_secondary`: Taken from secondary source, sum of the three percentages of visits for flu, rsv and covid.
+*  `percent_visits_covid_2023RVR`, `percent_visits_rsv_2023RVR`, `percent_visits_influenza_2023RVR`: Taken from secondary source, percentage of emergency department patient visits for specified pathogen.
+*  `percent_visits_combined_2023RVR`: Taken from secondary source, sum of the three percentages of visits for flu, rsv and covid.

--- a/nssp/DETAILS.md
+++ b/nssp/DETAILS.md
@@ -2,6 +2,11 @@
 
 We import the NSSP Emergency Department Visit data, including percentage and smoothed percentage of ER visits attributable to a given pathogen, from the CDC website. The data is provided at the county level, state level and national level; we do a population-weighted mean to aggregate from county data up to the HRR and MSA levels.
 
+There are 2 sources we grab data from for nssp:
+- Primary source: https://data.cdc.gov/Public-Health-Surveillance/NSSP-Emergency-Department-Visit-Trajectories-by-St/rdmq-nq56/data_preview
+- Secondary source: https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview
+There are 8 signals output from the primary source and 4 output from secondary. Secondary source data is only available from state-level geos and above, though secondary data might be updated more often.
+
 ## Geographical Levels
 * `state`: reported using two-letter postal code
 * `county`: reported using fips code
@@ -11,3 +16,5 @@ We import the NSSP Emergency Department Visit data, including percentage and smo
 *  `percent_visits_combined`: sum of the three percentages of visits for flu, rsv and covid.
 *  `smoothed_percent_visits_covid`, `smoothed_percent_visits_rsv`, `smoothed_percent_visits_influenza`: 3 week moving average of the percentage of emergency department patient visits for specified pathogen.
 *  `smoothed_percent_visits_combined`: 3 week moving average of the sum of the three percentages of visits for flu, rsv and covid.
+*  `percent_visits_covid_secondary`, `percent_visits_rsv_secondary`, `percent_visits_influenza_secondary`: Taken from secondary source, percentage of emergency department patient visits for specified pathogen.
+*  `percent_visits_combined_secondary`: Taken from secondary source, sum of the three percentages of visits for flu, rsv and covid.

--- a/nssp/README.md
+++ b/nssp/README.md
@@ -1,6 +1,11 @@
 # NSSP Emergency Department Visit data
 
 We import the NSSP Emergency Department Visit data, currently only the smoothed concentration, from the CDC website, aggregate to the state and national level from the wastewater sample site level, and export the aggregated data.
+
+There are 2 sources we grab data from for nssp:
+- Primary source: https://data.cdc.gov/Public-Health-Surveillance/NSSP-Emergency-Department-Visit-Trajectories-by-St/rdmq-nq56/data_preview
+- Secondary source: https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview
+
 For details see the `DETAILS.md` file in this directory.
 
 ## Create a MyAppToken

--- a/nssp/delphi_nssp/constants.py
+++ b/nssp/delphi_nssp/constants.py
@@ -50,10 +50,10 @@ SECONDARY_COLS_MAP = {
 }
 
 SECONDARY_SIGNALS_MAP = {
-    "COVID-19": "pct_ed_visits_covid_secondary",
-    "Influenza": "pct_ed_visits_influenza_secondary",
-    "RSV": "pct_ed_visits_rsv_secondary",
-    "Combined": "pct_ed_visits_combined_secondary",
+    "COVID-19": "pct_ed_visits_covid_2023RVR",
+    "Influenza": "pct_ed_visits_influenza_2023RVR",
+    "RSV": "pct_ed_visits_rsv_2023RVR",
+    "Combined": "pct_ed_visits_combined_2023RVR",
 }
 
 SECONDARY_SIGNALS = [val for (key, val) in SECONDARY_SIGNALS_MAP.items()]

--- a/nssp/delphi_nssp/constants.py
+++ b/nssp/delphi_nssp/constants.py
@@ -57,7 +57,7 @@ SECONDARY_SIGNALS_MAP = {
 }
 
 SECONDARY_SIGNALS = [val for (key, val) in SECONDARY_SIGNALS_MAP.items()]
-SECONDARY_GEOS = ["state","nation","hhs"]
+SECONDARY_GEOS = ["state", "nation", "hhs"]
 
 SECONDARY_TYPE_DICT = {
     "timestamp": "datetime64[ns]",

--- a/nssp/delphi_nssp/constants.py
+++ b/nssp/delphi_nssp/constants.py
@@ -51,7 +51,7 @@ SECONDARY_COLS_MAP = {
 
 SECONDARY_SIGNALS_MAP = {
     "COVID-19": "pct_ed_visits_covid_secondary",
-    "INFLUENZA": "pct_ed_visits_influenza_secondary",
+    "Influenza": "pct_ed_visits_influenza_secondary",
     "RSV": "pct_ed_visits_rsv_secondary",
     "Combined": "pct_ed_visits_combined_secondary",
 }

--- a/nssp/delphi_nssp/constants.py
+++ b/nssp/delphi_nssp/constants.py
@@ -41,3 +41,29 @@ TYPE_DICT.update(
         "fips": str,
     }
 )
+
+SECONDARY_COLS_MAP = {
+    "week_end": "timestamp",
+    "geography": "geo_value",
+    "percent_visits": "val",
+    "pathogen": "signal",
+}
+
+SECONDARY_SIGNALS_MAP = {
+    "COVID-19": "pct_ed_visits_covid_secondary",
+    "INFLUENZA": "pct_ed_visits_influenza_secondary",
+    "RSV": "pct_ed_visits_rsv_secondary",
+    "Combined": "pct_ed_visits_combined_secondary",
+}
+
+SECONDARY_SIGNALS = [val for (key, val) in SECONDARY_SIGNALS_MAP.items()]
+SECONDARY_GEOS = ["state","nation","hhs"]
+
+SECONDARY_TYPE_DICT = {
+    "timestamp": "datetime64[ns]",
+    "geo_value": str,
+    "val": float,
+    "geo_type": str,
+    "signal": str,
+}
+SECONDARY_KEEP_COLS = [key for (key, val) in SECONDARY_TYPE_DICT.items()]

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -37,7 +37,8 @@ def warn_string(df, type_dict):
 
 
 def pull_nssp_data(socrata_token: str):
-    """Pull the latest NSSP ER visits primary dataset
+    """Pull the latest NSSP ER visits primary dataset.
+
     https://data.cdc.gov/Public-Health-Surveillance/NSSP-Emergency-Department-Visit-Trajectories-by-St/rdmq-nq56/data_preview
 
     Parameters
@@ -78,7 +79,8 @@ def pull_nssp_data(socrata_token: str):
 
 
 def secondary_pull_nssp_data(socrata_token: str):
-    """Pull the latest NSSP ER visits secondary dataset:
+    """Pull the latest NSSP ER visits secondary dataset.
+
     https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview
 
     The output dataset has:

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -65,7 +65,7 @@ def pull_with_socrata_api(socrata_token: str, dataset_id: str):
     return results
 
 
-def pull_nssp_data(socrata_token: str, backup_dir: str, custom_run: bool, logger: Optional[logging.Logger] = None)::
+def pull_nssp_data(socrata_token: str, backup_dir: str, custom_run: bool, logger: Optional[logging.Logger] = None):
     """Pull the latest NSSP ER visits primary dataset.
 
     https://data.cdc.gov/Public-Health-Surveillance/NSSP-Emergency-Department-Visit-Trajectories-by-St/rdmq-nq56/data_preview

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -127,7 +127,7 @@ def secondary_pull_nssp_data(socrata_token: str):
 
     df_ervisits.loc[df_ervisits["geo_value"] == "National", "geo_type"] = "nation"
 
-    hhs_region_mask = df_ervisits["geo_value"].str.startswith("Region ")
+    hhs_region_mask = df_ervisits["geo_value"].str.lower().startswith("region ")
     df_ervisits.loc[hhs_region_mask, "geo_value"] = df_ervisits.loc[hhs_region_mask, "geo_value"].str.replace(
         "Region ", ""
     )

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -127,7 +127,7 @@ def secondary_pull_nssp_data(socrata_token: str):
 
     df_ervisits.loc[df_ervisits["geo_value"] == "National", "geo_type"] = "nation"
 
-    hhs_region_mask = df_ervisits["geo_value"].str.lower().startswith("region ")
+    hhs_region_mask = df_ervisits["geo_value"].str.lower().str.startswith("region ")
     df_ervisits.loc[hhs_region_mask, "geo_value"] = df_ervisits.loc[hhs_region_mask, "geo_value"].str.replace(
         "Region ", ""
     )

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -98,7 +98,9 @@ def pull_nssp_data(socrata_token: str, backup_dir: str, custom_run: bool, logger
     return df_ervisits[SIGNALS + keep_columns]
 
 
-def secondary_pull_nssp_data(socrata_token: str, backup_dir: str, custom_run: bool, logger: Optional[logging.Logger] = None):
+def secondary_pull_nssp_data(
+    socrata_token: str, backup_dir: str, custom_run: bool, logger: Optional[logging.Logger] = None
+):
     """Pull the latest NSSP ER visits secondary dataset.
 
     https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -6,7 +6,16 @@ import textwrap
 import pandas as pd
 from sodapy import Socrata
 
-from .constants import *
+from .constants import (
+    NEWLINE,
+    SECONDARY_COLS_MAP,
+    SECONDARY_KEEP_COLS,
+    SECONDARY_SIGNALS_MAP,
+    SECONDARY_TYPE_DICT,
+    SIGNALS,
+    SIGNALS_MAP,
+    TYPE_DICT,
+)
 
 
 def warn_string(df, type_dict):
@@ -102,15 +111,17 @@ def secondary_pull_nssp_data(socrata_token: str):
 
     # geo_type is not provided in the dataset, so we infer it from the geo_value
     # which is either state names, "National" or hhs region numbers
-    df_ervisits['geo_type'] = 'state'
+    df_ervisits["geo_type"] = "state"
 
-    df_ervisits.loc[df_ervisits['geo_value'] == 'National', 'geo_type'] = 'nation'
+    df_ervisits.loc[df_ervisits["geo_value"] == "National", "geo_type"] = "nation"
 
-    hhs_region_mask = df_ervisits['geo_value'].str.startswith('Region ')
-    df_ervisits.loc[hhs_region_mask, 'geo_value'] = df_ervisits.loc[hhs_region_mask, 'geo_value'].str.replace('Region ', '')
-    df_ervisits.loc[hhs_region_mask, 'geo_type'] = 'hhs'
+    hhs_region_mask = df_ervisits["geo_value"].str.startswith("Region ")
+    df_ervisits.loc[hhs_region_mask, "geo_value"] = df_ervisits.loc[hhs_region_mask, "geo_value"].str.replace(
+        "Region ", ""
+    )
+    df_ervisits.loc[hhs_region_mask, "geo_type"] = "hhs"
 
-    df_ervisits['signal'] = df_ervisits['signal'].map(SECONDARY_SIGNALS_MAP)
+    df_ervisits["signal"] = df_ervisits["signal"].map(SECONDARY_SIGNALS_MAP)
 
     df_ervisits = df_ervisits[SECONDARY_KEEP_COLS]
 

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -6,7 +6,7 @@ import textwrap
 import pandas as pd
 from sodapy import Socrata
 
-from .constants import NEWLINE, SIGNALS, SIGNALS_MAP, TYPE_DICT
+from .constants import *
 
 
 def warn_string(df, type_dict):
@@ -28,19 +28,13 @@ def warn_string(df, type_dict):
 
 
 def pull_nssp_data(socrata_token: str):
-    """Pull the latest NSSP ER visits data, and conforms it into a dataset.
-
-    The output dataset has:
-
-    - Each row corresponds to a single observation
-    - Each row additionally has columns for the signals in SIGNALS
+    """Pull the latest NSSP ER visits primary dataset
+    https://data.cdc.gov/Public-Health-Surveillance/NSSP-Emergency-Department-Visit-Trajectories-by-St/rdmq-nq56/data_preview
 
     Parameters
     ----------
     socrata_token: str
-        My App Token for pulling the NWSS data (could be the same as the nchs data)
-    test_file: Optional[str]
-        When not null, name of file from which to read test data
+        My App Token for pulling the NSSP data (could be the same as the nchs data)
 
     Returns
     -------
@@ -72,3 +66,57 @@ def pull_nssp_data(socrata_token: str):
 
     keep_columns = ["timestamp", "geography", "county", "fips"]
     return df_ervisits[SIGNALS + keep_columns]
+
+
+def secondary_pull_nssp_data(socrata_token: str):
+    """Pull the latest NSSP ER visits secondary dataset:
+    https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview
+
+    The output dataset has:
+
+    - Each row corresponds to a single observation
+
+    Parameters
+    ----------
+    socrata_token: str
+        My App Token for pulling the NSSP data (could be the same as the nchs data)
+
+    Returns
+    -------
+    pd.DataFrame
+        Dataframe as described above.
+    """
+    # Pull data from Socrata API
+    client = Socrata("data.cdc.gov", socrata_token)
+    results = []
+    offset = 0
+    limit = 50000  # maximum limit allowed by SODA 2.0
+    while True:
+        page = client.get("7mra-9cq9", limit=limit, offset=offset)
+        if not page:
+            break  # exit the loop if no more results
+        results.extend(page)
+        offset += limit
+    df_ervisits = pd.DataFrame.from_records(results)
+    df_ervisits = df_ervisits.rename(columns=SECONDARY_COLS_MAP)
+
+    # geo_type is not provided in the dataset, so we infer it from the geo_value
+    # which is either state names, "National" or hhs region numbers
+    df_ervisits['geo_type'] = 'state'
+
+    df_ervisits.loc[df_ervisits['geo_value'] == 'National', 'geo_type'] = 'nation'
+
+    hhs_region_mask = df_ervisits['geo_value'].str.startswith('Region ')
+    df_ervisits.loc[hhs_region_mask, 'geo_value'] = df_ervisits.loc[hhs_region_mask, 'geo_value'].str.replace('Region ', '')
+    df_ervisits.loc[hhs_region_mask, 'geo_type'] = 'hhs'
+
+    df_ervisits['signal'] = df_ervisits['signal'].map(SECONDARY_SIGNALS_MAP)
+
+    df_ervisits = df_ervisits[SECONDARY_KEEP_COLS]
+
+    try:
+        df_ervisits = df_ervisits.astype(SECONDARY_TYPE_DICT)
+    except KeyError as exc:
+        raise ValueError(warn_string(df_ervisits, SECONDARY_TYPE_DICT)) from exc
+
+    return df_ervisits

--- a/nssp/delphi_nssp/pull.py
+++ b/nssp/delphi_nssp/pull.py
@@ -98,7 +98,7 @@ def pull_nssp_data(socrata_token: str, backup_dir: str, custom_run: bool, logger
     return df_ervisits[SIGNALS + keep_columns]
 
 
-def secondary_pull_nssp_data(socrata_token: str):
+def secondary_pull_nssp_data(socrata_token: str, backup_dir: str, custom_run: bool, logger: Optional[logging.Logger] = None):
     """Pull the latest NSSP ER visits secondary dataset.
 
     https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview
@@ -119,6 +119,7 @@ def secondary_pull_nssp_data(socrata_token: str):
     """
     socrata_results = pull_with_socrata_api(socrata_token, "7mra-9cq9")
     df_ervisits = pd.DataFrame.from_records(socrata_results)
+    create_backup_csv(df_ervisits, backup_dir, custom_run, sensor="secondary", logger=logger)
     df_ervisits = df_ervisits.rename(columns=SECONDARY_COLS_MAP)
 
     # geo_type is not provided in the dataset, so we infer it from the geo_value

--- a/nssp/delphi_nssp/run.py
+++ b/nssp/delphi_nssp/run.py
@@ -31,8 +31,8 @@ from delphi_utils import create_export_csv, get_structured_logger
 from delphi_utils.geomap import GeoMapper
 from delphi_utils.nancodes import add_default_nancodes
 
-from .constants import AUXILIARY_COLS, CSV_COLS, GEOS, SIGNALS
-from .pull import pull_nssp_data
+from .constants import *
+from .pull import pull_nssp_data, secondary_pull_nssp_data
 
 
 def add_needed_columns(df, col_names=None):
@@ -81,6 +81,7 @@ def run_module(params):
     socrata_token = params["indicator"]["socrata_token"]
 
     run_stats = []
+
     ## build the base version of the signal at the most detailed geo level you can get.
     ## compute stuff here or farm out to another function or file
     df_pull = pull_nssp_data(socrata_token)
@@ -122,6 +123,46 @@ def run_module(params):
             else:
                 df = df[df["county"] != "All"]
                 df["geo_id"] = df["fips"]
+            # add se, sample_size, and na codes
+            missing_cols = set(CSV_COLS) - set(df.columns)
+            df = add_needed_columns(df, col_names=list(missing_cols))
+            df_csv = df[CSV_COLS + ["timestamp"]]
+            # actual export
+            dates = create_export_csv(
+                df_csv,
+                geo_res=geo,
+                export_dir=export_dir,
+                sensor=signal,
+                weekly_dates=True,
+            )
+            if len(dates) > 0:
+                run_stats.append((max(dates), len(dates)))
+
+    secondary_df_pull = secondary_pull_nssp_data(socrata_token)
+    ## aggregate
+    geo_mapper = GeoMapper()
+    for signal in SECONDARY_SIGNALS:
+        for geo in SECONDARY_GEOS:
+            df = secondary_df_pull.copy()
+            logger.info("Generating signal and exporting to CSV", geo_type=geo, signal=signal)
+            if geo == "state":
+                df = df[(df["geo_type"] == "state")]
+                df["geo_id"] = df["geo_value"].apply(
+                    lambda x: (
+                        us.states.lookup(x).abbr.lower() if us.states.lookup(x)
+                        else ("dc" if x == "District of Columbia" else x)
+                    )
+                )
+                unexpected_state_names = df[df["geo_id"] == df["geo_value"]]
+                if unexpected_state_names.shape[0] > 0:
+                    logger.error("Unexpected state names", df=unexpected_state_names)
+                    exit(1)
+            elif geo == "nation":
+                df = df[(df["geo_type"] == "nation")]
+                df["geo_id"] = "us"
+            elif geo == "hhs":
+                df = df[(df["geo_type"] == "hhs")]
+                df["geo_id"] = df["geo_type"]
             # add se, sample_size, and na codes
             missing_cols = set(CSV_COLS) - set(df.columns)
             df = add_needed_columns(df, col_names=list(missing_cols))

--- a/nssp/delphi_nssp/run.py
+++ b/nssp/delphi_nssp/run.py
@@ -83,6 +83,7 @@ def run_module(params):
 
     run_stats = []
 
+    logger.info("Generating primary signals")
     ## build the base version of the signal at the most detailed geo level you can get.
     ## compute stuff here or farm out to another function or file
     df_pull = pull_nssp_data(socrata_token)
@@ -139,9 +140,8 @@ def run_module(params):
             if len(dates) > 0:
                 run_stats.append((max(dates), len(dates)))
 
+    logger.info("Generating secondary signals")
     secondary_df_pull = secondary_pull_nssp_data(socrata_token)
-    ## aggregate
-    geo_mapper = GeoMapper()
     for signal in SECONDARY_SIGNALS:
         secondary_df_pull_signal = secondary_df_pull[secondary_df_pull["signal"] == signal]
         if secondary_df_pull_signal.empty:
@@ -160,8 +160,7 @@ def run_module(params):
                 )
                 unexpected_state_names = df[df["geo_id"] == df["geo_value"]]
                 if unexpected_state_names.shape[0] > 0:
-                    logger.error("Unexpected state names", df=unexpected_state_names)
-                    sys.exit(1)
+                    raise RuntimeError(f"Unexpected state names: {unexpected_state_names}")
             elif geo == "nation":
                 df = df[(df["geo_type"] == "nation")]
                 df["geo_id"] = "us"

--- a/nssp/delphi_nssp/run.py
+++ b/nssp/delphi_nssp/run.py
@@ -22,6 +22,7 @@ the following structure:
         - "cache_dir": str, directory of locally cached data
 """
 
+import sys
 import time
 from datetime import datetime
 
@@ -31,7 +32,7 @@ from delphi_utils import create_export_csv, get_structured_logger
 from delphi_utils.geomap import GeoMapper
 from delphi_utils.nancodes import add_default_nancodes
 
-from .constants import *
+from .constants import AUXILIARY_COLS, CSV_COLS, GEOS, SECONDARY_GEOS, SECONDARY_SIGNALS, SIGNALS
 from .pull import pull_nssp_data, secondary_pull_nssp_data
 
 
@@ -149,14 +150,15 @@ def run_module(params):
                 df = df[(df["geo_type"] == "state")]
                 df["geo_id"] = df["geo_value"].apply(
                     lambda x: (
-                        us.states.lookup(x).abbr.lower() if us.states.lookup(x)
+                        us.states.lookup(x).abbr.lower()
+                        if us.states.lookup(x)
                         else ("dc" if x == "District of Columbia" else x)
                     )
                 )
                 unexpected_state_names = df[df["geo_id"] == df["geo_value"]]
                 if unexpected_state_names.shape[0] > 0:
                     logger.error("Unexpected state names", df=unexpected_state_names)
-                    exit(1)
+                    sys.exit(1)
             elif geo == "nation":
                 df = df[(df["geo_type"] == "nation")]
                 df["geo_id"] = "us"

--- a/nssp/delphi_nssp/run.py
+++ b/nssp/delphi_nssp/run.py
@@ -22,7 +22,6 @@ the following structure:
         - "cache_dir": str, directory of locally cached data
 """
 
-import sys
 import time
 from datetime import datetime
 
@@ -160,7 +159,11 @@ def run_module(params):
                 )
                 unexpected_state_names = df[df["geo_id"] == df["geo_value"]]
                 if unexpected_state_names.shape[0] > 0:
-                    raise RuntimeError(f"Unexpected state names: {unexpected_state_names}")
+                    logger.error(
+                        "Unexpected state names",
+                        unexpected_state_names=unexpected_state_names["geo_value"].unique(),
+                    )
+                    raise RuntimeError
             elif geo == "nation":
                 df = df[(df["geo_type"] == "nation")]
                 df["geo_id"] = "us"

--- a/nssp/delphi_nssp/run.py
+++ b/nssp/delphi_nssp/run.py
@@ -142,7 +142,7 @@ def run_module(params):
                 run_stats.append((max(dates), len(dates)))
 
     logger.info("Generating secondary signals")
-    secondary_df_pull = secondary_pull_nssp_data(socrata_token)
+    secondary_df_pull = secondary_pull_nssp_data(socrata_token, backup_dir, custom_run, logger)
     for signal in SECONDARY_SIGNALS:
         secondary_df_pull_signal = secondary_df_pull[secondary_df_pull["signal"] == signal]
         if secondary_df_pull_signal.empty:

--- a/nssp/delphi_nssp/run.py
+++ b/nssp/delphi_nssp/run.py
@@ -146,6 +146,7 @@ def run_module(params):
     for signal in SECONDARY_SIGNALS:
         secondary_df_pull_signal = secondary_df_pull[secondary_df_pull["signal"] == signal]
         if secondary_df_pull_signal.empty:
+            logger.warning("No data found for signal", signal=signal)
             continue
         for geo in SECONDARY_GEOS:
             df = secondary_df_pull_signal.copy()

--- a/nssp/delphi_nssp/run.py
+++ b/nssp/delphi_nssp/run.py
@@ -143,8 +143,11 @@ def run_module(params):
     ## aggregate
     geo_mapper = GeoMapper()
     for signal in SECONDARY_SIGNALS:
+        secondary_df_pull_signal = secondary_df_pull[secondary_df_pull["signal"] == signal]
+        if secondary_df_pull_signal.empty:
+            continue
         for geo in SECONDARY_GEOS:
-            df = secondary_df_pull.copy()
+            df = secondary_df_pull_signal.copy()
             logger.info("Generating signal and exporting to CSV", geo_type=geo, signal=signal)
             if geo == "state":
                 df = df[(df["geo_type"] == "state")]
@@ -164,7 +167,7 @@ def run_module(params):
                 df["geo_id"] = "us"
             elif geo == "hhs":
                 df = df[(df["geo_type"] == "hhs")]
-                df["geo_id"] = df["geo_type"]
+                df["geo_id"] = df["geo_value"]
             # add se, sample_size, and na codes
             missing_cols = set(CSV_COLS) - set(df.columns)
             df = add_needed_columns(df, col_names=list(missing_cols))

--- a/nssp/tests/test_data/secondary_page.txt
+++ b/nssp/tests/test_data/secondary_page.txt
@@ -1,443 +1,73 @@
 [
     {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Michigan",
-        "percent_visits": "1.5",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Minnesota",
-        "percent_visits": "1.9",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Mississippi",
-        "percent_visits": "3.6",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Montana",
+        "week_end": "2022-10-01T00:00:00.000",
+        "pathogen": "COVID-19", "geography": "National",
         "percent_visits": "1.8",
         "status": "Reporting",
-        "trend_on_date": "No Change",
+        "trend_on_date": "Decreasing",
         "recent_trend": "Decreasing"
     },
     {
-        "week_end": "2024-08-03T00:00:00.000",
+        "week_end": "2022-10-01T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "National",
+        "percent_visits": "0.5",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Increasing"
+    },
+    {
+        "week_end": "2022-10-01T00:00:00.000",
+        "pathogen": "RSV",
+        "geography": "National",
+        "percent_visits": "0.5",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Increasing"
+    },
+    {
+        "week_end": "2022-10-01T00:00:00.000",
+        "pathogen": "Combined",
+        "geography": "National",
+        "percent_visits": "2.8",
+        "status": "Reporting",
+        "trend_on_date": "Decreasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2022-10-15T00:00:00.000",
         "pathogen": "COVID-19",
         "geography": "National",
-        "percent_visits": "2.5",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Nebraska",
-        "percent_visits": "1.4",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Nevada",
-        "percent_visits": "1.5",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "New Jersey",
-        "percent_visits": "1.8",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "New Mexico",
-        "percent_visits": "2.8",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "New York",
         "percent_visits": "1.6",
         "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "North Carolina",
-        "percent_visits": "3.5",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "North Dakota",
-        "percent_visits": "1.0",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Ohio",
-        "percent_visits": "1.8",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Oklahoma",
-        "percent_visits": "2.0",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Oregon",
-        "percent_visits": "2.6",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Pennsylvania",
-        "percent_visits": "1.5",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 1",
-        "percent_visits": "1.9",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 10",
-        "percent_visits": "2.5",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 2",
-        "percent_visits": "1.7",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 3",
-        "percent_visits": "2.1",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 4",
-        "percent_visits": "3.3",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 5",
-        "percent_visits": "1.9",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 6",
-        "percent_visits": "3.7",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 7",
-        "percent_visits": "1.0",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 8",
-        "percent_visits": "1.8",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Region 9",
-        "percent_visits": "2.4",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Rhode Island",
-        "percent_visits": "1.4",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "South Carolina",
-        "percent_visits": "3.4",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Tennessee",
-        "percent_visits": "2.3",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Texas",
-        "percent_visits": "3.9",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Utah",
-        "percent_visits": "1.8",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Vermont",
-        "percent_visits": "1.7",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Virginia",
-        "percent_visits": "2.8",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Washington",
-        "percent_visits": "2.5",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "West Virginia",
-        "percent_visits": "2.0",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "COVID-19",
-        "geography": "Wisconsin",
-        "percent_visits": "2.0",
-        "status": "Reporting",
-        "trend_on_date": "Increasing",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Alabama",
-        "percent_visits": "0.1",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "Increasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Alaska",
-        "percent_visits": "0.2",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "Decreasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Arizona",
-        "percent_visits": "0.1",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "Increasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Arkansas",
-        "percent_visits": "0.2",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "No Change"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "California",
-        "percent_visits": "0.1",
-        "status": "Reporting",
         "trend_on_date": "Decreasing",
-        "recent_trend": "No Change"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Colorado",
-        "percent_visits": "0.1",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "Increasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Connecticut",
-        "percent_visits": "0.0",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "No Change"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Delaware",
-        "percent_visits": "0.1",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "No Change"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "District of Columbia",
-        "percent_visits": "0.0",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "No Change"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Florida",
-        "percent_visits": "0.4",
-        "status": "Reporting",
-        "trend_on_date": "Decreasing",
-        "recent_trend": "Increasing"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Georgia",
-        "percent_visits": "0.1",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "No Change"
-    },
-    {
-        "week_end": "2024-08-03T00:00:00.000",
-        "pathogen": "Influenza",
-        "geography": "Hawaii",
-        "percent_visits": "1.0",
-        "status": "Reporting",
-        "trend_on_date": "No Change",
         "recent_trend": "Decreasing"
     },
     {
-        "week_end": "2024-08-03T00:00:00.000",
+        "week_end": "2022-10-15T00:00:00.000",
         "pathogen": "Influenza",
-        "geography": "Idaho",
-        "percent_visits": "0.0",
+        "geography": "National",
+        "percent_visits": "0.9",
         "status": "Reporting",
-        "trend_on_date": "No Change",
-        "recent_trend": "No Change"
+        "trend_on_date": "Increasing",
+        "recent_trend": "Increasing"
+    },
+    {
+        "week_end": "2022-10-15T00:00:00.000",
+        "pathogen": "RSV",
+        "geography": "National",
+        "percent_visits": "0.7",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Increasing"
+    },
+    {
+        "week_end": "2022-10-15T00:00:00.000",
+        "pathogen": "Combined",
+        "geography": "National",
+        "percent_visits": "3.2",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
     }
 ]

--- a/nssp/tests/test_data/secondary_page.txt
+++ b/nssp/tests/test_data/secondary_page.txt
@@ -1,0 +1,443 @@
+[
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Michigan",
+        "percent_visits": "1.5",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Minnesota",
+        "percent_visits": "1.9",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Mississippi",
+        "percent_visits": "3.6",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Montana",
+        "percent_visits": "1.8",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "National",
+        "percent_visits": "2.5",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Nebraska",
+        "percent_visits": "1.4",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Nevada",
+        "percent_visits": "1.5",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "New Jersey",
+        "percent_visits": "1.8",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "New Mexico",
+        "percent_visits": "2.8",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "New York",
+        "percent_visits": "1.6",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "North Carolina",
+        "percent_visits": "3.5",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "North Dakota",
+        "percent_visits": "1.0",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Ohio",
+        "percent_visits": "1.8",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Oklahoma",
+        "percent_visits": "2.0",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Oregon",
+        "percent_visits": "2.6",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Pennsylvania",
+        "percent_visits": "1.5",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 1",
+        "percent_visits": "1.9",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 10",
+        "percent_visits": "2.5",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 2",
+        "percent_visits": "1.7",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 3",
+        "percent_visits": "2.1",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 4",
+        "percent_visits": "3.3",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 5",
+        "percent_visits": "1.9",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 6",
+        "percent_visits": "3.7",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 7",
+        "percent_visits": "1.0",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 8",
+        "percent_visits": "1.8",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Region 9",
+        "percent_visits": "2.4",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Rhode Island",
+        "percent_visits": "1.4",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "South Carolina",
+        "percent_visits": "3.4",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Tennessee",
+        "percent_visits": "2.3",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Texas",
+        "percent_visits": "3.9",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Utah",
+        "percent_visits": "1.8",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Vermont",
+        "percent_visits": "1.7",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Virginia",
+        "percent_visits": "2.8",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Washington",
+        "percent_visits": "2.5",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "West Virginia",
+        "percent_visits": "2.0",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "COVID-19",
+        "geography": "Wisconsin",
+        "percent_visits": "2.0",
+        "status": "Reporting",
+        "trend_on_date": "Increasing",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Alabama",
+        "percent_visits": "0.1",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "Increasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Alaska",
+        "percent_visits": "0.2",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Arizona",
+        "percent_visits": "0.1",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "Increasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Arkansas",
+        "percent_visits": "0.2",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "No Change"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "California",
+        "percent_visits": "0.1",
+        "status": "Reporting",
+        "trend_on_date": "Decreasing",
+        "recent_trend": "No Change"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Colorado",
+        "percent_visits": "0.1",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "Increasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Connecticut",
+        "percent_visits": "0.0",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "No Change"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Delaware",
+        "percent_visits": "0.1",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "No Change"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "District of Columbia",
+        "percent_visits": "0.0",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "No Change"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Florida",
+        "percent_visits": "0.4",
+        "status": "Reporting",
+        "trend_on_date": "Decreasing",
+        "recent_trend": "Increasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Georgia",
+        "percent_visits": "0.1",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "No Change"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Hawaii",
+        "percent_visits": "1.0",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "Decreasing"
+    },
+    {
+        "week_end": "2024-08-03T00:00:00.000",
+        "pathogen": "Influenza",
+        "geography": "Idaho",
+        "percent_visits": "0.0",
+        "status": "Reporting",
+        "trend_on_date": "No Change",
+        "recent_trend": "No Change"
+    }
+]

--- a/nssp/tests/test_pull.py
+++ b/nssp/tests/test_pull.py
@@ -83,6 +83,9 @@ class TestPullNSSPData:
 
     @patch("delphi_nssp.pull.Socrata")
     def test_secondary_pull_nssp_data(self, mock_socrata):
+        today = pd.Timestamp.today().strftime("%Y%m%d")
+        backup_dir = 'test_raw_data_backups'
+
         # Load test data
         with open("test_data/secondary_page.txt", "r") as f:
             test_data = json.load(f)
@@ -92,9 +95,11 @@ class TestPullNSSPData:
         mock_client.get.side_effect = [test_data, []]  # Return test data on first call, empty list on second call
         mock_socrata.return_value = mock_client
 
+        custom_run = False
+        logger = get_structured_logger()
         # Call function with test token
         test_token = "test_token"
-        result = secondary_pull_nssp_data(test_token)
+        result = secondary_pull_nssp_data(test_token, backup_dir, custom_run, logger)
         # print(result)
 
         # Check that Socrata client was initialized with correct arguments
@@ -109,6 +114,11 @@ class TestPullNSSPData:
         assert result[result['geo_value'].str.startswith('Region') ].empty, "'Region ' need to be removed from geo_value for geo_type 'hhs'"
         assert (result[result['geo_type'] == 'nation']['geo_value'] == 'National').all(), "All rows with geo_type 'nation' must have geo_value 'National'"
 
+        # Check that backup file was created
+        backup_files = glob.glob(f"{backup_dir}/{today}*")
+        assert len(backup_files) == 2, "Backup file was not created"
+        for file in backup_files:
+            os.remove(file)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description
Add 4 signals: `pct_ed_visits_covid_2023RVR`, `pct_ed_visits_influenza_2023RVR`, `pct_ed_visits_rsv_2023RVR`, `pct_ed_visits_combined_2023RVR` to nssp.

These secondary signals are vailable at geo levels `state`, `hhs` and `nation`.

Adding 4 signals from [this](https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/data_preview) secondary nssp source dataset. They report essentially the same data as the [main dataset](https://data.cdc.gov/Public-Health-Surveillance/NSSP-Emergency-Department-Visit-Trajectories-by-St/rdmq-nq56/data_preview), but only available at state level and above. However, it appears this secondary source updates quicker than the main source recently. 

More info at [DETAILS.md](https://github.com/cmu-delphi/covidcast-indicators/blob/f3cb5090106c80423c8900cbb4672e26004dfa5a/nssp/DETAILS.md)

Context: https://delphi-org.slack.com/archives/C0130CSQRN3/p1730476295781409

Things to think about:
- [x] need signal names approval from Roni
- [x] source stash? (different source -> different stash?)

### Associated Issue(s) 
- Addresses #2073
