### PR TITLE
Sir Complains to ignore nssp combined signals

### DIFF
--- a/ansible/templates/sir_complainsalot-params-prod.json.j2
+++ b/ansible/templates/sir_complainsalot-params-prod.json.j2
@@ -44,7 +44,11 @@
     },
     "nssp": {
       "max_age":19,
-      "maintainers": []
+      "maintainers": [],
+      "retired-signals": [
+        "pct_ed_visits_combined",
+        "smoothed_pct_ed_visits_combined"
+      ]
     },
     "nhsn": {
       "max_age":19,

--- a/sir_complainsalot/params.json.template
+++ b/sir_complainsalot/params.json.template
@@ -44,7 +44,11 @@
     },
     "nssp": {
       "max_age":19,
-      "maintainers": []
+      "maintainers": [],
+      "retired-signals": [
+        "pct_ed_visits_combined",
+        "smoothed_pct_ed_visits_combined"
+      ]
     }
   }
 }


### PR DESCRIPTION
### Description
Make Sir complains ignore nssp combined signals lagging, as these signals are currently retired. 

### Changelog
Add "pct_ed_visits_combined" and "smoothed_pct_ed_visits_combined" to retired-signals section of nssp in sircomplains config. 

### Associated Issue(s)
https://github.com/cmu-delphi/covidcast-indicators/issues/2147