### PR TITLE
version pinning osqp==1.1.0 because 1.1.1 breaks the build

### DIFF
--- a/claims_hosp/setup.py
+++ b/claims_hosp/setup.py
@@ -6,6 +6,7 @@ required = [
     "darker[isort]~=2.1.1",
     "delphi-utils",
     "numpy",
+    "osqp==1.1.0",
     "pandas",
     "paramiko",
     "pyarrow",

--- a/doctor_visits/setup.py
+++ b/doctor_visits/setup.py
@@ -5,6 +5,7 @@ required = [
     "darker[isort]~=2.1.1",
     "delphi-utils",
     "numpy",
+    "osqp==1.1.0",
     "pandas",
     "paramiko",
     "pylint==2.8.3",

--- a/nchs_mortality/setup.py
+++ b/nchs_mortality/setup.py
@@ -9,6 +9,7 @@ required = [
     "freezegun",
     "moto~=4.2.14",
     "numpy",
+    "osqp==1.1.0",
     "pandas",
     "pydocstyle",
     "pylint==2.8.3",

--- a/nhsn/setup.py
+++ b/nhsn/setup.py
@@ -3,6 +3,7 @@ from setuptools import find_packages
 
 required = [
     "numpy",
+    "osqp==1.1.0",
     "pandas",
     "pydocstyle",
     "pytest",

--- a/nssp/setup.py
+++ b/nssp/setup.py
@@ -3,6 +3,7 @@ from setuptools import find_packages
 
 required = [
     "numpy",
+    "osqp==1.1.0",
     "pandas",
     "pydocstyle",
     "pytest",

--- a/quidel_covidtest/setup.py
+++ b/quidel_covidtest/setup.py
@@ -9,6 +9,7 @@ required = [
     "imap-tools",
     "numpy",
     "openpyxl",
+    "osqp==1.1.0",
     "pandas",
     "pyarrow",
     "pydocstyle",


### PR DESCRIPTION
`osqp` is a dependency of `cvxpy` which is a dependency of `delphi-utils` which gets imported all over the place :-/

pursuant to https://github.com/cmu-delphi/epidata-etl/issues/594