### PR TITLE
Remove nssp secondary signals from sircal configs

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -44,13 +44,7 @@
     },
     "nssp": {
       "max_age":19,
-      "maintainers": [],
-      "retired-signals": [
-        "pct_ed_visits_combined_2023rvr",
-        "pct_ed_visits_covid_2023rvr",
-        "pct_ed_visits_influenza_2023rvr",
-        "pct_ed_visits_rsv_2023rvr"
-      ]
+      "maintainers": []
     },
     "nhsn": {
       "max_age":19,

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -44,13 +44,7 @@
     },
     "nssp": {
       "max_age":19,
-      "maintainers": [],
-      "retired-signals": [
-        "pct_ed_visits_combined_2023rvr",
-        "pct_ed_visits_covid_2023rvr",
-        "pct_ed_visits_influenza_2023rvr",
-        "pct_ed_visits_rsv_2023rvr"
-      ]
+      "maintainers": []
     }
   }
 }


### PR DESCRIPTION
### Description
Remove nssp secondary signals from sircal configs

### Associated Issue(s) 
- Addresses #2109 and #2099. Both can be closed after this PR merges.
