### PR TITLE
claims format: make date-time separator optional

### DIFF
--- a/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
+++ b/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
@@ -27,30 +27,40 @@ def print_callback(filename, logger, bytes_so_far, bytes_total, progress_chunks)
         # Remove progress chunk, so it is not logged again
         progress_chunks.remove(rough_percent_transferred)
 
-OLD_FILENAME_TIMESTAMP = re.compile(
-    r".*EDI_AGG_INPATIENT_[0-9]_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
-NEW_FILENAME_TIMESTAMP = re.compile(r".*EDI_AGG_INPATIENT_(?P<ymd>[0-9]*)_?(?P<hm>[0-9]*)[^0-9]*")
+EPOCH = datetime.datetime(1900, 1, 1)
+
+# a drop filename is <source>_AGG_INPATIENT_[<chunk>_]<date>[_]<time><tz><ext>, where:
+# - the chunk number is only present on chunked drops
+# - the date is 8 digits, either YYYYMMDD or MMDDYYYY depending on the drop
+# - the separator between date and time is optional (dropped by the source in 2026)
+FILENAME_TIMESTAMP = re.compile(
+    r"^(?P<prefix>.*EDI_AGG_INPATIENT)_(?P<chunk>[0-9]_)?"
+    r"(?P<ymd>[0-9]{8})_?(?P<hm>[0-9]{4})(?P<suffix>[^0-9].*)?$")
+
 def get_timestamp(name):
     """Get the reference date in datetime format."""
-    if len(name.split("_")) > 5:
-        m = OLD_FILENAME_TIMESTAMP.match(name)
-    else:
-        m = NEW_FILENAME_TIMESTAMP.match(name)
+    m = FILENAME_TIMESTAMP.match(name)
     if not m:
-        return datetime.datetime(1900, 1, 1)
-    try:
-        return datetime.datetime.strptime(''.join(m.groups()), "%Y%m%d%H%M")
-    except ValueError:
-        return datetime.datetime.strptime(''.join(m.groups()), "%m%d%Y%H%M")
+        return EPOCH
+    stamp = m.group("ymd") + m.group("hm")
+    # MMDD as a year is always before 1231, so YYYYMMDD is the only reading that can parse
+    for date_format in ("%Y%m%d%H%M", "%m%d%Y%H%M"):
+        try:
+            return datetime.datetime.strptime(stamp, date_format)
+        except ValueError:
+            continue
+    return EPOCH
 
 def change_date_format(name):
-    """Flip date from YYYYMMDD to MMDDYYYY."""
-    split_name = name.split("_")
-    date = split_name[3]
-    flip_date = date[6:] + date[4:6] + date[:4]
-    split_name[3] = flip_date
-    name = '_'.join(split_name)
-    return name
+    """Rewrite the date field to DDMMYYYY, the layout get_latest_filename expects."""
+    m = FILENAME_TIMESTAMP.match(name)
+    timestamp = get_timestamp(name)
+    if m is None or timestamp == EPOCH:
+        return name
+    prefix = m.group("prefix")
+    chunk = m.group("chunk") or ""
+    suffix = m.group("suffix") or ""
+    return f"{prefix}_{chunk}{timestamp:%d%m%Y}_{timestamp:%H%M}{suffix}"
 
 
 def download(ftp_credentials, out_path, logger):

--- a/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
+++ b/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
@@ -29,7 +29,7 @@ def print_callback(filename, logger, bytes_so_far, bytes_total, progress_chunks)
 
 OLD_FILENAME_TIMESTAMP = re.compile(
     r".*EDI_AGG_INPATIENT_[0-9]_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
-NEW_FILENAME_TIMESTAMP = re.compile(r".*EDI_AGG_INPATIENT_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
+NEW_FILENAME_TIMESTAMP = re.compile(r".*EDI_AGG_INPATIENT_(?P<ymd>[0-9]*)_?(?P<hm>[0-9]*)[^0-9]*")
 def get_timestamp(name):
     """Get the reference date in datetime format."""
     if len(name.split("_")) > 5:

--- a/claims_hosp/tests/test_download_claims_ftp_files.py
+++ b/claims_hosp/tests/test_download_claims_ftp_files.py
@@ -1,34 +1,66 @@
 # standard
 import datetime
-import re
 
 # third party
-import numpy as np
+import pytest
 
 # first party
 from delphi_claims_hosp.download_claims_ftp_files import (change_date_format,
                                                           get_timestamp)
 
-OLD_FILENAME_TIMESTAMP = re.compile(
-    r".*EDI_AGG_INPATIENT_[0-9]_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
-NEW_FILENAME_TIMESTAMP = re.compile(r".*EDI_AGG_INPATIENT_(?P<ymd>[0-9]*)_?(?P<hm>[0-9]*)[^0-9]*")
 
 class TestDownloadClaimsFtpFiles:
-    
-    def test_change_date_format(self):
-        name = "SYNEDI_AGG_INPATIENT_20200611_1451CDT"
-        expected = "SYNEDI_AGG_INPATIENT_11062020_1451CDT"
-        assert(change_date_format(name)==expected)
-        
-    def test_get_timestamp(self):
-        name = "SYNEDI_AGG_INPATIENT_20200611_1451CDT"
-        assert(get_timestamp(name).date() == datetime.date(2020, 6, 11))
 
-        name = "EDI_AGG_INPATIENT_08272021_0251CDT.csv.gz.filepart"
-        assert(get_timestamp(name).date() == datetime.date(2021, 8, 27))
+    @pytest.mark.parametrize("name, expected", [
+        # YYYYMMDD, separated
+        ("SYNEDI_AGG_INPATIENT_20200611_1451CDT",
+         "SYNEDI_AGG_INPATIENT_11062020_1451CDT"),
+        # MMDDYYYY, separated
+        ("EDI_AGG_INPATIENT_08272021_0251CDT.csv.gz",
+         "EDI_AGG_INPATIENT_27082021_0251CDT.csv.gz"),
+        # MMDDYYYY, no separator between date and time
+        ("EDI_AGG_INPATIENT_060620260000CDT.csv.gz",
+         "EDI_AGG_INPATIENT_06062026_0000CDT.csv.gz"),
+        # chunked drops keep their chunk number
+        ("EDI_AGG_INPATIENT_1_05302020_0352CDT.csv.gz",
+         "EDI_AGG_INPATIENT_1_30052020_0352CDT.csv.gz"),
+        # unparseable names are passed through untouched
+        ("EDI_AGG_INPATIENT_nonsense.csv.gz",
+         "EDI_AGG_INPATIENT_nonsense.csv.gz"),
+    ])
+    def test_change_date_format(self, name, expected):
+        assert change_date_format(name) == expected
 
-        name = "EDI_AGG_INPATIENT_1_05302020_0352CDT.csv.gz"
-        assert(get_timestamp(name).date() == datetime.date(2020, 5, 30))
+    def test_change_date_format_is_readable_downstream(self):
+        """get_latest_filename splits on _ and parses field 3 as DDMMYYYY."""
+        flipped = change_date_format("EDI_AGG_INPATIENT_060620260000CDT.csv.gz")
+        split_name = flipped.split("_")
+        assert len(split_name) == 5
+        hhmm = ''.join(filter(str.isdigit, split_name[4]))
+        assert datetime.datetime.strptime(split_name[3] + hhmm, "%d%m%Y%H%M") == \
+            datetime.datetime(2026, 6, 6, 0, 0)
 
-        name = "EDI_AGG_INPATIENT_060620260000CDT.csv.gz"
-        assert(get_timestamp(name).date() == datetime.date(2026, 6, 6))
+    @pytest.mark.parametrize("name, expected", [
+        ("SYNEDI_AGG_INPATIENT_20200611_1451CDT",
+         datetime.datetime(2020, 6, 11, 14, 51)),
+        ("EDI_AGG_INPATIENT_08272021_0251CDT.csv.gz.filepart",
+         datetime.datetime(2021, 8, 27, 2, 51)),
+        ("EDI_AGG_INPATIENT_1_05302020_0352CDT.csv.gz",
+         datetime.datetime(2020, 5, 30, 3, 52)),
+        # no separator between date and time
+        ("EDI_AGG_INPATIENT_060620260000CDT.csv.gz",
+         datetime.datetime(2026, 6, 6, 0, 0)),
+        ("EDI_AGG_INPATIENT_1_060620260000CDT.csv.gz",
+         datetime.datetime(2026, 6, 6, 0, 0)),
+    ])
+    def test_get_timestamp(self, name, expected):
+        assert get_timestamp(name) == expected
+
+    @pytest.mark.parametrize("name", [
+        "EDI_AGG_OUTPATIENT_20200611_1451CDT.csv.gz",
+        "EDI_AGG_INPATIENT_nonsense.csv.gz",
+        "EDI_AGG_INPATIENT_123_1451CDT.csv.gz",
+    ])
+    def test_get_timestamp_unparseable(self, name):
+        """Names we can't read sort to the epoch rather than raising."""
+        assert get_timestamp(name) == datetime.datetime(1900, 1, 1)

--- a/claims_hosp/tests/test_download_claims_ftp_files.py
+++ b/claims_hosp/tests/test_download_claims_ftp_files.py
@@ -11,7 +11,7 @@ from delphi_claims_hosp.download_claims_ftp_files import (change_date_format,
 
 OLD_FILENAME_TIMESTAMP = re.compile(
     r".*EDI_AGG_INPATIENT_[0-9]_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
-NEW_FILENAME_TIMESTAMP = re.compile(r".*EDI_AGG_INPATIENT_(?P<ymd>[0-9]*)_(?P<hm>[0-9]*)[^0-9]*")
+NEW_FILENAME_TIMESTAMP = re.compile(r".*EDI_AGG_INPATIENT_(?P<ymd>[0-9]*)_?(?P<hm>[0-9]*)[^0-9]*")
 
 class TestDownloadClaimsFtpFiles:
     
@@ -23,9 +23,12 @@ class TestDownloadClaimsFtpFiles:
     def test_get_timestamp(self):
         name = "SYNEDI_AGG_INPATIENT_20200611_1451CDT"
         assert(get_timestamp(name).date() == datetime.date(2020, 6, 11))
-        
+
         name = "EDI_AGG_INPATIENT_08272021_0251CDT.csv.gz.filepart"
         assert(get_timestamp(name).date() == datetime.date(2021, 8, 27))
-        
+
         name = "EDI_AGG_INPATIENT_1_05302020_0352CDT.csv.gz"
         assert(get_timestamp(name).date() == datetime.date(2020, 5, 30))
+
+        name = "EDI_AGG_INPATIENT_060620260000CDT.csv.gz"
+        assert(get_timestamp(name).date() == datetime.date(2026, 6, 6))


### PR DESCRIPTION
## Summary

Ports epidata-etl#886 — `EDI_AGG_INPATIENT_060620260000CDT.csv.gz` is now a valid drop name, i.e. the separator between date and time is optional.

`get_timestamp` needed the same regex relaxation as upstream, but **not** upstream's `date_format` branching: this codebase joins the regex groups (`ymd + hm`) before `strptime`, so the separator is already discarded by capture, whereas epidata-etl passes the raw string to `pendulum.from_format` with a literal `_` in the format.

The real analogue of that `date_format` logic here is `change_date_format`, which is where this got interesting.

## The bug this actually fixes

`change_date_format` sliced `split("_")[3]` by index. For the new separator-less name, field 3 is the entire `060620260000CDT.csv.gz` blob, so it produced:

```
EDI_AGG_INPATIENT_060620260000CDT.csv.gz
  -> EDI_AGG_INPATIENT_260000CDT.csv.gz200606
```

That is the **local output path** in `download()`. Not a `.csv.gz`, and only 4 underscore-separated parts, so `get_latest_filename` (which requires exactly 5) never sees it. Relaxing only the regex would have converted a silent skip into a silent corrupt write — strictly worse.

## Changes

- Collapse `OLD_FILENAME_TIMESTAMP` / `NEW_FILENAME_TIMESTAMP` and the `len(split("_")) > 5` heuristic into one anchored regex with fixed-width date/time groups. The old loose `[0-9]*` groups meant a chunked separator-less name matched as 13 digits and raised an **uncaught** `ValueError` out of the download loop; it now fails the match and returns the epoch sentinel like every other unreadable name.
- Rebuild the filename from the parsed datetime rather than slicing by index, preserving the chunk number and the tz/extension suffix.
- Emit **DDMMYYYY**. The old docstring claimed MMDDYYYY, but neither the code nor its consumer did that — `get_latest_claims_name` parses `%d%m%Y%H%M`, and the pre-existing test already expected `20200611 -> 11062020`. Behavior preserved, docstring corrected.

## Incidental fix, worth a look

Inputs already in MMDDYYYY (e.g. `EDI_AGG_INPATIENT_08272021_0251CDT.csv.gz`) previously flipped to `21200827`, which `get_latest_filename` would have thrown `ValueError` on (day 21, month 20). They now normalize to `27082021`. **Reviewer check:** this is a live behavior change if such names actually land on the FTP server — `get_timestamp` has always sniffed both layouts, so presumably they do.

Chunked-drop handling is deliberately unchanged: those names still come out with 6 parts and are still ignored by `get_latest_filename`. Fixing that would change which files get picked up, which felt out of scope here.

## Test plan

- `change_date_format` and `get_timestamp` covered across all four filename shapes, plus unparseable names and a round-trip asserting the output is readable by `get_latest_filename`'s parser. 14 tests, all passing.
- pylint clean (10.00/10) on the changed module.
- Note: `pytest claims_hosp/` can't run end-to-end in my environment — `delphi_utils` is pinned to Python 3.8 and won't install on 3.13. I ran the real test file against the real source module with the package `__init__` stubbed out, so the code under test is genuine, but **CI should be treated as the authoritative run.**

🤖 Generated with Claude Code