### PR TITLE
prevent sircal from alerting on NSSP secondary signals

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -49,8 +49,8 @@
         "pct_ed_visits_combined_2023rvr",
         "pct_ed_visits_covid_2023rvr",
         "pct_ed_visits_influenza_2023rvr",
-        "pct_ed_visits_rsv_2023rvr",
-      ],
+        "pct_ed_visits_rsv_2023rvr"
+      ]
     },
     "nhsn": {
       "max_age":19,

--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -44,7 +44,13 @@
     },
     "nssp": {
       "max_age":19,
-      "maintainers": []
+      "maintainers": [],
+      "retired-signals": [
+        "pct_ed_visits_combined_2023rvr",
+        "pct_ed_visits_covid_2023rvr",
+        "pct_ed_visits_influenza_2023rvr",
+        "pct_ed_visits_rsv_2023rvr",
+      ],
     },
     "nhsn": {
       "max_age":19,

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -49,8 +49,8 @@
         "pct_ed_visits_combined_2023rvr",
         "pct_ed_visits_covid_2023rvr",
         "pct_ed_visits_influenza_2023rvr",
-        "pct_ed_visits_rsv_2023rvr",
-      ],
+        "pct_ed_visits_rsv_2023rvr"
+      ]
     }
   }
 }

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -44,7 +44,13 @@
     },
     "nssp": {
       "max_age":19,
-      "maintainers": []
+      "maintainers": [],
+      "retired-signals": [
+        "pct_ed_visits_combined_2023rvr",
+        "pct_ed_visits_covid_2023rvr",
+        "pct_ed_visits_influenza_2023rvr",
+        "pct_ed_visits_rsv_2023rvr",
+      ],
     }
   }
 }


### PR DESCRIPTION
New signals were added to NSSP in issue #2073 / PR #2074 in the hope of getting more frequent updates, but [that new source data](https://data.cdc.gov/Public-Health-Surveillance/2023-Respiratory-Virus-Response-NSSP-Emergency-Dep/7mra-9cq9/about_data) has not been appended to or revised since Oct 18, 2024 (currently ~100 days out of date).

This PR should cause Sir Complains-a-Lot to ignore those stale signals, thus preventing alerting on their age, and in turn allow us to get better alerting on the age of the "main" NSSP signals.

Some more discussion is available in a slack thread: https://delphi-org.slack.com/archives/C01LZ3A2UMU/p1736451710690869?thread_ts=1736404465.936839&cid=C01LZ3A2UMU