### PR TITLE
Let n_backfill_days set the claims_hosp output window

### DIFF
--- a/ansible/templates/claims_hosp-params-prod.json.j2
+++ b/ansible/templates/claims_hosp-params-prod.json.j2
@@ -5,7 +5,7 @@
   },
   "indicator": {
     "input_dir": "./retrieve_files",
-    "start_date": "2020-02-01",
+    "start_date": null,
     "end_date": null,
     "drop_date": null,
     "generate_backfill_files": true,


### PR DESCRIPTION
> [!WARNING]
> Draft on purpose — **do not merge until the premise is confirmed against prod.**
> See "How to verify" below. This changes daily hospital-admissions behavior.

### Description

`run.py` computes the output window from `n_backfill_days`, then overwrites the
start of it whenever `indicator.start_date` is non-null:

```python
startdate_dt = enddate_dt - timedelta(days=params["indicator"]["n_backfill_days"])
...
# now allow manual overrides
if params["indicator"]["start_date"] is not None:
    startdate = params["indicator"]['start_date']
```

Prod has set `start_date` to `2020-02-01` since the params file was first added
in 819b04369, so `n_backfill_days: 70` has never taken effect there.
`output_dates = drange(startdate, enddate)` and `write_to_csv` emits one CSV per
(date, geo, signal), so against a 2026-09-08 drop:

| `start_date` | output dates | CSVs per run (6 geos x 4 signals) |
|---|---|---|
| `"2020-02-01"` | 2,408 | ~57,800 |
| `null` | 70 | ~1,680 |

It costs compute as well as output — `burnindate = startdate - 1 day`, and
`ClaimsHospIndicator.fit` runs from there, so every per-geo fit covers the same
2,408-day span.

Setting it null restores the behavior `n_backfill_days` describes.

### Why this is safe

The dropped dates were re-issuing values identical to what the API already
holds. Claims that old do not revise — `backfill_corrections` treats 60 days as
settled (`ref_lag: 60`), and `n_backfill_days: 70` covers that window with room
to spare. An issue that omits a `time_value` writes no row for it, leaving the
previous issue's value current, so no version history is lost.

### How to verify before merging

I read this off the template and the code; I have not observed prod. `run.py`
logs the window every run, so the last `Loaded params` line in
`/var/log/indicators/hospital-admissions.log` settles it:

- `startdate=2020-02-01` — the premise holds, this PR is a ~34x reduction.
- `startdate=` ~70 days back — deployed params differ from this template, and
  this PR is wrong. Close it and fix the drift instead.

Also worth a moment's thought from someone with more history than me: whether
the daily full re-issue is load-bearing for any consumer, and whether the 2020
date was deliberate (initial catch-up that was never removed) or copied from a
dev config.

### Relationship to #2191

Kept separate on purpose. #2191 adds patching and does not depend on this; this
changes daily runs and does not depend on that. They can merge in either order.
The overlap is only that the override makes a wide patch far more expensive —
~5.3M CSVs for a 3-month range instead of ~156k — which is what surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
