### PR TITLE
updated to new key for update timestamp

### DIFF
--- a/nhsn/delphi_nhsn/pull.py
+++ b/nhsn/delphi_nhsn/pull.py
@@ -38,7 +38,7 @@ def check_last_updated(socrata_token, dataset_id, logger):
         client = Socrata("data.cdc.gov", socrata_token)
         response = client.get_metadata(dataset_id)
 
-        updated_timestamp = datetime.utcfromtimestamp(int(response["rowsUpdatedAt"]))
+        updated_timestamp = datetime.utcfromtimestamp(int(response["viewLastModified"]))
         now = datetime.utcnow()
         recently_updated_source = (now - updated_timestamp) < timedelta(days=1)
 

--- a/nhsn/tests/conftest.py
+++ b/nhsn/tests/conftest.py
@@ -72,6 +72,6 @@ def run_as_module(params):
             else:
                 return []
         mock_get.side_effect = side_effect
-        mock_get_metadata.return_value = {"rowsUpdatedAt": time.time()}
+        mock_get_metadata.return_value = {"viewLastModified": time.time()}
         run_module(params)
 

--- a/nhsn/tests/test_pull.py
+++ b/nhsn/tests/test_pull.py
@@ -123,7 +123,7 @@ class TestPullNHSNData:
         mock_socrata.return_value = mock_client
         mock_client.get.side_effect = [dataset["test_data"], []]
 
-        mock_client.get_metadata.return_value = {"rowsUpdatedAt": now}
+        mock_client.get_metadata.return_value = {"viewLastModified": now}
 
         today = pd.Timestamp.today().strftime("%Y%m%d")
         backup_dir = params["common"]["backup_dir"]
@@ -163,7 +163,7 @@ class TestPullNHSNData:
     def test_check_last_updated(self, mock_socrata, dataset, updatedAt, caplog):
         mock_client = MagicMock()
         mock_socrata.return_value = mock_client
-        mock_client.get_metadata.return_value = {"rowsUpdatedAt": updatedAt }
+        mock_client.get_metadata.return_value = {"viewLastModified": updatedAt }
         logger = get_structured_logger()
 
         check_last_updated(mock_client, dataset["id"], logger)

--- a/nhsn/tests/test_pull.py
+++ b/nhsn/tests/test_pull.py
@@ -86,7 +86,7 @@ class TestPullNHSNData:
         mock_client = MagicMock()
         mock_socrata.return_value = mock_client
         mock_client.get.side_effect = [dataset["test_data"],[]]
-        mock_client.get_metadata.return_value = {"rowsUpdatedAt": now}
+        mock_client.get_metadata.return_value = {"viewLastModified": now}
 
         backup_dir = params["common"]["backup_dir"]
         test_token = params["indicator"]["socrata_token"]


### PR DESCRIPTION
### Description
update update timestamp key value from `rowsUpdatedAt` to `viewLastModified` to reflect the changes from cdc data metadata api response

### Associated Issue(s) 
- Addresses #2152
