### PR TITLE
Automate patching for hospital-admissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ vault_backup*
 # testing_utils
 testing_utils/cache
 testing_utils/*.csv
+# Do not commit patch output
+**/patch/issue_*/

--- a/claims_hosp/README.md
+++ b/claims_hosp/README.md
@@ -49,9 +49,11 @@ env/bin/python -m delphi_claims_hosp.patch
 An issue is a full re-run of the indicator against the drop that arrived that
 day, not one day of data: each issue re-emits the same window of `time_value`s
 the daily run would have. That window is `n_backfill_days` deep unless
-`indicator.start_date` is set, which overrides it and can make it much deeper —
-check what your `params.json` uses before patching a wide range, since the CSV
-count per issue scales with it.
+`indicator.start_date` is set, which overrides it and can make it much deeper.
+The CSV count per issue scales with that window, so before the run starts the
+patch logs the issue count, the dates per issue and the estimated CSV count, and
+warns when `start_date` is what widened the window. Read that line before
+walking away from a wide patch.
 
 Each issue pulls the drop that arrived on its issue date from the ftp server, so
 patching needs working ftp credentials. How far back the server keeps drops is a

--- a/claims_hosp/README.md
+++ b/claims_hosp/README.md
@@ -47,8 +47,11 @@ env/bin/python -m delphi_claims_hosp.patch
 ```
 
 An issue is a full re-run of the indicator against the drop that arrived that
-day, not one day of data: each issue re-emits `n_backfill_days` of `time_value`s,
-exactly as the daily run would have.
+day, not one day of data: each issue re-emits the same window of `time_value`s
+the daily run would have. That window is `n_backfill_days` deep unless
+`indicator.start_date` is set, which overrides it and can make it much deeper —
+check what your `params.json` uses before patching a wide range, since the CSV
+count per issue scales with it.
 
 Each issue pulls the drop that arrived on its issue date from the ftp server, so
 patching needs working ftp credentials. How far back the server keeps drops is a

--- a/claims_hosp/README.md
+++ b/claims_hosp/README.md
@@ -36,6 +36,31 @@ params file with the following:
 make clean
 ```
 
+## Running Patches
+
+To regenerate data for a range of issue dates in batch issue format, turn on the
+`custom_run` flag and add a `patch` section to `params.json` as described in
+`patch.py`, then run
+
+```
+env/bin/python -m delphi_claims_hosp.patch
+```
+
+An issue is a full re-run of the indicator against the drop that arrived that
+day, not one day of data: each issue re-emits `n_backfill_days` of `time_value`s,
+exactly as the daily run would have.
+
+Each issue pulls the drop that arrived on its issue date from the ftp server, so
+patching needs working ftp credentials. How far back the server keeps drops is a
+property of the server; for older issues, stage the drops in
+`indicator.input_dir` yourself and the downloader will skip over them. Issue
+dates with no drop available are logged and skipped.
+
+A patch leaves `input_dir` populated when it finishes rather than clearing it the
+way a daily run does, since later issues in the range still need the earlier
+drops. Point patches at their own `input_dir` to keep them out of the staging
+directory the daily run uses.
+
 ## Testing the code
 
 To run static tests of the code style, run the following command:
@@ -67,6 +92,10 @@ should not include critical sub-routines.
 ## Code tour
 
 - run.py: reads params.json to generated updated signal, run daily
+- patch.py: runs the indicator over a range of issue dates, for backfilling
+    missed issues
+- backfill.py: stores daily backfill files and merges them; also folds a patched
+    issue back into the merged file that covers its date
 - update_indicator.py: 
     ClaimsHospIndicatorUpdater: reads the data, makes transformations, writes output
 - indicator.py:

--- a/claims_hosp/delphi_claims_hosp/backfill.py
+++ b/claims_hosp/delphi_claims_hosp/backfill.py
@@ -5,6 +5,7 @@ Author: Jingjing Tang
 Created: 2022-08-03
 
 """
+
 import glob
 import os
 import re
@@ -14,7 +15,6 @@ from pathlib import Path
 # third party
 import pandas as pd
 from delphi_utils import GeoMapper
-
 
 from .config import Config
 
@@ -84,8 +84,8 @@ def store_backfill_file(claims_filepath, _end_date, backfill_dir, logger):
     logger.info("Stored source data in parquet", filename=path)
     return path
 
-def merge_backfill_file(backfill_dir, backfill_merge_day, today, logger,
-                        test_mode=False, check_nd=25):
+
+def merge_backfill_file(backfill_dir, backfill_merge_day, today, logger, test_mode=False, check_nd=25):
     """
     Merge ~4 weeks' backfill data into one file.
 
@@ -129,14 +129,15 @@ def merge_backfill_file(backfill_dir, backfill_merge_day, today, logger,
         logger.info("Not a merge day, skipping merge")
         return
     if (today - earliest_date).days <= check_nd:
-        logger.info("Not enough unmerged days, skipping merge",
-                    earliest_date=earliest_date.strftime("%Y-%m-%d"))
+        logger.info("Not enough unmerged days, skipping merge", earliest_date=earliest_date.strftime("%Y-%m-%d"))
         return
 
     # Start to merge files
-    logger.info("Merging backfill files",
-                start_date=earliest_date.strftime("%Y-%m-%d"),
-                end_date=latest_date.strftime("%Y-%m-%d"))
+    logger.info(
+        "Merging backfill files",
+        start_date=earliest_date.strftime("%Y-%m-%d"),
+        end_date=latest_date.strftime("%Y-%m-%d"),
+    )
     pdList = []
     for fn in new_files:
         df = pd.read_parquet(fn, engine='pyarrow')
@@ -161,7 +162,8 @@ def merged_filename(start_date, end_date):
     """Build the name of the merged backfill file spanning the given dates."""
     return "claims_hosp_from_%s_to_%s.parquet" % (
         datetime.strftime(start_date, "%Y%m%d"),
-        datetime.strftime(end_date, "%Y%m%d"))
+        datetime.strftime(end_date, "%Y%m%d"),
+    )
 
 
 def get_merged_file_for_date(backfill_dir, issue_date):
@@ -190,9 +192,9 @@ def get_merged_file_for_date(backfill_dir, issue_date):
         match = MERGED_FILENAME.match(filepath.name)
         if not match:
             continue
-        spans.append((filepath,
-                      datetime.strptime(match.group(1), "%Y%m%d"),
-                      datetime.strptime(match.group(2), "%Y%m%d")))
+        spans.append(
+            (filepath, datetime.strptime(match.group(1), "%Y%m%d"), datetime.strptime(match.group(2), "%Y%m%d"))
+        )
 
     for filepath, start_date, end_date in spans:
         if start_date <= issue_date <= end_date:
@@ -233,15 +235,18 @@ def merge_existing_backfill_files(backfill_dir, backfill_file, issue_date, logge
     file_path, new_file_path = get_merged_file_for_date(backfill_dir, issue_date)
 
     if file_path is None:
-        logger.info("No merged backfill file covers this issue date; "
-                    "leaving the daily file for the next scheduled merge",
-                    issue_date=issue_date.strftime("%Y-%m-%d"))
+        logger.info(
+            "No merged backfill file covers this issue date; " "leaving the daily file for the next scheduled merge",
+            issue_date=issue_date.strftime("%Y-%m-%d"),
+        )
         return
 
-    logger.info("Adding patched issue to merged backfill file",
-                issue_date=issue_date.strftime("%Y-%m-%d"),
-                filename=str(backfill_file),
-                merged_filename=str(file_path))
+    logger.info(
+        "Adding patched issue to merged backfill file",
+        issue_date=issue_date.strftime("%Y-%m-%d"),
+        filename=str(backfill_file),
+        merged_filename=str(file_path),
+    )
 
     merge_file = file_path.parent / f"{file_path.stem}_after_merge.parquet"
     try:
@@ -250,15 +255,21 @@ def merge_existing_backfill_files(backfill_dir, backfill_file, issue_date, logge
         issue_str = datetime.strftime(issue_date, "%Y-%m-%d")
         already_present = existing_df["issue_date"] == issue_str
         if already_present.any():
-            logger.info("Replacing rows already present for this issue date",
-                        issue_date=issue_str, row_count=int(already_present.sum()))
+            logger.info(
+                "Replacing rows already present for this issue date",
+                issue_date=issue_str,
+                row_count=int(already_present.sum()),
+            )
             existing_df = existing_df[~already_present]
         merged_df = pd.concat([existing_df, df]).sort_values(["time_value", "fips"])
         merged_df.to_parquet(merge_file, index=False)
     except Exception as e:  # pylint: disable=broad-except
         # leave the daily file in place; the patched data is still recoverable
-        logger.error("Failed to merge patched issue into existing backfill file",
-                     issue_date=issue_date.strftime("%Y-%m-%d"), msg=str(e))
+        logger.error(
+            "Failed to merge patched issue into existing backfill file",
+            issue_date=issue_date.strftime("%Y-%m-%d"),
+            msg=str(e),
+        )
         if os.path.exists(merge_file):
             os.remove(merge_file)
         return

--- a/claims_hosp/delphi_claims_hosp/backfill.py
+++ b/claims_hosp/delphi_claims_hosp/backfill.py
@@ -5,9 +5,11 @@ Author: Jingjing Tang
 Created: 2022-08-03
 
 """
-import os
 import glob
-from datetime import datetime
+import os
+import re
+from datetime import datetime, timedelta
+from pathlib import Path
 
 # third party
 import pandas as pd
@@ -18,7 +20,7 @@ from .config import Config
 
 gmpr = GeoMapper()
 
-def store_backfill_file(claims_filepath, _end_date, backfill_dir):
+def store_backfill_file(claims_filepath, _end_date, backfill_dir, logger):
     """
     Store county level backfill data into backfill_dir.
 
@@ -29,6 +31,10 @@ def store_backfill_file(claims_filepath, _end_date, backfill_dir):
             The most recent date when the raw data is received
         backfill_dir: str
             specified path to store backfill files.
+        logger: structlog.BoundLogger
+
+    Returns:
+        str, path of the file written.
     """
     backfilldata = pd.read_csv(
         claims_filepath,
@@ -75,8 +81,10 @@ def store_backfill_file(claims_filepath, _end_date, backfill_dir):
         "/claims_hosp_as_of_%s.parquet"%datetime.strftime(_end_date, "%Y%m%d")
     # Store intermediate file into the backfill folder
     backfilldata.to_parquet(path, index=False)
+    logger.info("Stored source data in parquet", filename=path)
+    return path
 
-def merge_backfill_file(backfill_dir, backfill_merge_day, today,
+def merge_backfill_file(backfill_dir, backfill_merge_day, today, logger,
                         test_mode=False, check_nd=25):
     """
     Merge ~4 weeks' backfill data into one file.
@@ -93,6 +101,7 @@ def merge_backfill_file(backfill_dir, backfill_merge_day, today,
     backfill_merge_day: int
         The day of a week that we used to merge the backfill files. e.g. 0
         is Monday.
+    logger: structlog.BoundLogger
     test_mode: bool
     check_nd: int
         The criteria of the number of unmerged files. Ideally, we want the
@@ -101,6 +110,7 @@ def merge_backfill_file(backfill_dir, backfill_merge_day, today,
     """
     new_files = glob.glob(backfill_dir + "/claims_hosp_as_of_*")
     if len(new_files) == 0: # if no any daily file is stored
+        logger.info("No unmerged backfill files, skipping merge")
         return
 
     def get_date(file_link):
@@ -115,10 +125,18 @@ def merge_backfill_file(backfill_dir, backfill_merge_day, today,
 
     # Check whether to merge
     # Check the number of files that are not merged
-    if today.weekday() != backfill_merge_day or (today-earliest_date).days <= check_nd:
+    if today.weekday() != backfill_merge_day:
+        logger.info("Not a merge day, skipping merge")
+        return
+    if (today - earliest_date).days <= check_nd:
+        logger.info("Not enough unmerged days, skipping merge",
+                    earliest_date=earliest_date.strftime("%Y-%m-%d"))
         return
 
     # Start to merge files
+    logger.info("Merging backfill files",
+                start_date=earliest_date.strftime("%Y-%m-%d"),
+                end_date=latest_date.strftime("%Y-%m-%d"))
     pdList = []
     for fn in new_files:
         df = pd.read_parquet(fn, engine='pyarrow')
@@ -133,4 +151,120 @@ def merge_backfill_file(backfill_dir, backfill_merge_day, today,
     if not test_mode:
         for fn in new_files:
             os.remove(fn)
+    return
+
+
+MERGED_FILENAME = re.compile(r"^claims_hosp_from_(\d{8})_to_(\d{8})\.parquet$")
+
+
+def merged_filename(start_date, end_date):
+    """Build the name of the merged backfill file spanning the given dates."""
+    return "claims_hosp_from_%s_to_%s.parquet" % (
+        datetime.strftime(start_date, "%Y%m%d"),
+        datetime.strftime(end_date, "%Y%m%d"))
+
+
+def get_merged_file_for_date(backfill_dir, issue_date):
+    """
+    Find the merged backfill file that a patched issue date belongs in.
+
+    An issue inside an existing [from, to] span goes back into that file under
+    its current name. An issue immediately before or after a span extends it,
+    so the file has to be renamed. An issue that touches no span at all is left
+    to the regular weekly merge.
+
+    Parameters
+    ----------
+    backfill_dir : str
+        specified path to store backfill files.
+    issue_date : datetime
+        The issue date being patched.
+
+    Returns
+    -------
+    (Path, Path) of the merged file to update and the name it should carry
+    afterwards, or (None, None) if no merged file covers or abuts the date.
+    """
+    spans = []
+    for filepath in sorted(Path(backfill_dir).glob("claims_hosp_from_*_to_*.parquet")):
+        match = MERGED_FILENAME.match(filepath.name)
+        if not match:
+            continue
+        spans.append((filepath,
+                      datetime.strptime(match.group(1), "%Y%m%d"),
+                      datetime.strptime(match.group(2), "%Y%m%d")))
+
+    for filepath, start_date, end_date in spans:
+        if start_date <= issue_date <= end_date:
+            return filepath, filepath
+
+    # the issue date fell on the edge of an outage, just outside a merged span
+    for filepath, start_date, end_date in spans:
+        if issue_date == end_date + timedelta(days=1):
+            return filepath, filepath.parent / merged_filename(start_date, issue_date)
+        if issue_date == start_date - timedelta(days=1):
+            return filepath, filepath.parent / merged_filename(issue_date, end_date)
+
+    return None, None
+
+
+def merge_existing_backfill_files(backfill_dir, backfill_file, issue_date, logger):
+    """
+    Add a patched issue to the merged backfill file that already covers its date.
+
+    When the indicator fails for a day, that day is missing from the backfill
+    files. By the time we patch it the surrounding days have usually been merged
+    already, so the newly stored daily file has to be folded into the merged
+    file rather than left for the weekly merge.
+
+    Rows already carrying this issue date are dropped before the merge, so
+    re-running a patch over the same date does not double up the data.
+
+    Parameters
+    ----------
+    backfill_dir : str
+        specified path to store backfill files.
+    backfill_file : str
+        daily backfill file just written for the patched issue.
+    issue_date : datetime
+        The issue date being patched.
+    logger: structlog.BoundLogger
+    """
+    file_path, new_file_path = get_merged_file_for_date(backfill_dir, issue_date)
+
+    if file_path is None:
+        logger.info("No merged backfill file covers this issue date; "
+                    "leaving the daily file for the next scheduled merge",
+                    issue_date=issue_date.strftime("%Y-%m-%d"))
+        return
+
+    logger.info("Adding patched issue to merged backfill file",
+                issue_date=issue_date.strftime("%Y-%m-%d"),
+                filename=str(backfill_file),
+                merged_filename=str(file_path))
+
+    merge_file = file_path.parent / f"{file_path.stem}_after_merge.parquet"
+    try:
+        existing_df = pd.read_parquet(file_path, engine="pyarrow")
+        df = pd.read_parquet(backfill_file, engine="pyarrow")
+        issue_str = datetime.strftime(issue_date, "%Y-%m-%d")
+        already_present = existing_df["issue_date"] == issue_str
+        if already_present.any():
+            logger.info("Replacing rows already present for this issue date",
+                        issue_date=issue_str, row_count=int(already_present.sum()))
+            existing_df = existing_df[~already_present]
+        merged_df = pd.concat([existing_df, df]).sort_values(["time_value", "fips"])
+        merged_df.to_parquet(merge_file, index=False)
+    except Exception as e:  # pylint: disable=broad-except
+        # leave the daily file in place; the patched data is still recoverable
+        logger.error("Failed to merge patched issue into existing backfill file",
+                     issue_date=issue_date.strftime("%Y-%m-%d"), msg=str(e))
+        if os.path.exists(merge_file):
+            os.remove(merge_file)
+        return
+
+    os.remove(file_path)
+    os.replace(merge_file, new_file_path)
+    os.remove(backfill_file)
+    logger.info("Merged patched issue into backfill file", merged_filename=str(new_file_path))
     return

--- a/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
+++ b/claims_hosp/delphi_claims_hosp/download_claims_ftp_files.py
@@ -70,9 +70,12 @@ def change_date_format(name):
     return "_".join(split_name)
 
 
-def download(ftp_credentials, out_path, logger):
+def download(ftp_credentials, out_path, logger, issue_date=None):
     """Pull the latest raw files."""
-    current_time = datetime.datetime.now()
+    if issue_date:
+        current_time = datetime.datetime.strptime(issue_date, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
+    else:
+        current_time = datetime.datetime.now()
     seconds_in_day = 24 * 60 * 60
     logger.info("Starting download")
 

--- a/claims_hosp/delphi_claims_hosp/get_latest_claims_name.py
+++ b/claims_hosp/delphi_claims_hosp/get_latest_claims_name.py
@@ -5,9 +5,17 @@
 import datetime
 from pathlib import Path
 
-def get_latest_filename(dir_path, logger):
+
+class NoDropError(AssertionError):
+    """Raised when no raw drop is available for the requested date."""
+
+
+def get_latest_filename(dir_path, logger, issue_date=None):
     """Get the latest filename from the list of downloaded raw files."""
-    current_date = datetime.datetime.now()
+    if issue_date:
+        current_date = datetime.datetime.strptime(issue_date, "%Y-%m-%d").replace(hour=23, minute=59, second=59)
+    else:
+        current_date = datetime.datetime.now()
     files = list(Path(dir_path).glob("*"))
 
     latest_timestamp = datetime.datetime(1900, 1, 1)
@@ -28,7 +36,8 @@ def get_latest_filename(dir_path, logger):
                     latest_timestamp = timestamp
                     latest_filename = file
 
-    assert current_date.date() == latest_timestamp.date(), "no drop for today"
+    if current_date.date() != latest_timestamp.date():
+        raise NoDropError(f"no drop for {current_date.date()}")
 
     logger.info("Latest claims file", filename=latest_filename)
 

--- a/claims_hosp/delphi_claims_hosp/modify_claims_drops.py
+++ b/claims_hosp/delphi_claims_hosp/modify_claims_drops.py
@@ -17,7 +17,7 @@ import numpy as np
 import pandas as pd
 
 
-def modify_and_write(data_path, logger, test_mode=False):
+def modify_and_write(data_path, logger, test_mode=False, filepaths=None):
     """
     Modify drops given a folder path.
 
@@ -26,10 +26,16 @@ def modify_and_write(data_path, logger, test_mode=False):
 
     Args:
       data_path: path to the folder with duplicated drops.
+      filepaths: optional list of drops to modify. If not given, every drop in
+        data_path is modified. Patch runs pass the single drop for the issue
+        being patched so we don't rewrite the whole raw archive once per issue.
       test_mode: Don't overwrite the drops if test_mode==True
 
     """
-    files = np.array(list(Path(data_path).glob("*.csv.gz")))
+    if filepaths is None:
+        files = np.array(list(Path(data_path).glob("*.csv.gz")))
+    else:
+        files = np.array([Path(f) for f in filepaths])
     dfs_list = []
     for f in files:
         filename = str(f)
@@ -57,5 +63,5 @@ def modify_and_write(data_path, logger, test_mode=False):
             dfs_list.append(dfs)
         else:
             dfs.to_csv(out_path, index=False)
-            logger.info("Wrote modified csv", filename=out_path)
+            logger.info("Wrote modified csv", filename=str(out_path))
     return files, dfs_list

--- a/claims_hosp/delphi_claims_hosp/patch.py
+++ b/claims_hosp/delphi_claims_hosp/patch.py
@@ -2,8 +2,9 @@
 This module is used for patching data in the delphi_claims_hosp package.
 
 An issue is a whole re-run of the indicator against the drop that arrived that
-day, not one day of data: each issue re-emits n_backfill_days of time_values,
-exactly as the daily run would have.
+day, not one day of data: each issue re-emits the same window of time_values the
+daily run would have. That window is n_backfill_days deep unless
+indicator.start_date is set, which overrides it and can make it much deeper.
 
 Each issue pulls the drop that arrived on its issue date from the ftp server, so
 patching needs working ftp credentials. How far back the server keeps drops is a
@@ -148,9 +149,7 @@ def patch():
             run_module(params, logger)
         except NoDropError:
             # one issue with no drop shouldn't take down the rest of the patch
-            logger.warning(
-                "No drop available for this issue, skipping", issue_date=current_issue.strftime("%Y-%m-%d")
-            )
+            logger.warning("No drop available for this issue, skipping", issue_date=current_issue.strftime("%Y-%m-%d"))
             rmtree(current_issue_dir)
             rmdir(path.dirname(current_issue_dir))
         current_issue += timedelta(days=1)

--- a/claims_hosp/delphi_claims_hosp/patch.py
+++ b/claims_hosp/delphi_claims_hosp/patch.py
@@ -1,0 +1,162 @@
+"""
+This module is used for patching data in the delphi_claims_hosp package.
+
+An issue is a whole re-run of the indicator against the drop that arrived that
+day, not one day of data: each issue re-emits n_backfill_days of time_values,
+exactly as the daily run would have.
+
+Each issue pulls the drop that arrived on its issue date from the ftp server, so
+patching needs working ftp credentials. How far back the server keeps drops is a
+property of the server; for older issues, stage the drops
+(EDI_AGG_INPATIENT_DDMMYYYY_HHMM{timezone}.csv.gz) in "input_dir" yourself and
+the downloader will skip over them. A patch leaves "input_dir" populated when it
+finishes rather than clearing it the way a daily run does, so give patches their
+own "input_dir" if you don't want the drops mixed in with the daily staging dir.
+
+Issue dates with no drop available are logged and skipped.
+
+To use this module, configure params.json like so:
+
+{
+  "common": {
+    "custom_run": true,
+    ...
+  },
+  "indicator": {
+    "input_dir": "/common/covidcast/archive/hospital-admissions",
+    ...
+  },
+  "patch": {
+    "patch_dir": "/covidcast-indicators/claims_hosp/AprilPatch",
+    "start_issue": "2024-04-20",
+    "end_issue": "2024-04-21"
+  }
+}
+
+In this params.json, we
+- Turn on the "custom_run" flag under "common"
+- Add a "patch" section, which contains:
+    + "patch_dir": the local directory to write all patch issues output
+    + "start_issue": str, YYYY-MM-DD format, first issue date
+    + "end_issue": str, YYYY-MM-DD format, last issue date
+
+It will generate data for that range of issue dates, and store them in batch
+issue format:
+[patch_dir]/issue_[issue-date]/hospital-admissions/actual_data_file.csv
+
+If "generate_backfill_files" is on, each patched issue is also stored as a
+daily backfill file and folded back into the merged backfill file that covers
+its date. See merge_existing_backfill_files in backfill.py.
+"""
+
+import sys
+from datetime import datetime, timedelta
+from os import makedirs, path, rmdir
+from shutil import rmtree
+
+from delphi_utils import get_structured_logger, read_params
+
+from .get_latest_claims_name import NoDropError
+from .run import run_module
+
+
+def good_patch_config(params, logger):
+    """
+    Check if the params.json file is correctly configured for patching.
+
+    params: Dict[str, Any]
+        Nested dictionary of parameters, typically loaded from params.json file.
+    logger: structlog.BoundLogger
+    """
+    valid_config = True
+    if not params["common"].get("custom_run", False):
+        logger.error("Calling patch.py without custom_run flag set true.")
+        valid_config = False
+
+    patch_config = params.get("patch", {})
+    if patch_config == {}:
+        logger.error("Custom flag is on, but patch section is missing.")
+        valid_config = False
+    else:
+        missing_keys = [key for key in ["start_issue", "end_issue", "patch_dir"] if key not in patch_config]
+        if missing_keys:
+            logger.error("Patch section is missing required key(s)", missing_keys=missing_keys)
+            valid_config = False
+        else:
+            try:  # issue dates validity check
+                start_issue = datetime.strptime(patch_config["start_issue"], "%Y-%m-%d")
+                end_issue = datetime.strptime(patch_config["end_issue"], "%Y-%m-%d")
+                if start_issue > end_issue:
+                    logger.error("Start issue date is after end issue date.")
+                    valid_config = False
+            except ValueError:
+                logger.error("Issue dates must be in YYYY-MM-DD format.")
+                valid_config = False
+
+    # every issue would otherwise be generated against the same drop date
+    for key in ["drop_date", "end_date"]:
+        if params["indicator"].get(key) is not None:
+            logger.error("Indicator section must leave this null when patching", key=key)
+            valid_config = False
+
+    if valid_config:
+        logger.info("Good patch configuration.")
+        return True
+    logger.info("Bad patch configuration.")
+    return False
+
+
+def patch():
+    """
+    Run the hospital-admissions indicator for a range of issue dates.
+
+    The range of issue dates is specified in params.json using the following keys:
+    - "patch": Only used for patching data
+        - "start_issue": str, YYYY-MM-DD format, first issue date
+        - "end_issue": str, YYYY-MM-DD format, last issue date
+        - "patch_dir": str, directory to write all issues output
+    """
+    params = read_params()
+    logger = get_structured_logger("delphi_claims_hosp.patch", filename=params["common"].get("log_filename"))
+    if not good_patch_config(params, logger):
+        sys.exit(1)
+
+    start_issue = datetime.strptime(params["patch"]["start_issue"], "%Y-%m-%d")
+    end_issue = datetime.strptime(params["patch"]["end_issue"], "%Y-%m-%d")
+
+    logger.info(
+        "Starting patching",
+        patch_directory=params["patch"]["patch_dir"],
+        start_issue=start_issue.strftime("%Y-%m-%d"),
+        end_issue=end_issue.strftime("%Y-%m-%d"),
+    )
+
+    makedirs(params["patch"]["patch_dir"], exist_ok=True)
+
+    current_issue = start_issue
+    while current_issue <= end_issue:
+        logger.info("Running issue", issue_date=current_issue.strftime("%Y-%m-%d"))
+
+        params["patch"]["current_issue"] = current_issue.strftime("%Y-%m-%d")
+
+        current_issue_yyyymmdd = current_issue.strftime("%Y%m%d")
+        current_issue_dir = f"""{params["patch"]["patch_dir"]}/issue_{current_issue_yyyymmdd}/hospital-admissions"""
+        makedirs(f"{current_issue_dir}", exist_ok=True)
+        params["common"]["export_dir"] = f"""{current_issue_dir}"""
+
+        try:
+            run_module(params, logger)
+        except NoDropError:
+            # one issue with no drop shouldn't take down the rest of the patch
+            logger.warning(
+                "No drop available for this issue, skipping", issue_date=current_issue.strftime("%Y-%m-%d")
+            )
+            rmtree(current_issue_dir)
+            rmdir(path.dirname(current_issue_dir))
+        current_issue += timedelta(days=1)
+
+    logger.info("Finished patching")
+
+
+if __name__ == "__main__":
+    patch()

--- a/claims_hosp/delphi_claims_hosp/patch.py
+++ b/claims_hosp/delphi_claims_hosp/patch.py
@@ -107,6 +107,63 @@ def good_patch_config(params, logger):
     return False
 
 
+def output_dates_per_issue(params, issue_date):
+    """
+    Count the time_values one issue will emit, mirroring run.py's window arithmetic.
+
+    run.py derives the window from n_backfill_days, then replaces its start with
+    indicator.start_date whenever that is non-null. A drop arrives on its issue
+    date, so dropdate is the issue date here.
+
+    params: Dict[str, Any]
+    issue_date: datetime
+    """
+    enddate = issue_date - timedelta(days=params["indicator"]["n_waiting_days"])
+    start_date = params["indicator"].get("start_date")
+    if start_date is not None:
+        startdate = datetime.strptime(start_date, "%Y-%m-%d")
+    else:
+        startdate = enddate - timedelta(days=params["indicator"]["n_backfill_days"])
+    return (enddate - startdate).days
+
+
+def log_patch_size(params, start_issue, end_issue, logger):
+    """
+    Report how much output the patch will produce before it starts producing it.
+
+    A patch writes one csv per (time_value, geo, signal) per issue, so a widened
+    output window multiplies across every issue in the range. Warn when
+    indicator.start_date is what widened it, since copying the prod params is
+    the easy way to end up there by accident.
+
+    params: Dict[str, Any]
+    start_issue: datetime
+    end_issue: datetime
+    logger: structlog.BoundLogger
+    """
+    issue_count = (end_issue - start_issue).days + 1
+    first, last = (output_dates_per_issue(params, issue) for issue in (start_issue, end_issue))
+    # run.py generates both numerators for each requested geo and weekday setting
+    signals_per_date = len(params["indicator"]["geos"]) * len(params["indicator"]["weekday"]) * 2
+    csv_count = (first + last) // 2 * signals_per_date * issue_count
+
+    logger.info(
+        "Patch size",
+        issue_count=issue_count,
+        dates_per_issue=first if first == last else f"{first}-{last}",
+        estimated_csv_count=csv_count,
+    )
+
+    if params["indicator"].get("start_date") is not None:
+        logger.warning(
+            "indicator.start_date overrides n_backfill_days, widening every issue's output window",
+            start_date=params["indicator"]["start_date"],
+            n_backfill_days=params["indicator"]["n_backfill_days"],
+            dates_per_issue=first if first == last else f"{first}-{last}",
+            estimated_csv_count=csv_count,
+        )
+
+
 def patch():
     """
     Run the hospital-admissions indicator for a range of issue dates.
@@ -132,6 +189,7 @@ def patch():
         end_issue=end_issue.strftime("%Y-%m-%d"),
     )
 
+    log_patch_size(params, start_issue, end_issue, logger)
     makedirs(params["patch"]["patch_dir"], exist_ok=True)
 
     current_issue = start_issue

--- a/claims_hosp/delphi_claims_hosp/run.py
+++ b/claims_hosp/delphi_claims_hosp/run.py
@@ -20,10 +20,11 @@ from .download_claims_ftp_files import download
 from .modify_claims_drops import modify_and_write
 from .get_latest_claims_name import get_latest_filename
 from .update_indicator import ClaimsHospIndicatorUpdater
-from .backfill import (store_backfill_file, merge_backfill_file)
+from .backfill import (store_backfill_file, merge_backfill_file,
+                       merge_existing_backfill_files)
 
 
-def run_module(params):
+def run_module(params, logger=None):
     """
     Generate updated claims-based hospitalization indicator values.
 
@@ -52,21 +53,36 @@ def run_module(params):
             - "weekday": list of bool, which weekday adjustments to perform. For each value in the
                 list, signals will be generated with weekday adjustments (True) or without
                 adjustments (False).
+        - "patch": Only used for patching data, remove if not patching.
+                   Check out patch.py and README for more details on how to run patches.
+            - "start_issue": str, YYYY-MM-DD format, first issue date
+            - "end_issue": str, YYYY-MM-DD format, last issue date
+            - "patch_dir": str, directory to write all issues output
     """
     start_time = time.time()
-    logger = get_structured_logger(
-        __name__, filename=params["common"].get("log_filename"),
-        log_exceptions=params["common"].get("log_exceptions", True))
+    custom_run = params["common"].get("custom_run", False)
+    issue_date = params.get("patch", {}).get("current_issue", None)
+    if not logger:
+        logger = get_structured_logger(
+            __name__, filename=params["common"].get("log_filename"),
+            log_exceptions=params["common"].get("log_exceptions", True))
 
-    # pull latest data
+    # pull latest data; a patch pulls the drop that arrived on the issue date.
+    # Drops already staged in input_dir are skipped by the downloader.
     download(params["indicator"]["ftp_credentials"],
-             params["indicator"]["input_dir"], logger)
+             params["indicator"]["input_dir"], logger, issue_date=issue_date)
 
-    # aggregate data
-    modify_and_write(params["indicator"]["input_dir"], logger)
+    if custom_run and issue_date:
+        # find this issue's drop and aggregate only that one; a patch leaves
+        # earlier issues' drops in input_dir, and they don't need redoing
+        claims_file = get_latest_filename(params["indicator"]["input_dir"], logger, issue_date=issue_date)
+        modify_and_write(params["indicator"]["input_dir"], logger, filepaths=[claims_file])
+    else:
+        # aggregate data
+        modify_and_write(params["indicator"]["input_dir"], logger)
 
-    # find the latest files (these have timestamps)
-    claims_file = get_latest_filename(params["indicator"]["input_dir"], logger)
+        # find the latest files (these have timestamps)
+        claims_file = get_latest_filename(params["indicator"]["input_dir"], logger)
 
     # handle range of estimates to produce
     # filename expected to have format: EDI_AGG_INPATIENT_DDMMYYYY_HHMM{timezone}.csv.gz
@@ -94,8 +110,15 @@ def run_module(params):
     if params["indicator"].get("generate_backfill_files", True):
         backfill_dir = params["indicator"]["backfill_dir"]
         backfill_merge_day = params["indicator"]["backfill_merge_day"]
-        merge_backfill_file(backfill_dir, backfill_merge_day, datetime.today())
-        store_backfill_file(claims_file, dropdate_dt, backfill_dir)
+        if custom_run and issue_date:
+            # the days around this issue are usually merged already, so fold the
+            # patched issue back into the merged file instead of waiting for the
+            # next scheduled merge
+            backfill_file = store_backfill_file(claims_file, dropdate_dt, backfill_dir, logger)
+            merge_existing_backfill_files(backfill_dir, backfill_file, dropdate_dt, logger)
+        else:
+            merge_backfill_file(backfill_dir, backfill_merge_day, datetime.today(), logger)
+            store_backfill_file(claims_file, dropdate_dt, backfill_dir, logger)
 
     # print out information
     logger.info("Loaded params",
@@ -153,11 +176,15 @@ def run_module(params):
                 n_csv_export.append(len(updater.output_dates))
         logger.info("Finished updating", geo_type=geo)
 
-    # Remove all the raw files
-    for fn in os.listdir(params["indicator"]["input_dir"]):
-        if ".csv.gz" in fn:
-            os.remove(f'{params["indicator"]["input_dir"]}/{fn}')
-    logger.info('Remove all the raw files.')
+    # Remove all the raw files. A patch run reads its drops out of the archive in
+    # input_dir and still needs them for the remaining issues, so leave them alone.
+    if custom_run and issue_date:
+        logger.info("Patch run, keeping the raw files")
+    else:
+        for fn in os.listdir(params["indicator"]["input_dir"]):
+            if ".csv.gz" in fn:
+                os.remove(f'{params["indicator"]["input_dir"]}/{fn}')
+        logger.info('Remove all the raw files.')
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
     min_max_date = min(max_dates)

--- a/claims_hosp/delphi_claims_hosp/run.py
+++ b/claims_hosp/delphi_claims_hosp/run.py
@@ -5,23 +5,24 @@ This module should contain a function called `run_module`, that is executed
 when the module is run with `python -m delphi_claims_hosp`.
 """
 
+import os
+
 # standard packages
 import time
-import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
 # third party
 from delphi_utils import get_structured_logger
 
+from .backfill import merge_backfill_file, merge_existing_backfill_files, store_backfill_file
+
 # first party
 from .config import Config
 from .download_claims_ftp_files import download
-from .modify_claims_drops import modify_and_write
 from .get_latest_claims_name import get_latest_filename
+from .modify_claims_drops import modify_and_write
 from .update_indicator import ClaimsHospIndicatorUpdater
-from .backfill import (store_backfill_file, merge_backfill_file,
-                       merge_existing_backfill_files)
 
 
 def run_module(params, logger=None):
@@ -64,13 +65,14 @@ def run_module(params, logger=None):
     issue_date = params.get("patch", {}).get("current_issue", None)
     if not logger:
         logger = get_structured_logger(
-            __name__, filename=params["common"].get("log_filename"),
-            log_exceptions=params["common"].get("log_exceptions", True))
+            __name__,
+            filename=params["common"].get("log_filename"),
+            log_exceptions=params["common"].get("log_exceptions", True),
+        )
 
     # pull latest data; a patch pulls the drop that arrived on the issue date.
     # Drops already staged in input_dir are skipped by the downloader.
-    download(params["indicator"]["ftp_credentials"],
-             params["indicator"]["input_dir"], logger, issue_date=issue_date)
+    download(params["indicator"]["ftp_credentials"], params["indicator"]["input_dir"], logger, issue_date=issue_date)
 
     if custom_run and issue_date:
         # find this issue's drop and aggregate only that one; a patch leaves
@@ -184,7 +186,7 @@ def run_module(params, logger=None):
         for fn in os.listdir(params["indicator"]["input_dir"]):
             if ".csv.gz" in fn:
                 os.remove(f'{params["indicator"]["input_dir"]}/{fn}')
-        logger.info('Remove all the raw files.')
+        logger.info("Remove all the raw files.")
 
     elapsed_time_in_seconds = round(time.time() - start_time, 2)
     min_max_date = min(max_dates)

--- a/claims_hosp/params.json.template
+++ b/claims_hosp/params.json.template
@@ -1,7 +1,8 @@
 {
   "common": {
     "export_dir": "./receiving",
-    "log_exceptions": false
+    "log_exceptions": false,
+    "custom_run": false
   },
   "indicator": {
     "input_dir": "./retrieve_files",

--- a/claims_hosp/tests/conftest.py
+++ b/claims_hosp/tests/conftest.py
@@ -1,0 +1,51 @@
+import copy
+from pathlib import Path
+
+import pytest
+
+TEST_DIR = Path(__file__).parent
+
+
+@pytest.fixture
+def params():
+    return copy.deepcopy({
+        "common": {
+            "export_dir": f"{TEST_DIR}/receiving",
+            "log_filename": f"{TEST_DIR}/test.log",
+            "custom_run": False,
+        },
+        "indicator": {
+            "input_dir": f"{TEST_DIR}/test_data",
+            "start_date": None,
+            "end_date": None,
+            "drop_date": None,
+            "n_backfill_days": 70,
+            "n_waiting_days": 3,
+            "generate_backfill_files": False,
+            "backfill_dir": f"{TEST_DIR}/backfill",
+            "backfill_merge_day": 0,
+            "write_se": False,
+            "obfuscated_prefix": "foo_obfuscated",
+            "parallel": False,
+            "geos": ["nation"],
+            "weekday": [False],
+            "ftp_credentials": {
+                "host": "test_host",
+                "user": "test_user",
+                "pass": "test_pass",
+                "port": 2222,
+            },
+        },
+    })
+
+
+@pytest.fixture
+def params_w_patch(params):
+    params_copy = copy.deepcopy(params)
+    params_copy["common"]["custom_run"] = True
+    params_copy["patch"] = {
+        "start_issue": "2020-06-11",
+        "end_issue": "2020-06-11",
+        "patch_dir": f"{TEST_DIR}/patch_dir",
+    }
+    return params_copy

--- a/claims_hosp/tests/test_backfill.py
+++ b/claims_hosp/tests/test_backfill.py
@@ -1,6 +1,8 @@
 import os
 import glob
-from datetime import datetime
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import Mock
 
 # third party
 import pandas as pd
@@ -8,8 +10,10 @@ import pytest
 
 # first party
 from delphi_claims_hosp.config import Config, GeoConstants
-from delphi_claims_hosp.backfill import store_backfill_file, merge_backfill_file
+from delphi_claims_hosp.backfill import (store_backfill_file, merge_backfill_file,
+                                         get_merged_file_for_date, merge_existing_backfill_files)
 
+TEST_LOGGER = Mock()
 CONFIG = Config()
 CONSTANTS = GeoConstants()
 PARAMS = {
@@ -31,7 +35,7 @@ class TestBackfill:
         assert fn not in os.listdir(backfill_dir)
        
         # Store backfill file
-        store_backfill_file(DATA_FILEPATH, dropdate, backfill_dir)
+        store_backfill_file(DATA_FILEPATH, dropdate, backfill_dir, TEST_LOGGER)
         assert fn in os.listdir(backfill_dir)
         fn = "claims_hosp_as_of_20200101.parquet"
         backfill_df = pd.read_parquet(backfill_dir + "/"+ fn, engine='pyarrow')
@@ -52,23 +56,23 @@ class TestBackfill:
         
         # Check when there is no daily file to merge.
         today = datetime(2020, 6, 14)
-        merge_backfill_file(backfill_dir, today.weekday(), today, 
+        merge_backfill_file(backfill_dir, today.weekday(), today, TEST_LOGGER,
                             test_mode=True, check_nd=8)
         assert fn not in os.listdir(backfill_dir)
         
         # Generate backfill daily files     
         for d in range(11, 15):
             dropdate = datetime(2020, 6, d)        
-            store_backfill_file(DATA_FILEPATH, dropdate, backfill_dir)
+            store_backfill_file(DATA_FILEPATH, dropdate, backfill_dir, TEST_LOGGER)
         
         # Check the when the merged file is not generated
         today = datetime(2020, 6, 14)
-        merge_backfill_file(backfill_dir, today.weekday(), today, 
+        merge_backfill_file(backfill_dir, today.weekday(), today, TEST_LOGGER,
                             test_mode=True, check_nd=8)
         assert fn not in os.listdir(backfill_dir)
         
          # Generate the merged file, but not delete it
-        merge_backfill_file(backfill_dir, today.weekday(), today, 
+        merge_backfill_file(backfill_dir, today.weekday(), today, TEST_LOGGER,
                             test_mode=True, check_nd=2)         
         assert fn in os.listdir(backfill_dir)
 
@@ -95,3 +99,113 @@ class TestBackfill:
         
         os.remove(backfill_dir + "/" + fn)
         assert fn not in os.listdir(backfill_dir)
+
+
+class TestMergeExistingBackfillFiles:
+
+    def cleanup(self):
+        for fn in self.parquet_files():
+            os.remove(backfill_dir + "/" + fn)
+
+    def parquet_files(self):
+        return sorted(os.path.basename(fn)
+                      for fn in glob.glob(backfill_dir + "/claims_hosp*.parquet"))
+
+    def make_merged_file(self, start_date, end_date):
+        """Write a merged file spanning start_date to end_date, one issue per day."""
+        dfs = []
+        for d in range((end_date - start_date).days + 1):
+            dropdate = start_date + timedelta(days=d)
+            fn = store_backfill_file(DATA_FILEPATH, dropdate, backfill_dir, TEST_LOGGER)
+            dfs.append(pd.read_parquet(fn, engine="pyarrow"))
+            os.remove(fn)
+        merged = pd.concat(dfs).sort_values(["time_value", "fips"])
+        fn = "claims_hosp_from_%s_to_%s.parquet" % (
+            start_date.strftime("%Y%m%d"), end_date.strftime("%Y%m%d"))
+        merged.to_parquet(backfill_dir + "/" + fn, index=False)
+        return fn
+
+    def test_get_merged_file_for_date(self):
+        self.cleanup()
+        fn = self.make_merged_file(datetime(2020, 6, 11), datetime(2020, 6, 14))
+
+        # inside the span: same file, same name
+        old, new = get_merged_file_for_date(backfill_dir, datetime(2020, 6, 12))
+        assert old.name == fn and new.name == fn
+
+        # boundaries of the span count as inside
+        old, new = get_merged_file_for_date(backfill_dir, datetime(2020, 6, 11))
+        assert old.name == fn and new.name == fn
+
+        # one day after the span: file gets renamed to cover it
+        old, new = get_merged_file_for_date(backfill_dir, datetime(2020, 6, 15))
+        assert old.name == fn
+        assert new.name == "claims_hosp_from_20200611_to_20200615.parquet"
+
+        # one day before the span: same, in the other direction
+        old, new = get_merged_file_for_date(backfill_dir, datetime(2020, 6, 10))
+        assert old.name == fn
+        assert new.name == "claims_hosp_from_20200610_to_20200614.parquet"
+
+        # nowhere near the span: leave it to the weekly merge
+        assert get_merged_file_for_date(backfill_dir, datetime(2020, 7, 1)) == (None, None)
+
+        self.cleanup()
+
+    def test_merge_existing_backfill_files(self):
+        self.cleanup()
+        # a merged file with 06-13 missing, as if the indicator failed that day
+        dfs = []
+        for d in [11, 12, 14]:
+            dropdate = datetime(2020, 6, d)
+            fn = store_backfill_file(DATA_FILEPATH, dropdate, backfill_dir, TEST_LOGGER)
+            dfs.append(pd.read_parquet(fn, engine="pyarrow"))
+            os.remove(fn)
+        merged_fn = "claims_hosp_from_20200611_to_20200614.parquet"
+        pd.concat(dfs).sort_values(["time_value", "fips"]).to_parquet(
+            backfill_dir + "/" + merged_fn, index=False)
+
+        issue_date = datetime(2020, 6, 13)
+        backfill_file = store_backfill_file(DATA_FILEPATH, issue_date, backfill_dir, TEST_LOGGER)
+        merge_existing_backfill_files(backfill_dir, backfill_file, issue_date, TEST_LOGGER)
+
+        # the daily file is folded in and cleaned up, the name is unchanged
+        assert not os.path.exists(backfill_file)
+        assert self.parquet_files() == [merged_fn]
+        merged = pd.read_parquet(backfill_dir + "/" + merged_fn, engine="pyarrow")
+        assert set(merged["issue_date"]) == {"2020-06-11", "2020-06-12", "2020-06-13", "2020-06-14"}
+        assert merged.equals(merged.sort_values(["time_value", "fips"]))
+        n_rows = len(merged)
+
+        # re-running the same patch replaces the rows instead of doubling them
+        backfill_file = store_backfill_file(DATA_FILEPATH, issue_date, backfill_dir, TEST_LOGGER)
+        merge_existing_backfill_files(backfill_dir, backfill_file, issue_date, TEST_LOGGER)
+        merged = pd.read_parquet(backfill_dir + "/" + merged_fn, engine="pyarrow")
+        assert len(merged) == n_rows
+
+        self.cleanup()
+
+    def test_merge_existing_backfill_files_extends_span(self):
+        self.cleanup()
+        self.make_merged_file(datetime(2020, 6, 11), datetime(2020, 6, 14))
+
+        issue_date = datetime(2020, 6, 15)
+        backfill_file = store_backfill_file(DATA_FILEPATH, issue_date, backfill_dir, TEST_LOGGER)
+        merge_existing_backfill_files(backfill_dir, backfill_file, issue_date, TEST_LOGGER)
+
+        assert self.parquet_files() == ["claims_hosp_from_20200611_to_20200615.parquet"]
+        self.cleanup()
+
+    def test_merge_existing_backfill_files_no_match(self):
+        self.cleanup()
+        merged_fn = self.make_merged_file(datetime(2020, 6, 11), datetime(2020, 6, 14))
+
+        issue_date = datetime(2020, 7, 1)
+        backfill_file = store_backfill_file(DATA_FILEPATH, issue_date, backfill_dir, TEST_LOGGER)
+        merge_existing_backfill_files(backfill_dir, backfill_file, issue_date, TEST_LOGGER)
+
+        # nothing covers this date, so the daily file is left for the weekly merge
+        assert os.path.exists(backfill_file)
+        assert self.parquet_files() == sorted(
+            [merged_fn, "claims_hosp_as_of_20200701.parquet"])
+        self.cleanup()

--- a/claims_hosp/tests/test_patch.py
+++ b/claims_hosp/tests/test_patch.py
@@ -1,10 +1,12 @@
 import os
 import shutil
+from datetime import datetime
 from unittest.mock import MagicMock, patch as mock_patch
 
 import pytest
 
-from delphi_claims_hosp.patch import good_patch_config, patch
+from delphi_claims_hosp.patch import (good_patch_config, log_patch_size,
+                                      output_dates_per_issue, patch)
 
 from conftest import TEST_DIR
 
@@ -37,6 +39,35 @@ class TestGoodPatchConfig:
     def test_start_issue_after_end_issue(self, params_w_patch):
         params_w_patch["patch"]["end_issue"] = "2020-06-10"
         assert not good_patch_config(params_w_patch, MagicMock())
+
+
+class TestPatchSize:
+
+    def test_window_from_n_backfill_days(self, params_w_patch):
+        # start_date null, so the window is n_backfill_days deep
+        assert output_dates_per_issue(params_w_patch, datetime(2026, 9, 8)) == 70
+
+    def test_start_date_overrides_the_window(self, params_w_patch):
+        # what the prod template sets; run.py applies it after n_backfill_days
+        params_w_patch["indicator"]["start_date"] = "2020-02-01"
+        assert output_dates_per_issue(params_w_patch, datetime(2026, 9, 8)) == 2408
+
+    def test_reports_size_without_warning(self, params_w_patch):
+        logger = MagicMock()
+        log_patch_size(params_w_patch, datetime(2026, 9, 8), datetime(2026, 9, 10), logger)
+
+        # 1 geo x 1 weekday setting x 2 numerators x 70 dates x 3 issues
+        assert logger.info.call_args.kwargs == {
+            "issue_count": 3, "dates_per_issue": 70, "estimated_csv_count": 420}
+        logger.warning.assert_not_called()
+
+    def test_warns_when_start_date_widens_the_window(self, params_w_patch):
+        params_w_patch["indicator"]["start_date"] = "2020-02-01"
+        logger = MagicMock()
+        log_patch_size(params_w_patch, datetime(2026, 9, 8), datetime(2026, 9, 10), logger)
+
+        logger.warning.assert_called_once()
+        assert logger.warning.call_args.kwargs["estimated_csv_count"] > 14000
 
 
 class TestPatchModule:

--- a/claims_hosp/tests/test_patch.py
+++ b/claims_hosp/tests/test_patch.py
@@ -1,0 +1,93 @@
+import os
+import shutil
+from unittest.mock import MagicMock, patch as mock_patch
+
+import pytest
+
+from delphi_claims_hosp.patch import good_patch_config, patch
+
+from conftest import TEST_DIR
+
+
+class TestGoodPatchConfig:
+
+    def test_good_config(self, params_w_patch):
+        assert good_patch_config(params_w_patch, MagicMock())
+
+    def test_missing_custom_run_flag(self, params_w_patch):
+        params_w_patch["common"]["custom_run"] = False
+        assert not good_patch_config(params_w_patch, MagicMock())
+
+    def test_missing_patch_section(self, params):
+        params["common"]["custom_run"] = True
+        assert not good_patch_config(params, MagicMock())
+
+    def test_missing_patch_keys(self, params_w_patch):
+        del params_w_patch["patch"]["patch_dir"]
+        assert not good_patch_config(params_w_patch, MagicMock())
+
+    def test_drop_date_set(self, params_w_patch):
+        params_w_patch["indicator"]["drop_date"] = "2020-06-11"
+        assert not good_patch_config(params_w_patch, MagicMock())
+
+    def test_bad_issue_date_format(self, params_w_patch):
+        params_w_patch["patch"]["start_issue"] = "06-11-2020"
+        assert not good_patch_config(params_w_patch, MagicMock())
+
+    def test_start_issue_after_end_issue(self, params_w_patch):
+        params_w_patch["patch"]["end_issue"] = "2020-06-10"
+        assert not good_patch_config(params_w_patch, MagicMock())
+
+
+class TestPatchModule:
+
+    def test_patch(self, params_w_patch):
+        with mock_patch("delphi_claims_hosp.patch.get_structured_logger"), \
+                mock_patch("delphi_claims_hosp.patch.read_params") as mock_read_params, \
+                mock_patch("delphi_claims_hosp.run.download") as mock_download, \
+                mock_patch("delphi_claims_hosp.run.modify_and_write") as mock_modify:
+            mock_read_params.return_value = params_w_patch
+
+            patch()
+
+            # the drop is pulled for the issue date, not for today
+            mock_download.assert_called_once()
+            assert mock_download.call_args.kwargs["issue_date"] == "2020-06-11"
+            # and only that drop is aggregated, not the whole staging dir
+            assert mock_modify.call_count == 1
+            assert mock_modify.call_args.kwargs["filepaths"][0].name == \
+                "SYNEDI_AGG_INPATIENT_11062020_1451CDT.csv.gz"
+
+            issue_dir = f"{TEST_DIR}/patch_dir/issue_20200611/hospital-admissions"
+            assert os.path.isdir(issue_dir)
+            assert len(os.listdir(issue_dir)) > 0
+
+            # the drops survive the run, later issues in the range still need them
+            assert "SYNEDI_AGG_INPATIENT_11062020_1451CDT.csv.gz" in \
+                os.listdir(params_w_patch["indicator"]["input_dir"])
+
+        shutil.rmtree(params_w_patch["patch"]["patch_dir"])
+
+    def test_patch_skips_issue_without_drop(self, params_w_patch):
+        # no drop for 06-12 on the server or on disk, so the issue is skipped
+        # rather than failing the rest of the run
+        params_w_patch["patch"]["start_issue"] = "2020-06-12"
+        params_w_patch["patch"]["end_issue"] = "2020-06-12"
+        with mock_patch("delphi_claims_hosp.patch.get_structured_logger"), \
+                mock_patch("delphi_claims_hosp.patch.read_params") as mock_read_params, \
+                mock_patch("delphi_claims_hosp.run.download"):
+            mock_read_params.return_value = params_w_patch
+
+            patch()
+
+            # nothing to generate, so no issue directory is left behind
+            assert not os.path.isdir(f"{TEST_DIR}/patch_dir/issue_20200612")
+
+        shutil.rmtree(params_w_patch["patch"]["patch_dir"])
+
+    def test_patch_exits_on_bad_config(self, params):
+        with mock_patch("delphi_claims_hosp.patch.get_structured_logger"), \
+                mock_patch("delphi_claims_hosp.patch.read_params") as mock_read_params:
+            mock_read_params.return_value = params
+            with pytest.raises(SystemExit):
+                patch()


### PR DESCRIPTION
### Description

Adds a patch module to `claims_hosp`, so we can reconstruct the version history
for hospital-admissions after an outage. It reruns the indicator for a range of
issue dates and writes them in the batch issue format acquisition expects:

```
[patch_dir]/issue_[issue-date]/hospital-admissions/*.csv
```

Structured after `doctor_visits`' patch module, with the params validation from
`nssp`. Revives the approach from #2043 (closed unmerged); differences from that
PR are called out below.

An issue here is a full rerun against the drop that arrived that day, not one
day of data — each issue re-emits the same window of `time_value`s the daily run
would have. That window is `n_backfill_days` deep only when
`indicator.start_date` is null; `run.py` applies `start_date` *after* computing
the window, so a non-null value replaces it. Prod sets
`"start_date": "2020-02-01"` (confirmed deployed, not just the template), which
against a recent drop is ~2,400 dates per
issue rather than 70, and the CSV count per issue scales with it. Worth checking
what your `params.json` uses before patching a wide range.

Run it with:

```
env/bin/python -m delphi_claims_hosp.patch
```

### What's in it

- `download()` and `get_latest_filename()` take an optional `issue_date`, the
  same parameter `doctor_visits` already has, so a patch resolves the drop that
  arrived on the issue date rather than today's. Drops already staged in
  `input_dir` are skipped by the downloader, which is how issues older than the
  server's retention get patched.
- A patch aggregates only its own drop rather than the whole staging directory,
  and leaves `input_dir` populated on exit. Clearing it costs a re-download for
  every subsequent issue, and for issues older than the server's retention —
  the ones that have to be staged by hand — it loses the drop outright.
- `merge_existing_backfill_files()` folds a patched issue into the merged
  backfill file whose issue-date span covers it, extending the span when the
  issue falls just outside it. Rows already carrying that `issue_date` are
  dropped first, so rerunning a patch replaces the issue rather than doubling
  it. An issue matching no merged file is left for the weekly merge.
- `good_patch_config()` rejects a non-null `indicator.drop_date` or `end_date`,
  which would otherwise pin every issue in the range to the same drop date.
- Before the loop starts, the patch logs its issue count, dates per issue and
  estimated CSV count, and warns when `indicator.start_date` is what widened the
  window. Prod sets it to `2020-02-01`, which is 2,408 dates per issue against a
  recent drop rather than 70 — a 3-month patch is ~5.3M CSVs with it and ~156k
  without. Copying the prod params is the natural way to set up a patch, so this
  is easy to inherit by accident and otherwise only shows up as a directory
  filling with files. Advisory only: `good_patch_config` still accepts a
  non-null `start_date`, since matching the daily run's window is a legitimate
  thing to want.
- `NoDropError` (subclasses `AssertionError`) lets `patch()` skip an issue with
  no drop without swallowing a real assertion failure, such as the
  duplicate-rows check in `modify_claims_drops`.

### Effect on daily runs

None. `custom_run` defaults to false and `issue_date` is `None` outside a patch,
so every new branch takes the existing path, and the prod ansible template needs
no change. Verified against the pre-existing suite: 27 tests at `main`, all still
passing here (45 total, 18 new).

Three non-functional differences worth knowing about in the logs:

- `store_backfill_file()` and `merge_backfill_file()` now log — including why a
  merge was skipped, which used to return silently.
- `modify_claims_drops` logs `filename` as a string rather than a `PosixPath` repr.
- the "no drop" message is now `no drop for 2026-09-08` rather than `no drop for today`.

`store_backfill_file()` and `merge_backfill_file()` gained a required `logger`
argument and `store_backfill_file()` returns the path it wrote; the only callers
are `run.py` and the tests.

### Differences from #2043

- Patching is idempotent — #2043 concatenated unconditionally, so rerunning a
  patch over the same date doubled its rows in the merged file.
- Fixes the leaked loop variable in `get_file_with_date`'s second pass (it read
  `pattern` from the previous loop), and the duplicate `to_parquet` write in
  `store_backfill_file`.
- On failure the daily backfill file is kept rather than deleted, so the patched
  data stays recoverable; on success it's removed so the weekly merge can't pick
  it up a second time.

### Known gaps

- Outages longer than `check_nd` still aren't automated — patching those means
  rewriting several merged parquets, which should stay a human decision. Same
  conclusion @aysim319 reached on #2043.
- `doctor_visits/delphi_doctor_visits/run.py` clears `input_dir` the same way at
  the end of `run_module`. Not touched here.

### Associated Issue(s)

- Addresses #2040

🤖 Generated with [Claude Code](https://claude.com/claude-code)





