### PR TITLE
move source backup dir to common

### DIFF
--- a/ansible/templates/nchs_mortality-params-prod.json.j2
+++ b/ansible/templates/nchs_mortality-params-prod.json.j2
@@ -1,7 +1,7 @@
 {
   "common": {
     "daily_export_dir": "./daily_receiving",
-    "backup_dir": "./raw_data_backups",
+    "backup_dir": "/common/covidcast/source_backup/nchs-mortality",
     "log_filename": "/var/log/indicators/nchs_mortality.log",
     "weekly_export_dir": "/common/covidcast/receiving/nchs-mortality"
   },

--- a/ansible/templates/nhsn-params-prod.json.j2
+++ b/ansible/templates/nhsn-params-prod.json.j2
@@ -1,7 +1,7 @@
 {
   "common": {
     "export_dir": "/common/covidcast/receiving/nhsn",
-    "backup_dir": "./raw_data_backups",
+    "backup_dir": "/common/covidcast/source_backup/nhsn",
     "log_filename": "/var/log/indicators/nhsn.log",
     "log_exceptions": false
   },

--- a/ansible/templates/nssp-params-prod.json.j2
+++ b/ansible/templates/nssp-params-prod.json.j2
@@ -1,7 +1,7 @@
 {
   "common": {
     "export_dir": "/common/covidcast/receiving/nssp",
-    "backup_dir": "./raw_data_backups",
+    "backup_dir": "/common/covidcast/source_backup/nssp",
     "log_filename": "/var/log/indicators/nssp.log",
     "log_exceptions": false
   },


### PR DESCRIPTION
### Changelog
Change backup dir to `/common/covidcast/source_backup/` in prod

### Associated Issue(s) 
#2089
